### PR TITLE
Improve Shopify product sync error dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "core-js": "^3.6.5",
         "cron-parser": "^5.5.0",
         "cronstrue": "^3.14.0",
+        "dexie": "^4.4.2",
         "http-status-codes": "^2.1.4",
         "luxon": "^2.3.0",
         "mitt": "^2.1.0",
@@ -7975,6 +7976,12 @@
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true
+    },
+    "node_modules/dexie": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.4.2.tgz",
+      "integrity": "sha512-zMtV8q79EFE5U8FKZvt0Y/77PCU/Hr/RDxv1EDeo228L+m/HTbeN2AjoQm674rhQCX8n3ljK87lajt7UQuZfvw==",
+      "license": "Apache-2.0"
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "core-js": "^3.6.5",
     "cron-parser": "^5.5.0",
     "cronstrue": "^3.14.0",
+    "dexie": "^4.4.2",
     "http-status-codes": "^2.1.4",
     "luxon": "^2.3.0",
     "mitt": "^2.1.0",

--- a/src/components/ShopifyProductSyncReturningView.vue
+++ b/src/components/ShopifyProductSyncReturningView.vue
@@ -162,9 +162,9 @@
         <ion-item>
           <ion-label>
             {{ translate("Error records")}}
-            <p>In the last 24 hours</p>
+            <p>{{ translate("In the last 24 hours") }}</p>
           </ion-label>
-          <ion-label slot="end">0</ion-label>
+          <ion-label slot="end">{{ errorRecordCount }}</ion-label>
         </ion-item>
       </ion-list>
     </ion-card>
@@ -271,50 +271,62 @@
     </div>
   </section>
 
+
   <section class="sync-stat">
     <div class="stat-header">
       <ion-item class="stat-title" lines="none">
         <ion-label>
-          <h2>{{ translate("Recent sync errors") }}</h2>
-          <p>{{ translate("Audit what products failed to sync recently and retry them") }}</p>
+          <h2>{{ translate("Parsed error details") }}</h2>
+          <p style="margin-top: 2px;">{{ failedRecords.length }} {{ translate("of") }} {{ totalDetailedErrorsCount }} {{ translate("failed objects") }}</p>
         </ion-label>
       </ion-item>
-      <ion-searchbar v-model="errorsQuery" :placeholder="translate('Search by internal name')" />
+      <ion-buttons slot="end" v-if="hasDetailedErrors">
+        <ion-button color="medium" @click="emit('refresh-errors')">
+          <ion-icon slot="icon-only" :icon="refreshOutline" />
+        </ion-button>
+      </ion-buttons>
+      <ion-searchbar :value="detailedErrorQuery" @ionInput="emit('update:detailed-error-query', $event.detail.value)" :placeholder="translate('Search by ID, Name or Handle')" />
     </div>
-    <div class="stat-data">
-      <ion-spinner v-if="isSecondaryLoading" name="crescent"></ion-spinner>
-      <template v-else>
-      <ion-card v-for="item in filteredErrors" :key="item.id">
-      <ion-list lines="full">
-        <ion-item>
-          <ion-label>
-            {{ item.internalName }}
-            <p>{{ item.shopifyId }}</p>
-          </ion-label>
-          <ion-note slot="end">{{ item.updatedTime }}</ion-note>
-        </ion-item>
-        <ion-item>
-          <ion-label>{{ item.errorContent }}</ion-label>
-        </ion-item>
-      </ion-list>
-      <ion-card-content>
-        <ion-button fill="clear">{{ translate("Retry") }}</ion-button>
-        <ion-button fill="clear">{{ translate("Download raw file") }}</ion-button>
-      </ion-card-content>
-    </ion-card>
-    <ion-card v-if="!filteredErrors.length">
-      <ion-list lines="full">
-        <ion-item>
-          <ion-label>
-            {{ translate("No recent sync errors") }}
-            <p>{{ translate("No error records in the last {count} product update imports.", { count: errorLookbackCount }) }}</p>
+    <div class="stat-data" v-if="failedRecords.length">
+      <ion-card v-for="record in failedRecords" :key="record.id" style="flex: 0 0 320px; margin: 8px;">
+        <ion-item lines="full">
+          <ion-label class="ion-text-wrap">
+            <h3>{{ record.title }}</h3>
+            <p v-if="record.handle">{{ record.handle }}</p>
           </ion-label>
         </ion-item>
-      </ion-list>
-    </ion-card>
-          </template>
+        <ion-card-content>
+          <p class="ion-no-margin">
+            <strong>{{ translate("Product ID") }}:</strong> {{ record.numericId || 'N/A' }}
+          </p>
+          <p class="ion-no-margin" style="font-size: 1.1rem; margin-top: 8px;">
+            {{ record.error }}
+          </p>
+          <div class="ion-margin-top">
+            <ion-button fill="clear" size="small" class="ion-no-padding" @click="emit('show-error-modal', record)">
+              {{ translate("View details") }}
+            </ion-button>
+            <ion-button fill="clear" size="small" color="primary" @click="emit('resync-product', record)">
+              {{ translate("Retry") }}
+            </ion-button>
+          </div>
+        </ion-card-content>
+      </ion-card>
+      
+      <!-- Load More at the end of carousel -->
+      </div>
+    <div class="stat-data" v-else>
+      <ion-card>
+        <ion-item lines="none">
+          <ion-label class="ion-text-center">
+            <p v-if="detailedErrorQuery">{{ translate("No records match your search.") }}</p>
+            <p v-else>{{ translate("All caught up! No recent errors found.") }}</p>
+          </ion-label>
+        </ion-item>
+      </ion-card>
     </div>
   </section>
