### PR TITLE
Fixed: Added product-store-details childRoute in Product Store Menu to persist menu highlighting when open Product Store Details Page (#58) 

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -44,7 +44,7 @@ const appPages = [
   {
     title: "Product Store",
     url: "/product-store",
-    childRoutes: ["/product-store/"],
+    childRoutes: ["/product-store/", "/product-store-details/"],
     iosIcon: businessOutline,
     mdIcon: businessOutline,
   },


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#58 

### Short Description and Why It's Useful

- Added support to show Product Store Item in menu selected when user clicks on Product details page also.
- Current flow of UI has not been affected by the change


### Screenshots of Visual Changes before/after (If There Are Any)
After Changes
<img width="1440" alt="Screenshot 2025-05-22 at 11 17 45" src="https://github.com/user-attachments/assets/4252c826-b769-4c91-9e6a-dddd9972433b" />

Before Changes
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/0c85742d-9316-4c9b-95af-d4a35ea89771" />