### PR TITLE
Ensure split pane uses lg breakpoint

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,9 @@
 <template>
   <ion-app>
-    <IonSplitPane content-id="main-content" when="lg">
+    <ion-split-pane content-id="main-content" when="lg">
       <Menu />
       <ion-router-outlet id="main-content"></ion-router-outlet>
-    </IonSplitPane>
+    </ion-split-pane>
   </ion-app>
 </template>
 
@@ -85,8 +85,3 @@ onUnmounted(() => {
 })
 </script>
 
-<style scoped>
-ion-split-pane {
-  --side-width: 304px;
-}
-</style>


### PR DESCRIPTION
## Summary
- enforce the Ionic split pane to use the lg breakpoint
- remove custom styling overrides so the component uses Ionic defaults

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68f08a83a39c8321bb4aae19214ccc9d