+
 
 </template>
 
@@ -331,6 +343,8 @@ import {
   IonCardSubtitle,
   IonCardTitle,
   IonIcon,
+  IonInfiniteScroll,
+  IonInfiniteScrollContent,
   IonItem,
   IonChip,
   IonLabel,
@@ -341,7 +355,7 @@ import {
 } from "@ionic/vue";
 import { translate } from "@/i18n";
 import { computed, defineEmits, defineProps, ref } from "vue";
-import { checkmarkCircleOutline, ellipsisVerticalOutline, flashOutline, pauseCircleOutline, timeOutline } from "ionicons/icons";
+import { checkmarkCircleOutline, closeOutline, ellipsisVerticalOutline, flashOutline, pauseCircleOutline, refreshOutline, timeOutline } from "ionicons/icons";
 import { modalController, popoverController } from "@ionic/vue";
 import ScheduleModal from "./ScheduleModal.vue";
 import ShopifyProductSyncActionsPopover from "./ShopifyProductSyncActionsPopover.vue";
@@ -360,7 +374,6 @@ const props = defineProps<{
   summarySubtitle: string
   errorLookbackCount: number
   currentSyncRun?: ShopifyProductSyncRun
-  recentSyncErrors: Array<{ id: string, internalName: string, shopifyId: string, updatedTime: string, errorContent: string }>
   recentSyncUpdates: Array<{
     id: string,
     internalName: string,
@@ -385,8 +398,13 @@ const props = defineProps<{
   hasCurrentShopifyRequest?: boolean
   syncJobObj?: any
   isSecondaryLoading?: boolean
+  errorRecordCount: number | string
+  failedRecords: Array<{ id: string, numericId?: string, logId?: string, title: string, vendor?: string, handle?: string, productType?: string, sku?: string, barcode?: string, error: string }>
+  detailedErrorQuery: string
+  hasDetailedErrors: boolean
+  totalDetailedErrorsCount: number
 }>();
-const emit = defineEmits(["open-history", "schedule-sync", "run-job", "open-unsynced-updates", "open-specific-products-sync", "open-resync-entire-catalog", "open-sync-job-details", "open-step-details", "toggle-pause-sync-job"]);
+const emit = defineEmits(["open-history", "schedule-sync", "run-job", "open-unsynced-updates", "open-specific-products-sync", "open-resync-entire-catalog", "open-sync-job-details", "open-step-details", "toggle-pause-sync-job", "download-file", "view-error-details", "update:detailed-error-query", "show-error-modal", "refresh-errors", "resync-product"]);
 
 
 
@@ -429,7 +447,6 @@ async function openActionsPopover(event: Event) {
 
 
 const updatesQuery = ref("");
-const errorsQuery = ref("");
 const visibleChangeSummaryCount = 4;
 
 function getDetailActionLabel(type: string) {
@@ -454,14 +471,6 @@ const filteredUpdates = computed(() => {
   });
 });
 
-const filteredErrors = computed(() => {
-  const query = errorsQuery.value.trim().toLowerCase();
-  if (!query) return props.recentSyncErrors;
-
-  return props.recentSyncErrors.filter((item) => {
-    return item.internalName.toLowerCase().includes(query) || item.shopifyId.toLowerCase().includes(query);
-  });
-});
 </script>
 
 <style>

--- a/src/components/ShopifyProductSyncReturningView.vue
+++ b/src/components/ShopifyProductSyncReturningView.vue
@@ -27,7 +27,7 @@
         </ion-item>
         <ion-item>
           <ion-label>{{ translate("Updates synced") }}</ion-label>
-          <ion-label slot="end">{{ 40 }}</ion-label>
+          <ion-label slot="end">{{ lastSyncTotalRecordCount }}</ion-label>
         </ion-item>
         <ion-item button :detail="isSyncScheduled" @click="isSyncScheduled ? emit('open-sync-job-details') : undefined">
           <ion-label>{{ translate("Next sync time") }}
@@ -367,6 +367,7 @@ const props = defineProps<{
   isSyncPaused?: boolean
   lastSyncLabel: string
   lastSyncRelativeLabel: string
+  lastSyncTotalRecordCount: number | string
   nextSyncLabel: string
   nextSyncRelativeLabel: string
   systemMessageSendJobNextRunLabel: string

--- a/src/composables/useDataManagerLog.ts
+++ b/src/composables/useDataManagerLog.ts
@@ -163,6 +163,7 @@ export function useDataManagerLog() {
         method: "GET",
         params: {
           configId,
+          orderByField: "-finishDateTime",
           pageSize,
           pageIndex: 0
         }

--- a/src/composables/useDataManagerLog.ts
+++ b/src/composables/useDataManagerLog.ts
@@ -1,6 +1,7 @@
 import { reactive, toRefs } from 'vue';
 import api from '@/api';
 import logger from '@/logger';
+import { clearStorage, getErrorRecords, setErrorRecords } from '@/utils/storage';
 
 export function useDataManagerLog() {
   const state = reactive({
@@ -34,12 +35,22 @@ export function useDataManagerLog() {
   };
 
   const fetchFailedRecords = async (configId: string, errorLogContentId: string) => {
+    state.loading = true;
+    console.log("Fetching failed records", configId, errorLogContentId);
+    const cachedData = await getErrorRecords(errorLogContentId);
+    if (cachedData && cachedData.length > 0) {
+      state.errorLogs = cachedData;
+      state.loading = false;
+      return;
+    }
+
     try {
       const resp = await downloadDataManagerFile(configId, errorLogContentId);
 
       state.errorCsvRecords = resp?.data?.csvData || resp?.data;
       if (isValidJSON(state.errorCsvRecords)) {
         state.errorLogs = JSON.parse(state.errorCsvRecords);
+        await setErrorRecords(errorLogContentId, state.errorLogs);
       } else {
         // Fallback since PapaParse might not be available in this app
         // Stores raw CSV string as an array of rows
@@ -47,7 +58,9 @@ export function useDataManagerLog() {
           ? state.errorCsvRecords.split('\n').filter(Boolean) 
           : [];
       }
+      state.loading = false;
     } catch (err) {
+      state.loading = false;
       logger.error("Failed to download the error records", err);
       throw err;
     }
@@ -58,6 +71,7 @@ export function useDataManagerLog() {
       ...mdmLog,
       successRecordCount: (Number(mdmLog?.totalRecordCount) || 0) - (Number(mdmLog?.failedRecordCount) || 0)
     };
+    console.log({mdmLog, mdmLogDetails})
 
     state.currentMdmLog = mdmLogDetails;
 
@@ -166,6 +180,45 @@ export function useDataManagerLog() {
     return [];
   };
 
+  const fetchAllRecentFailedRecords = async (configId: string, logs: any[]) => {
+    state.loading = true;
+    const accumulatedLogs: any[] = [];
+    
+    try {
+      for (const log of logs) {
+        const errorLogContentId = log.errorLogContentId;
+        if (!errorLogContentId) continue;
+
+        let records = await getErrorRecords(errorLogContentId);
+        
+        if (!records || records.length === 0) {
+          const resp = await downloadDataManagerFile(configId, errorLogContentId);
+          const data = resp?.data?.csvData || resp?.data;
+          if (isValidJSON(data)) {
+            records = JSON.parse(data);
+            await setErrorRecords(errorLogContentId, records);
+          }
+        }
+
+        if (records && records.length > 0) {
+          // Flatten to include the logId for context if needed
+          const logId = log.logId;
+          accumulatedLogs.push(...records.map(r => ({ ...r, logId })));
+        }
+
+        // Target at least 100 errors total across all processed logs
+        if (accumulatedLogs.length >= 100) {
+          break;
+        }
+      }
+      state.errorLogs = accumulatedLogs;
+    } catch (err) {
+      logger.error("Failed to aggregate error records", err);
+    } finally {
+      state.loading = false;
+    }
+  };
+
   return {
     ...toRefs(state),
     downloadDataManagerFile,
@@ -173,6 +226,8 @@ export function useDataManagerLog() {
     fetchMdmLogBySystemMessageId,
     fetchMdmLogBySystemMessageIds,
     fetchLogDetails,
-    fetchRecentLogsByConfigId
+    fetchAllRecentFailedRecords,
+    fetchRecentLogsByConfigId,
+    clearStorage
   };
 }

--- a/src/services/ShopifyProductSyncService.ts
+++ b/src/services/ShopifyProductSyncService.ts
@@ -1244,6 +1244,22 @@ const fetchErrorRecordCount = async (payload: any): Promise<number> => {
   }
 };
 
+const fetchDashboardSummary = async (payload: any): Promise<any> => {
+  const { shopId, systemMessageRemoteId, shop } = payload;
+  
+  const [syncRunState, pendingRequests, runningOperation] = await Promise.all([
+    fetchProductUpdateSyncRunState(systemMessageRemoteId),
+    fetchPendingProductUpdateRequests(systemMessageRemoteId),
+    fetchRunningBulkOperation({ shopId, systemMessageRemoteId, shop })
+  ]);
+
+  return {
+    syncRunState,
+    pendingRequests,
+    runningOperation
+  };
+};
+
 export const ShopifyProductSyncService = {
   fetchDashboardSummary,
   fetchShopSystemMessageRemoteId,

--- a/src/services/ShopifyProductSyncService.ts
+++ b/src/services/ShopifyProductSyncService.ts
@@ -664,7 +664,7 @@ const fetchProductUpdateSyncRunState = async (payload: any): Promise<ShopifyProd
   const confirmedMessages = systemMessages.filter((systemMessage: any) => systemMessage.statusId === "SmsgConfirmed");
   const consumedMessages = systemMessages.filter((systemMessage: any) => {
     const statusId = String(systemMessage.statusId || "").toLowerCase();
-    return statusId === "smsgconsumed" || statusId === "consumed";
+    return statusId === "smsgconsumed" || statusId === "consumed" || statusId === "smsgconfirmed" || statusId === "confirmed";
   });
   const latestConfirmedSystemMessage = getLatestSystemMessage(confirmedMessages, ["processedDate", "lastUpdatedStamp", "initDate"]);
   const latestConsumedSystemMessage = getLatestSystemMessage(consumedMessages, ["initDate", "lastUpdatedStamp", "processedDate"]);

--- a/src/services/ShopifyProductSyncService.ts
+++ b/src/services/ShopifyProductSyncService.ts
@@ -1214,27 +1214,34 @@ const configureSyncJob = async (payload: any): Promise<any> => {
   });
 };
 
+const fetchErrorRecordCount = async (payload: any): Promise<number> => {
+  const { shopId, configId } = payload;
+  const finishDateTimeFrom = Date.now() - (24 * 60 * 60 * 1000); // 24 hours ago in ms
 
+  try {
+    const response = await requestBackend<any>({
+      url: "oms/dataDocumentView",
+      method: "post",
+      data: {
+        dataDocumentId: "DATA_MANAGER_LOG_AND_PARAMETER",
+        customParametersMap: {
+          configId: configId || "SYNC_SHOPIFY_PRODUCT",
+          parameterName: "shopId",
+          parameterValue: shopId,
+          failedRecordCount: 0,
+          failedRecordCount_op: "equals",
+          failedRecordCount_not: "true",
+          finishDateTime_from: finishDateTimeFrom.toString()
+        },
+        fieldsToSelect: "failedRecordCount"
+      }
+    });
 
-export interface ShopifyProductSyncDashboardSummary {
-  syncRunState: ShopifyProductUpdateSyncRunState;
-  pendingRequests: ShopifyPendingProductUpdateRequestsState;
-  runningOperation: ShopifyRunningBulkOperation | null;
-}
-
-const fetchDashboardSummary = async (payload: any): Promise<ShopifyProductSyncDashboardSummary> => {
-  const systemMessageRemoteId = typeof payload === "string" ? payload : resolveSystemMessageRemoteId(payload);
-  if (!systemMessageRemoteId) {
-    throw new Error("Shopify systemMessageRemoteId is required for dashboard summary.");
+    return Number(response?.entityValueList?.[0]?.failedRecordCount || 0);
+  } catch (error) {
+    logger.warn("Failed to fetch error record count using dataDocumentView", error);
+    return 0;
   }
-
-  const [syncRunState, pendingRequests, runningOperation] = await Promise.all([
-    fetchProductUpdateSyncRunState(systemMessageRemoteId),
-    fetchPendingProductUpdateRequests(systemMessageRemoteId),
-    fetchRunningBulkOperation(systemMessageRemoteId)
-  ]);
-
-  return { syncRunState, pendingRequests, runningOperation };
 };
 
 export const ShopifyProductSyncService = {
@@ -1257,5 +1264,6 @@ export const ShopifyProductSyncService = {
   fetchReconcile,
   fetchHistory,
   fetchSyncJobConfig,
-  configureSyncJob
+  configureSyncJob,
+  fetchErrorRecordCount
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -20,9 +20,28 @@ const showToast = async (message: string) => {
     })
   return toast.present();
 }
-
 const generateInternalId = (name: string) => {
   return name.trim().toUpperCase().split(' ').join('_');
 }
 
-export { generateInternalId, hasError, showToast ,getCurrentTime}
+
+const getDownloadFileContent = (data: any) => {
+  const fileContent = data?.csvData ?? data?.fileData ?? data?.data ?? data;
+  if (typeof fileContent === "string") return fileContent;
+  if (fileContent === undefined || fileContent === null) return "";
+  return JSON.stringify(fileContent, null, 2);
+}
+
+const downloadTextFile = (content: string, fileName: string) => {
+  const blob = new Blob([content], { type: "text/plain;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = fileName;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
+export { generateInternalId, hasError, showToast ,getCurrentTime, getDownloadFileContent, downloadTextFile}

--- a/src/utils/shopifyProductSyncWizard.ts
+++ b/src/utils/shopifyProductSyncWizard.ts
@@ -207,3 +207,9 @@ export function resolveProductSyncExperienceMode(
 
   return hasLinkedOmsProducts ? "returning" : "first-time";
 }
+
+export function getRawShopifyFileName(run: { mdmLogFileName?: string; logId?: string; id?: string }) {
+  const fileName = String(run.mdmLogFileName || "").split(/[\\/]/).pop();
+  return fileName || `shopify-product-sync-${run.logId || run.id}.json`;
+}
+

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,123 @@
+import Dexie, { Table } from 'dexie';
+
+const EXPIRATION_TIME = 2 * 60 * 60 * 1000; // 2 hour in milliseconds
+
+/**
+ * Interface for an individual error record.
+ */
+export interface ErrorRecord {
+  id?: number;
+  logContentId: string;
+  numericId: string;
+  title: string;
+  handle: string;
+  sku: string;
+  error: string;
+  createdAt: number;   // Timestamp for automatic invalidation
+  raw: any;
+}
+
+/**
+ * Dexie Database definition
+ */
+export class ShopifySyncDatabase extends Dexie {
+  errorLogRecords!: Table<ErrorRecord>;
+
+  constructor() {
+    super('ShopifySyncDB');
+    this.version(3).stores({
+      errorLogRecords: '++id, logContentId, numericId, title, sku, handle, createdAt'
+    });
+  }
+}
+
+export const db = new ShopifySyncDatabase();
+
+/**
+ * Save error records with a timestamp.
+ */
+export const setErrorRecords = async (logContentId: string, records: any[]): Promise<void> => {
+  try {
+    const timestamp = Date.now();
+    const formattedRecords: ErrorRecord[] = records.map(record => {
+      const product = record.virtualProduct || {};
+      return {
+        logContentId,
+        numericId: record.numericId || (product.id ? product.id.split('/').pop() : ''),
+        title: record.title || product.title || '',
+        handle: record.handle || product.handle || '',
+        sku: record.sku || (product.variants?.[0]?.sku) || '',
+        error: record.error || record._ERROR_MESSAGE_ || record.message || record.errorMessage || '',
+        createdAt: timestamp,
+        raw: record.raw || record
+      };
+    });
+
+    await db.errorLogRecords.where({ logContentId }).delete();
+    await db.errorLogRecords.bulkAdd(formattedRecords);
+    
+    // Also trigger a background cleanup for other old logs
+    cleanupExpiredRecords();
+  } catch (err) {
+    console.error("Dexie: Failed to save error records", err);
+  }
+};
+
+/**
+ * Get error records and automatically invalidate if older than 1 hour.
+ */
+export const getErrorRecords = async (logContentId: string): Promise<any[]> => {
+  try {
+    const records = await db.errorLogRecords.where({ logContentId }).toArray();
+    
+    if (records.length > 0) {
+      const isExpired = Date.now() - records[0].createdAt > EXPIRATION_TIME;
+      if (isExpired) {
+        await deleteErrorRecords(logContentId);
+        return [];
+      }
+    }
+
+    return records.map(r => ({
+      ...r.raw,
+      numericId: r.numericId,
+      title: r.title,
+      handle: r.handle,
+      sku: r.sku,
+      error: r.error
+    }));
+  } catch (err) {
+    console.error("Dexie: Failed to get error records", err);
+    return [];
+  }
+};
+
+/**
+ * Delete records for a specific log.
+ */
+export const deleteErrorRecords = async (logContentId: string): Promise<void> => {
+  try {
+    await db.errorLogRecords.where({ logContentId }).delete();
+  } catch (err) {
+    console.error("Dexie: Failed to delete records", err);
+  }
+};
+
+/**
+ * Background cleanup for all logs older than 1 hour.
+ */
+export const cleanupExpiredRecords = async (): Promise<void> => {
+  try {
+    const expirationLimit = Date.now() - EXPIRATION_TIME;
+    await db.errorLogRecords.where('createdAt').below(expirationLimit).delete();
+  } catch (err) {
+    console.error("Dexie: Cleanup failed", err);
+  }
+};
+
+/**
+ * Clear all records manually
+ */
+export const clearStorage = async (): Promise<void> => {
+  await db.errorLogRecords.clear();
+};

--- a/src/views/ShopifyProductSync.vue
+++ b/src/views/ShopifyProductSync.vue
@@ -65,6 +65,7 @@
           :has-current-shopify-request="hasRunningShopifyBulkOperation"
           :sync-job-obj="syncJobObj"
           :error-record-count="errorRecordCount"
+          :last-sync-total-record-count="lastSyncTotalRecordCount"
           :failed-records="pagedFilteredParsedErrorRecords"
           :total-detailed-errors-count="filteredParsedErrorRecords.length"
           :has-detailed-errors="recentMdmLogs.length > 0"
@@ -900,6 +901,10 @@ const systemMessageSendJobNextRunLabel = computed(() => {
 });
 const bulkOperationPollJobNextRunLabel = computed(() => {
   return getJobNextRunLabel(bulkOperationPollJob.value);
+});
+const lastSyncTotalRecordCount = computed(() => {
+  const latestLog = recentMdmLogs.value[0];
+  return latestLog?.totalRecordCount || 0;
 });
 const stepDetailsTitle = computed(() => {
   if (currentStepDetail.value?.type === "systemMessage") return translate("System Message");

--- a/src/views/ShopifyProductSync.vue
+++ b/src/views/ShopifyProductSync.vue
@@ -45,7 +45,6 @@
           :system-message-send-job-next-run-label="systemMessageSendJobNextRunLabel"
           :bulk-operation-poll-job-next-run-label="bulkOperationPollJobNextRunLabel"
           :current-sync-run="currentSyncRun"
-          :recent-sync-errors="recentSyncErrors"
           :recent-sync-updates="recentSyncUpdates"
           :selected-product-store-name="selectedProductStoreName"
           :summary-subtitle="syncSummarySubtitle"
@@ -65,6 +64,16 @@
           :current-shopify-request-status-color="currentShopifyRequestStatusColor"
           :has-current-shopify-request="hasRunningShopifyBulkOperation"
           :sync-job-obj="syncJobObj"
+          :error-record-count="errorRecordCount"
+          :failed-records="pagedFilteredParsedErrorRecords"
+          :total-detailed-errors-count="filteredParsedErrorRecords.length"
+          :has-detailed-errors="recentMdmLogs.length > 0"
+          :detailed-error-query="detailedErrorSearchQuery"
+          @update:detailed-error-query="detailedErrorSearchQuery = $event"
+          @show-error-modal="openErrorDetailsModal"
+          @refresh-errors="refreshErrorRecords"
+          @resync-product="resyncProduct"
+          @load-more-errors="loadMoreErrorRecords"
           @open-history="openHistory"
           @open-sync-job-details="openSyncJobDetailsModal"
           @schedule-sync="scheduleSyncJob"
@@ -74,6 +83,7 @@
           @open-resync-entire-catalog="openResyncEntireCatalogModal"
           @open-step-details="openStepDetails"
           @run-job="runSyncJob"
+          @download-file="downloadRawFile"
         />
 
         <shopify-product-sync-wizard-view
@@ -136,8 +146,9 @@
           @toggle-start-confirmation="toggleStartConfirmation"
           @open-step-details="openStepDetails"
         />
+      </template>
 
-        <ion-modal :is-open="showModeModal" :backdrop-dismiss="false" @didDismiss="showModeModal = false">
+      <ion-modal :is-open="showModeModal" :backdrop-dismiss="false" @didDismiss="showModeModal = false">
           <ion-header>
             <ion-toolbar>
               <ion-buttons slot="start">
@@ -538,7 +549,29 @@
           </ion-content>
         </ion-modal>
 
-      </template>
+        <ion-modal :is-open="showErrorDetailsModal" @didDismiss="showErrorDetailsModal = false">
+          <ion-header>
+            <ion-toolbar>
+              <ion-buttons slot="start">
+                <ion-button @click="showErrorDetailsModal = false">
+                  <ion-icon slot="icon-only" :icon="closeOutline" />
+                </ion-button>
+              </ion-buttons>
+              <ion-title>{{ translate("Error details") }}</ion-title>
+              <ion-buttons slot="end">
+                <ion-button color="primary" @click="resyncProduct(selectedErrorRecord)">
+                  {{ translate("Resync") }}
+                </ion-button>
+              </ion-buttons>
+            </ion-toolbar>
+          </ion-header>
+          <ion-content>
+            <div class="ion-padding">
+              <pre>{{ JSON.stringify(selectedErrorRecord, null, 2) }}</pre>
+            </div>
+          </ion-content>
+        </ion-modal>
+
     </ion-content>
   </ion-page>
 </template>
@@ -602,6 +635,7 @@ import {
   canStartProductSync,
   createProductSyncWizardDraft,
   getReviewImportAction,
+  getRawShopifyFileName,
   nextProductSyncStep,
   normalizeProductSyncStatus,
   previousProductSyncStep,
@@ -612,13 +646,14 @@ import {
   selectProductStore,
   shouldShowProductSyncProgress
 } from "@/utils/shopifyProductSyncWizard";
-import { hasError, showToast } from "@/utils";
+import { downloadTextFile, getDownloadFileContent, hasError, showToast } from "@/utils";
 import logger from "@/logger";
 import useServiceJob from "@/composables/useServiceJob";
 import { useDataManagerLog } from "@/composables/useDataManagerLog";
 import { useProductUpdateHistory } from "@/composables/useProductUpdateHistory";
 import { useShopifyProductSyncRun } from "@/composables/useShopifyProductSyncRun";
 import { getSystemMessageBulkOperationId } from "@/utils/shopifyBulkOperation";
+import { deleteErrorRecords } from "@/utils/storage";
 
 const props = defineProps(["id"]);
 const store = useStore();
@@ -634,7 +669,7 @@ const {
   updateJob,
   runNow
 } = useServiceJob();
-const { fetchLogDetails, fetchMdmLogBySystemMessageId, fetchRecentLogsByConfigId, currentMdmLog, recentMdmLogs, errorLogs } = useDataManagerLog();
+const { downloadDataManagerFile, fetchLogDetails, fetchMdmLogBySystemMessageId, fetchRecentLogsByConfigId, currentMdmLog, recentMdmLogs, errorLogs, fetchAllRecentFailedRecords, clearStorage } = useDataManagerLog();
 const { productUpdateHistories, fetchProductUpdateHistory } = useProductUpdateHistory();
 const { currentSyncRun, fetchSyncRun } = useShopifyProductSyncRun();
 const PRODUCT_UPDATE_SYNC_SERVICE_NAME = "sync_ShopifyProductUpdates";
@@ -703,6 +738,7 @@ const relatedShops = ref<any[]>([]);
 const shopifyShopProductCount = ref(0);
 const pendingUpdateRequestsCount = ref(0);
 const pendingUpdateRequestsLastCreatedAt = ref("");
+const errorRecordCount = ref(0);
 const syncJobDetails = ref<any>({});
 const syncJobDraftCronExpression = ref("");
 const syncJobDraftActive = ref(true);
@@ -742,6 +778,9 @@ const progressState = ref<any>({
   queuedJobsAhead: 0
 });
 const reconcileState = ref<any>({});
+const detailedErrorSearchQuery = ref("");
+const selectedErrorRecord = ref<any>(null);
+const showErrorDetailsModal = ref(false);
 let progressPoll: number | undefined;
 let nextSyncRefreshPoll: number | undefined;
 
@@ -1097,31 +1136,49 @@ function isSelectedShopProductSyncJob(job: any = {}) {
 }
 
 
-const recentSyncErrors = computed(() => {
-  if (errorLogs.value && errorLogs.value.length) {
-    return errorLogs.value.map((err: any, index: number) => ({
-      id: err.id || err.internalName || err.shopifyId || `sync-error-${index}`,
-      internalName: err.internalName || translate("Unknown product"),
-      shopifyId: err.shopifyId || err.id || "N/A",
-      updatedTime: err.updatedTime || currentMdmLog.value?.createdDate || translate("Recent"),
-      errorContent: err.errorString || err.error || err.message || JSON.stringify(err)
-    }));
-  }
-  return recentMdmLogs.value
-    .filter((log: any) => {
-      return Number(log.failedRecordCount || 0) > 0 || log.errorLogContentId || String(log.statusId || "").toLowerCase().includes("error");
-    })
-    .map((log: any) => ({
-      id: log.logId || [log.configId, log.createdDate].filter(Boolean).join("-"),
-      internalName: log.logId || translate("Data Manager log"),
-      shopifyId: `${translate("Config ID")}: ${log.configId || PRODUCT_SYNC_MDM_CONFIG_ID}`,
-      updatedTime: log.createdDate ? new Date(log.createdDate).toLocaleString() : translate("Recent"),
-      errorContent: translate("{failed} failed of {total} records.", {
-        failed: Number(log.failedRecordCount || 0),
-        total: Number(log.totalRecordCount || 0)
-      })
-    }));
+
+const filteredParsedErrorRecords = computed(() => {
+  const query = detailedErrorSearchQuery.value.trim().toLowerCase();
+  const records = errorLogs.value.map((err: any) => {
+    const product = err.virtualProduct || {};
+    const numericId = product.id ? product.id.split('/').pop() : '';
+    
+    // Robust extraction of SKU and Barcode (handles variants array, GraphQL edges, or top-level properties)
+    const variantsData = product.variants?.edges || (Array.isArray(product.variants) ? product.variants : []);
+    const firstVariant = variantsData[0]?.node || variantsData[0] || {};
+    const sku = firstVariant.sku || product.sku || err.sku || '';
+    const barcode = firstVariant.barcode || product.barcode || err.barcode || '';
+
+    const error = err.error || err._ERROR_MESSAGE_ || err.message || (typeof err === 'string' ? err : '');
+
+    return {
+      id: product.id || err.id,
+      numericId,
+      logId: currentMdmLog.value?.logId,
+      title: product.title || err.title || translate("Unknown product"),
+      vendor: product.vendor || err.vendor,
+      handle: product.handle,
+      productType: product.productType,
+      sku,
+      barcode,
+      error: error || translate("Unknown error"),
+      raw: err
+    }
+  });
+
+  if (!query) return records;
+
+  return records.filter((record: any) => 
+    record.numericId?.toLowerCase().includes(query) ||
+    record.title?.toLowerCase().includes(query) ||
+    record.handle?.toLowerCase().includes(query)
+  );
 });
+
+const pagedFilteredParsedErrorRecords = computed(() => {
+  return filteredParsedErrorRecords.value.slice(0, 100);
+});
+
 const preflightTitle = computed(() => {
   return requiresPreflightConfirmation(preflightResult.value)
     ? translate("Review possible catalog mismatch")
@@ -1348,6 +1405,37 @@ async function loadShopifyShopProductCount() {
   }
 }
 
+async function loadPendingUpdateRequests() {
+  try {
+    const pendingState = await ShopifyProductSyncService.fetchPendingProductUpdateRequests({
+      shopId: props.id,
+      systemMessageRemoteId: selectedShopSystemMessageRemoteId.value,
+      shop: shop.value
+    });
+    pendingUpdateRequestsCount.value = Number(pendingState.count || 0);
+    pendingUpdateRequestsLastCreatedAt.value = pendingState.latestSystemMessage?.initDate ||
+      pendingState.latestSystemMessage?.createdDate ||
+      pendingState.latestSystemMessage?.lastUpdatedStamp ||
+      "";
+  } catch (error: any) {
+    logger.error(error);
+    pendingUpdateRequestsCount.value = 0;
+    pendingUpdateRequestsLastCreatedAt.value = "";
+  }
+}
+
+async function loadErrorRecordCount() {
+  try {
+    errorRecordCount.value = await ShopifyProductSyncService.fetchErrorRecordCount({
+      shopId: props.id,
+      configId: PRODUCT_SYNC_MDM_CONFIG_ID
+    });
+  } catch (error) {
+    logger.error("Failed to load error record count", error);
+    errorRecordCount.value = 0;
+  }
+}
+
 async function openUnsyncedUpdatesModal() {
   if (!selectedShopSystemMessageRemoteId.value) {
     showToast(translate("Shopify product search is unavailable for this shop."));
@@ -1446,6 +1534,120 @@ function getSelectedProductSyncResultMessage(result: any, requestedCount: number
     rejected: Number(result?.rejectedCount || 0),
     requested: requestedCount
   });
+}
+
+async function loadLatestSystemMessage() {
+  const syncRunState = await ShopifyProductSyncService.fetchProductUpdateSyncRunState({
+    shopId: props.id,
+    systemMessageRemoteId: selectedShopSystemMessageRemoteId.value,
+    shop: shop.value
+  });
+
+  latestSystemMessage.value = await selectTrackProgressSystemMessage(syncRunState.systemMessages || []);
+  latestConfirmedSystemMessage.value = syncRunState.latestConfirmedSystemMessage || null;
+  latestConsumedSystemMessage.value = syncRunState.latestConsumedSystemMessage || null;
+  lastProductUpdateSyncedAt.value = syncRunState.lastSyncedAt || "";
+
+  if (latestSystemMessage.value?.systemMessageId) {
+    await fetchSyncRun(latestSystemMessage.value.systemMessageId);
+  } else {
+    currentSyncRun.value = {} as any;
+  }
+
+  await Promise.all([
+    fetchProductUpdateHistory({ shopId: props.id, pageSize: 10 }),
+    fetchRecentLogsByConfigId(PRODUCT_SYNC_MDM_CONFIG_ID, PRODUCT_SYNC_ERROR_LOG_LIMIT),
+    loadErrorRecordCount()
+  ]);
+  
+  if (recentMdmLogs.value.length) {
+    await fetchAllRecentFailedRecords(PRODUCT_SYNC_MDM_CONFIG_ID, recentMdmLogs.value);
+  }
+}
+
+async function downloadRawFile(item: any) {
+  try {
+    const configId = item.configId || PRODUCT_SYNC_MDM_CONFIG_ID;
+    const logContentId = item.logContentId;
+
+    if (!configId || !logContentId) {
+      showToast(translate("Raw file is not available"));
+      return;
+    }
+
+    const response = await downloadDataManagerFile(configId, logContentId);
+    const fileContent = getDownloadFileContent(response?.data);
+
+    if (!fileContent) {
+      throw new Error("No file content returned");
+    }
+
+    downloadTextFile(fileContent, getRawShopifyFileName(item));
+    showToast(translate("File downloaded successfully"));
+  } catch (error) {
+    logger.error(`Failed to download raw file for ${item.id}`, error);
+    showToast(translate("Failed to download raw file"));
+  }
+}
+
+async function viewErrorDetails(item: any) {
+  const logId = item.logId;
+  if (!logId) {
+    showToast(translate("Log ID is not available"));
+    return;
+  }
+
+  try {
+    await fetchLogDetails(logId);
+    if (!errorLogs.value.length) {
+       showToast(translate("No detailed error records found in this log"));
+    }
+  } catch (error) {
+    logger.error(`Failed to fetch log details for ${logId}`, error);
+    showToast(translate("Failed to fetch detailed error records"));
+  }
+}
+
+function openErrorDetailsModal(record: any) {
+  selectedErrorRecord.value = record;
+  showErrorDetailsModal.value = true;
+}
+
+async function refreshErrorRecords() {
+  await clearStorage();
+  errorLogs.value = [];
+  detailedErrorSearchQuery.value = "";
+  
+  // Re-fetch everything fresh
+  await fetchRecentLogsByConfigId(PRODUCT_SYNC_MDM_CONFIG_ID, PRODUCT_SYNC_ERROR_LOG_LIMIT);
+  if (recentMdmLogs.value.length) {
+    await fetchAllRecentFailedRecords(PRODUCT_SYNC_MDM_CONFIG_ID, recentMdmLogs.value);
+  }
+}
+
+async function resyncProduct(record: any) {
+  const shopifyProductId = record.numericId;
+  if (!shopifyProductId) {
+    showToast(translate("Shopify product ID not available for resync."));
+    return;
+  }
+
+  isSaving.value = true;
+  try {
+    const result = await ShopifyProductSyncService.syncShopifyProductsOnDemand({
+      shopId: props.id,
+      shopifyProductIds: [shopifyProductId]
+    });
+
+    showToast(getSelectedProductSyncResultMessage(result, 1));
+    await loadLatestSystemMessage();
+    await loadPendingUpdateRequests();
+  } catch (error: any) {
+    logger.error(error);
+    showToast(getErrorMessage(error, translate("Failed to resync product.")));
+  } finally {
+    isSaving.value = false;
+  }
 }
 
 async function selectTrackProgressSystemMessage(systemMessages: any[]) {

--- a/src/views/ShopifyProductSyncHistory.vue
+++ b/src/views/ShopifyProductSyncHistory.vue
@@ -128,7 +128,7 @@ import ShopifyProductSyncHistoryView from "@/components/ShopifyProductSyncHistor
 import { ShopifyProductSyncService } from "@/services/ShopifyProductSyncService";
 import { useSystemMessage } from "@/composables/useSystemMessage";
 import { useDataManagerLog } from "@/composables/useDataManagerLog";
-import { showToast } from "@/utils";
+import { downloadTextFile, getDownloadFileContent, showToast } from "@/utils";
 import {
   getSystemMessageTime,
   hasMoreForwardSystemMessagePages,
@@ -137,6 +137,7 @@ import {
 } from "@/utils/systemMessageHistory";
 import { getSystemMessageBulkOperationId } from "@/utils/shopifyBulkOperation";
 
+import { getRawShopifyFileName } from "@/utils/shopifyProductSyncWizard";
 const props = defineProps(["id"]);
 const store = useStore();
 const { fetchShopifyBulkOperationBySystemMessageId, fetchSystemMessageLogDetailsPage } = useSystemMessage();
@@ -601,30 +602,6 @@ async function getDownloadableHistoryRun(run: ShopifyProductSyncHistoryRun) {
   };
   updateHistoryRun(run.id, updatedRun);
   return updatedRun;
-}
-
-function getDownloadFileContent(data: any) {
-  const fileContent = data?.csvData ?? data?.fileData ?? data?.data ?? data;
-  if (typeof fileContent === "string") return fileContent;
-  if (fileContent === undefined || fileContent === null) return "";
-  return JSON.stringify(fileContent, null, 2);
-}
-
-function getRawShopifyFileName(run: ShopifyProductSyncHistoryRun) {
-  const fileName = String(run.mdmLogFileName || "").split(/[\\/]/).pop();
-  return fileName || `shopify-product-sync-${run.id}.json`;
-}
-
-function downloadTextFile(content: string, fileName: string) {
-  const blob = new Blob([content], { type: "text/plain;charset=utf-8;" });
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement("a");
-  link.href = url;
-  link.download = fileName;
-  document.body.appendChild(link);
-  link.click();
-  link.remove();
-  URL.revokeObjectURL(url);
 }
 
 function getErrorMessage(error: any, defaultMessage: string) {


### PR DESCRIPTION
- Show total errors found in the last 24 hours.
- Show errors as a list of cards with retry and view details buttons.
- Use local storage to store and search error data faster.
- Replace clear action with a refresh button to re-fetch errors.
- Clean up search to use product name, handle, and ID.
- Fix a bug that showed incorrect error content.
- Clean up code and fix template errors