### PR TITLE
feat: reapply product sync migration flow after PR 97

### DIFF
--- a/src/components/ShopifyProductSyncReturningView.vue
+++ b/src/components/ShopifyProductSyncReturningView.vue
@@ -66,9 +66,9 @@
               <p>{{ currentSyncRun.systemMessageId }}</p>
               <p>{{ translate("Next send attempt") }}: {{ systemMessageSendJobNextRunLabel }}</p>
             </ion-label>
-            <ion-badge slot="end" :color="currentSyncRun.systemMessage.statusColor">{{ currentSyncRun.systemMessage.statusLabel }}</ion-badge>
+            <ion-badge slot="end" :color="currentSyncRun.systemMessage?.statusColor || 'medium'">{{ currentSyncRun.systemMessage?.statusLabel || translate("Pending") }}</ion-badge>
           </ion-item>
-          <ion-item button detail @click="emit('open-step-details', { type: 'bulkOperation', id: currentSyncRun.bulkOperation.id })" :disabled="!currentSyncRun.bulkOperation?.id">
+          <ion-item button detail @click="emit('open-step-details', { type: 'bulkOperation', id: currentSyncRun.bulkOperation?.id })" :disabled="!currentSyncRun.bulkOperation?.id">
             <ion-label>
               {{ translate("Shopify bulk operation") }}
               <p>{{ currentSyncRun.bulkOperation?.id || translate("Not started") }}</p>
@@ -79,7 +79,7 @@
             </ion-note>
             <ion-badge slot="end" :color="currentSyncRun.bulkOperation?.statusColor || 'medium'">{{ currentSyncRun.bulkOperation?.statusLabel || translate("Pending") }}</ion-badge>
           </ion-item>
-          <ion-item button detail @click="emit('open-step-details', { type: 'mdmLog', id: currentSyncRun.mdmLog.id })" :disabled="!currentSyncRun.mdmLog?.id">
+          <ion-item button detail @click="emit('open-step-details', { type: 'mdmLog', id: currentSyncRun.mdmLog?.id })" :disabled="!currentSyncRun.mdmLog?.id">
             <ion-label>
               {{ translate("HotWax bulk import") }}
               <p>{{ currentSyncRun.mdmLog?.id || translate("Not started") }}</p>
@@ -274,13 +274,13 @@
 
   <section class="sync-stat">
     <div class="stat-header">
-      <ion-item class="stat-title" lines="none">
-        <ion-label>
-          <h2>{{ translate("Parsed error details") }}</h2>
-          <p style="margin-top: 2px;">{{ failedRecords.length }} {{ translate("of") }} {{ totalDetailedErrorsCount }} {{ translate("failed objects") }}</p>
-        </ion-label>
-        <ion-spinner v-if="isErrorLogsLoading" name="crescent" class="ion-margin-start" />
-      </ion-item>
+        <ion-item class="stat-title" lines="none">
+          <ion-label>
+            <h2>{{ translate("Parsed error details") }}</h2>
+            <p>{{ failedRecords.length }} {{ translate("of") }} {{ totalDetailedErrorsCount }} {{ translate("failed objects") }}</p>
+          </ion-label>
+          <ion-spinner v-if="isErrorLogsLoading" name="crescent" class="ion-margin-start" />
+        </ion-item>
       <ion-buttons slot="end" v-if="hasDetailedErrors">
         <ion-button color="medium" @click="emit('refresh-errors')">
           <ion-icon slot="icon-only" :icon="refreshOutline" />
@@ -289,7 +289,7 @@
       <ion-searchbar :value="detailedErrorQuery" @ionInput="emit('update:detailed-error-query', $event.detail.value)" :placeholder="translate('Search by ID, Name or Handle')" />
     </div>
     <div class="stat-data" v-if="failedRecords.length">
-      <ion-card v-for="record in failedRecords" :key="record.id" style="flex: 0 0 320px; margin: 8px;">
+      <ion-card v-for="record in failedRecords" :key="record.id">
         <ion-item lines="full">
           <ion-label class="ion-text-wrap">
             <h3>{{ record.title }}</h3>
@@ -300,7 +300,7 @@
           <p class="ion-no-margin">
             <strong>{{ translate("Product ID") }}:</strong> {{ record.numericId || 'N/A' }}
           </p>
-          <p class="ion-no-margin" style="font-size: 1.1rem; margin-top: 8px;">
+          <p class="ion-no-margin ion-margin-top">
             {{ record.error }}
           </p>
           <div class="ion-margin-top">

--- a/src/components/ShopifyProductSyncWizardView.vue
+++ b/src/components/ShopifyProductSyncWizardView.vue
@@ -233,141 +233,48 @@
     </ion-card>
 
     <template v-if="currentStep === 'progress'">
-      <ion-card>
-        <ion-card-header>
-          <ion-card-title>{{ translate("Track sync progress") }}</ion-card-title>
-          <ion-card-subtitle>{{ translate("Monitor each step as products get imported from Shopify")
-            }}</ion-card-subtitle>
-        </ion-card-header>
-        <ion-list lines="full">
-          <template v-if="currentSyncRun && currentSyncRun.systemMessageId">
-            <ion-item button detail
-              @click="$emit('open-step-details', { type: 'systemMessage', id: currentSyncRun.systemMessageId })">
-              <ion-label>
-                {{ translate("System message") }}
-                <p>{{ currentSyncRun.systemMessageId }}</p>
-                <p>{{ translate("Next send attempt") }}: {{ systemMessageSendJobNextRunLabel }}</p>
-              </ion-label>
-              <ion-badge slot="end" :color="currentSyncRun.statusColor">{{ currentSyncRun.status }}</ion-badge>
-            </ion-item>
-            <ion-item button detail
-              @click="$emit('open-step-details', { type: 'bulkOperation', id: currentSyncRun.bulkOperation.id })"
-              :disabled="!currentSyncRun.bulkOperation?.id">
-              <ion-label>
-                {{ translate("Shopify bulk operation") }}
-                <p>{{ currentSyncRun.bulkOperation?.id || translate("Not started") }}</p>
-                <p>{{ translate("Next poll attempt") }}: {{ bulkOperationPollJobNextRunLabel }}</p>
-              </ion-label>
-              <ion-note slot="end" v-if="currentSyncRun.bulkOperation?.objectCount">
-                {{ currentSyncRun.bulkOperation.objectCount }} {{ translate("objects") }}
-              </ion-note>
-              <ion-badge slot="end" :color="currentSyncRun.bulkOperation?.statusColor || 'medium'">{{
-                currentSyncRun.bulkOperation?.statusLabel || translate("Pending") }}</ion-badge>
-            </ion-item>
-            <ion-item button detail @click="$emit('open-step-details', { type: 'mdmLog', id: currentSyncRun.mdmLog.id })"
-              :disabled="!currentSyncRun.mdmLog?.id">
-              <ion-label>
-                {{ translate("HotWax bulk import") }}
-                <p>{{ currentSyncRun.mdmLog?.id || translate("Not started") }}</p>
-              </ion-label>
-              <ion-note slot="end" v-if="currentSyncRun.mdmLog?.totalRecordCount">
-                {{ currentSyncRun.mdmLog.totalRecordCount }} {{ translate("records") }}
-              </ion-note>
-              <ion-badge slot="end" :color="currentSyncRun.mdmLog?.statusColor || 'medium'">{{
-                currentSyncRun.mdmLog?.statusLabel || translate("Pending") }}</ion-badge>
-            </ion-item>
-          </template>
-          <ion-item v-else>
-            <ion-label>{{ translate("Syncing...") }}</ion-label>
-          </ion-item>
-        </ion-list>
-      </ion-card>
 
-      <ion-card>
-        <ion-card-header>
-          <ion-card-title>{{ translate("Product export request payload") }}</ion-card-title>
-          <ion-card-subtitle>{{ translate("Using Shopify's bulk query API to export all products in the catalog.") }}</ion-card-subtitle>
-        </ion-card-header>
-        <ion-list lines="full">
-          <ion-item button detail
-            @click="emit('open-step-details', { type: 'systemMessage', id: systemMessageId })"
-            :disabled="!systemMessageId">
-            <ion-icon slot="start" :icon="documentTextOutline" />
+      <div class="bulk-steps">
+        <!-- Export message -->
+        <ion-card class="message">
+          <ion-item lines="none">
+            <ion-icon slot="start" :icon="pulseOutline" />
             <ion-label>
-              {{ translate("System message") }}
-              <p>{{ systemMessageId || translate("Not available") }}</p>
+              {{ translate("Product export request payload") }}
+              <p>{{ translate("Using Shopify’s bulk query API to export all products in the catalog.") }}</p>
+              <p>{{ translate("System message id") }}: {{ systemMessageId }}</p>
             </ion-label>
             <ion-badge slot="end" :color="systemMessageStatusColor">{{ systemMessageStatusLabel }}</ion-badge>
           </ion-item>
-          <ion-item button detail
-            @click="emit('open-step-details', { type: 'bulkOperation', id: bulkOperationId })"
-            :disabled="!bulkOperationId">
+        </ion-card>
+
+        <!-- Shopify bulk operation -->
+        <ion-card class="export">
+          <ion-item lines="none">
             <ion-icon slot="start" :icon="pulseOutline" />
             <ion-label>
-              {{ translate("Shopify bulk operation") }}
+              {{ translate("Pending bulk operations") }}
               <p>{{ translate("Shopify might take some time to process bulk operation requests.") }}</p>
               <p>{{ bulkOperationProgressLabel }}</p>
-              <p>{{ translate("Next poll attempt") }}: {{ bulkOperationPollJobNextRunLabel }}</p>
+              <p v-if="bulkOperationId">{{ translate("Bulk operation id") }}: {{ bulkOperationId }}</p>
             </ion-label>
-            <ion-badge slot="end" :color="bulkOperationStatusColor">{{ bulkOperationStatusLabel }}</ion-badge>
+            <ion-badge :color="bulkOperationStatusColor" slot="end">{{ bulkOperationStatusLabel }}</ion-badge>
           </ion-item>
-          <ion-progress-bar v-if="hasBulkOperationProgress" :value="bulkOperationProgressValue" />
-          <ion-item>
-            <ion-label>{{ translate("Products and variants processed / Total product count") }}</ion-label>
-            <ion-note slot="end">{{ bulkOperationProgressLabel }}</ion-note>
-          </ion-item>
-        </ion-list>
-      </ion-card>
+          <ion-progress-bar :value="bulkOperationProgressValue"></ion-progress-bar>
+        </ion-card>
 
-      <ion-card>
-        <ion-card-header>
-          <ion-card-title>{{ translate("Pending bulk operations") }}</ion-card-title>
-          <ion-card-subtitle>{{ translate("Shopify might take some time to process bulk operation requests.") }}</ion-card-subtitle>
-        </ion-card-header>
-        <ion-list lines="full">
-          <ion-item v-if="queuedJobsAhead">
-            <ion-label>{{ translate("Queued jobs ahead") }}</ion-label>
-            <ion-note slot="end">{{ queuedJobsAhead }}</ion-note>
-          </ion-item>
-          <ion-item>
-            <ion-icon slot="start" :icon="sendOutline" />
+        <!-- HotWax bulk import -->
+        <ion-card class="import">
+          <ion-item lines="none">
+            <ion-icon slot="start" :icon="pulseOutline" />
             <ion-label>
-              {{ translate("Your request") }}
-              <p>{{ bulkOperationId || systemMessageId || translate("Not available") }}</p>
+              {{ translate("Bulk file process") }}
+              <p>{{ bulkFileProcessDescription }}</p>
             </ion-label>
-            <ion-badge slot="end" :color="bulkOperationStatusColor">{{ bulkOperationStatusLabel }}</ion-badge>
+            <ion-note :color="mdmLogStatusColor">{{ mdmLogStatusLabel }}</ion-note>
           </ion-item>
-        </ion-list>
-      </ion-card>
-
-      <ion-card>
-        <ion-card-header>
-          <ion-card-title>{{ translate("Bulk file process") }}</ion-card-title>
-          <ion-card-subtitle>{{ bulkFileProcessDescription }}</ion-card-subtitle>
-        </ion-card-header>
-        <ion-list lines="full">
-          <ion-item button detail @click="emit('open-step-details', { type: 'mdmLog', id: mdmLogId })"
-            :disabled="!mdmLogId">
-            <ion-icon slot="start" :icon="serverOutline" />
-            <ion-label>
-              {{ translate("HotWax bulk import") }}
-              <p>{{ mdmLogId || translate("Not started") }}</p>
-            </ion-label>
-            <ion-note slot="end" v-if="mdmRecordCount">
-              {{ mdmRecordCount }} {{ translate("records") }}
-            </ion-note>
-            <ion-badge slot="end" :color="mdmLogStatusColor">{{ mdmLogStatusLabel }}</ion-badge>
-          </ion-item>
-        </ion-list>
-        <ion-card-content>
-          <ion-button expand="block" fill="outline" @click="$emit('load-progress')">{{ translate("Refresh status")
-            }}</ion-button>
-          <ion-button expand="block" :disabled="!reconcileAvailable" @click="$emit('go-next')"
-            data-testid="reconcile-sync">
-            {{ translate("Reconcile product sync") }}
-          </ion-button>
-        </ion-card-content>
-      </ion-card>
+        </ion-card>
+      </div>
     </template>
 
     <ion-card class="step" v-if="currentStep === 'reconcile'">
@@ -379,11 +286,11 @@
       <ion-list lines="full">
         <ion-item>
           <ion-label>{{ translate("Shopify products") }}</ion-label>
-          <ion-note slot="end">{{ reviewStats.shopifyProductCount }}</ion-note>
+          <ion-note slot="end">{{ reviewStats?.shopifyProductCount }}</ion-note>
         </ion-item>
         <ion-item>
           <ion-label>{{ translate("HotWax products") }}</ion-label>
-          <ion-note slot="end">{{ reviewStats.omsProductCount }}</ion-note>
+          <ion-note slot="end">{{ reviewStats?.omsProductCount }}</ion-note>
         </ion-item>
         <ion-item>
           <ion-label>{{ translate("Completion status") }}</ion-label>
@@ -502,6 +409,8 @@
 <script setup lang="ts">
 import type { ShopifyProductSyncRun } from "@/services/ShopifyProductSyncService";
 import {
+  IonAccordion,
+  IonAccordionGroup,
   IonBadge,
   IonButton,
   IonButtons,
@@ -657,6 +566,8 @@ const hasBulkOperationProgress = computed(() => {
 });
 
 const bulkOperationProgressValue = computed(() => {
+  const status = (props.currentSyncRun?.bulkOperation?.status || props.progressState?.bulkOperationStatus || "").toLowerCase();
+  if (status === "complete" || status === "completed") return 1;
   return bulkOperationProgress.value.value;
 });
 
@@ -728,4 +639,17 @@ function isCompleteStatus(status = "") {
   justify-self: center;
 }
 
+.bulk-steps {
+  grid-column: 2;
+}
+
+.bulk-steps ion-card {
+  border: 1px solid var(--ion-color-medium);
+  --background: transparent;
+  border-radius: 8px;
+}
+
+.bulk-steps ion-item {
+  --background: transparent;
+}
 </style>

--- a/src/composables/useProductUpdateHistory.ts
+++ b/src/composables/useProductUpdateHistory.ts
@@ -136,6 +136,11 @@ function getProductUpdateHistoryPayload(data: any): any[] {
 }
 
 export function useProductUpdateHistory() {
+  const setProductUpdateHistory = (histories: any) => {
+    state.productUpdateHistories = processHistories(getProductUpdateHistoryPayload(histories));
+    return state.productUpdateHistories;
+  };
+
   const fetchProductUpdateHistory = async (params: any) => {
     state.loading = true;
     try {
@@ -148,8 +153,7 @@ export function useProductUpdateHistory() {
         }
       }) as any;
 
-      state.productUpdateHistories = processHistories(getProductUpdateHistoryPayload(response?.data));
-      return state.productUpdateHistories;
+      return setProductUpdateHistory(response?.data);
     } catch (err) {
       logger.error("Failed to fetch product update history", err);
       state.productUpdateHistories = [];
@@ -161,6 +165,7 @@ export function useProductUpdateHistory() {
 
   return {
     ...toRefs(state),
+    setProductUpdateHistory,
     fetchProductUpdateHistory
   };
 }

--- a/src/services/ShopifyProductSyncService.ts
+++ b/src/services/ShopifyProductSyncService.ts
@@ -59,6 +59,13 @@ export interface ShopifyPendingProductUpdateRequestsState {
   latestSystemMessage?: any;
 }
 
+export interface ShopifyProductSyncDashboardSummary {
+  syncRunState: ShopifyProductUpdateSyncRunState;
+  pendingRequests: ShopifyPendingProductUpdateRequestsState;
+  runningOperation: ShopifyRunningBulkOperation | null;
+  unsyncedUpdates: ShopifyShopProductCount;
+}
+
 export interface ShopifyRunningBulkOperation {
   id: string;
   status: string;
@@ -762,7 +769,8 @@ const fetchShopifyShopProductCount = async (payload: any): Promise<ShopifyShopPr
     throw new Error("Shopify systemMessageRemoteId is required to fetch unsynced product update counts.");
   }
 
-  const lastSyncedAt = payload.lastSyncedAt || (await fetchProductUpdateSyncRunState(systemMessageRemoteId)).lastSyncedAt;
+  const lastSyncedAt = payload.lastSyncedAt || payload.syncRunState?.lastSyncedAt ||
+    (await fetchProductUpdateSyncRunState(systemMessageRemoteId)).lastSyncedAt;
   const response = await requestBackend<ShopifyGraphqlResponse>({
     url: "shopify/graphql",
     method: "post",
@@ -789,7 +797,8 @@ const fetchUnsyncedProductUpdates = async (payload: any): Promise<ShopifyUnsynce
     throw new Error("Shopify systemMessageRemoteId is required to fetch unsynced product updates.");
   }
 
-  const lastSyncedAt = payload.lastSyncedAt || (await fetchProductUpdateSyncRunState(systemMessageRemoteId)).lastSyncedAt;
+  const lastSyncedAt = payload.lastSyncedAt || payload.syncRunState?.lastSyncedAt ||
+    (await fetchProductUpdateSyncRunState(systemMessageRemoteId)).lastSyncedAt;
   const response = await requestBackend<ShopifyGraphqlResponse>({
     url: "shopify/graphql",
     method: "post",
@@ -1172,7 +1181,7 @@ const fetchErrorRecordCount = async (payload: any): Promise<number> => {
   }
 };
 
-const fetchDashboardSummary = async (payload: any): Promise<any> => {
+const fetchDashboardSummary = async (payload: any): Promise<ShopifyProductSyncDashboardSummary> => {
   const { shopId, systemMessageRemoteId, shop } = payload;
   
   const [syncRunState, pendingRequests, runningOperation] = await Promise.all([
@@ -1180,11 +1189,17 @@ const fetchDashboardSummary = async (payload: any): Promise<any> => {
     fetchPendingProductUpdateRequests(payload),
     fetchRunningBulkOperation(payload)
   ]);
+  const unsyncedUpdates = await fetchShopifyShopProductCount({
+    ...payload,
+    systemMessageRemoteId,
+    syncRunState
+  });
 
   return {
     syncRunState,
     pendingRequests,
-    runningOperation
+    runningOperation,
+    unsyncedUpdates
   };
 };
 

--- a/src/utils/shopifyProductSync.ts
+++ b/src/utils/shopifyProductSync.ts
@@ -1,0 +1,66 @@
+
+export interface SystemMessage {
+  systemMessageId: string;
+  statusId: string;
+  initDate?: string | number;
+  lastUpdatedStamp?: string | number;
+  processedDate?: string | number;
+}
+
+export const SYSTEM_MESSAGE_RECEIVED_STATUSES = ["smsgreceived", "received"];
+export const SYSTEM_MESSAGE_SENT_STATUSES = ["smsgsent", "sent"];
+export const SYSTEM_MESSAGE_PRODUCED_STATUSES = ["smsgproduced", "produced"];
+export const SYSTEM_MESSAGE_CONSUMED_STATUSES = ["smsgconsumed", "consumed", "smsgconfirmed", "confirmed"];
+
+export function normalizeStatusValue(statusId: string) {
+  return String(statusId || "").toLowerCase().replace(/[_\-\s]/g, "");
+}
+
+export function hasSystemMessageStatus(systemMessage: SystemMessage, statuses: string[]) {
+  return statuses.includes(normalizeStatusValue(systemMessage?.statusId));
+}
+
+export function getSystemMessageTime(systemMessage: SystemMessage) {
+  const value = systemMessage?.initDate || systemMessage?.lastUpdatedStamp || systemMessage?.processedDate;
+  if (!value) return 0;
+  if (typeof value === "number") return value;
+  const parsed = new Date(value).getTime();
+  return isNaN(parsed) ? 0 : parsed;
+}
+
+export function sortSystemMessagesOldestFirst(systemMessages: SystemMessage[]) {
+  return [...systemMessages].sort((a, b) => getSystemMessageTime(a) - getSystemMessageTime(b));
+}
+
+export function sortSystemMessagesNewestFirst(systemMessages: SystemMessage[]) {
+  return [...systemMessages].sort((a, b) => getSystemMessageTime(b) - getSystemMessageTime(a));
+}
+
+export function getOldestSystemMessageByStatus(systemMessages: SystemMessage[], statuses: string[]) {
+  return sortSystemMessagesOldestFirst(systemMessages.filter((message) => hasSystemMessageStatus(message, statuses)))[0] || null;
+}
+
+/**
+ * Original complex selection logic.
+ * Finds the oldest pending message or the newest consumed message.
+ */
+export function selectTrackProgressSystemMessage(systemMessages: SystemMessage[]) {
+  if (!systemMessages.length) return null;
+
+  const consumedMessages = systemMessages.filter((message) => hasSystemMessageStatus(message, SYSTEM_MESSAGE_CONSUMED_STATUSES));
+
+  return getOldestSystemMessageByStatus(systemMessages, SYSTEM_MESSAGE_RECEIVED_STATUSES) ||
+    getOldestSystemMessageByStatus(systemMessages, SYSTEM_MESSAGE_SENT_STATUSES) ||
+    getOldestSystemMessageByStatus(systemMessages, SYSTEM_MESSAGE_PRODUCED_STATUSES) ||
+    sortSystemMessagesNewestFirst(consumedMessages)[0] ||
+    null;
+}
+
+/**
+ * Simplified selection logic as requested by the user.
+ * Simply returns the most recent system message regardless of status.
+ */
+export function selectMostRecentSystemMessage(systemMessages: SystemMessage[]) {
+  if (!systemMessages.length) return null;
+  return sortSystemMessagesNewestFirst(systemMessages)[0] || null;
+}

--- a/src/views/ShopifyConnectionDetails.vue
+++ b/src/views/ShopifyConnectionDetails.vue
@@ -142,7 +142,7 @@
             <ion-item detail class="item-box" lines="none" button @click="openProductTypes()">
               <ion-label>{{ translate("Product types") }}</ion-label>
             </ion-item>
-            
+
           </section>
         </div>
 
@@ -438,18 +438,11 @@ async function loadProductsInventorySummary() {
 
     const trackProgressMessage = await selectTrackProgressSystemMessage(productSyncSummary.value.syncRunState?.systemMessages || []);
     if (trackProgressMessage?.systemMessageId) {
-      await fetchSyncRun(trackProgressMessage.systemMessageId);
+      await fetchSyncRun(trackProgressMessage.systemMessageId, trackProgressMessage);
     }
 
     productSyncRecordsProcessed.value = Number(currentSyncRun.value?.mdmLog?.totalRecordCount || 0);
-
-    const unsyncedCountState = await ShopifyProductSyncService.fetchShopifyShopProductCount({
-      shopId: props.id,
-      systemMessageRemoteId,
-      lastSyncedAt: productSyncSummary.value.syncRunState?.lastSyncedAt,
-      shop: shop.value
-    });
-    productSyncUnsyncedCount.value = Number(unsyncedCountState.count || 0);
+    productSyncUnsyncedCount.value = Number(productSyncSummary.value.unsyncedUpdates?.count || 0);
   } catch (error) {
     logger.error(error);
     hasProductSyncSummaryError.value = true;

--- a/src/views/ShopifyProductSync.vue
+++ b/src/views/ShopifyProductSync.vue
@@ -615,19 +615,22 @@ import {
   alertController,
   modalController
 } from "@ionic/vue";
+import {
+  selectMostRecentSystemMessage
+} from "@/utils/shopifyProductSync";
 import { closeOutline, refreshOutline, saveOutline } from "ionicons/icons";
 import cronstrue from "cronstrue";
 
 import { translate } from "@/i18n";
 import { computed, defineProps, onBeforeUnmount, ref, watch } from "vue";
 import { useStore } from "vuex";
-import { useRouter } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 import ShopifyProductSyncReturningView from "@/components/ShopifyProductSyncReturningView.vue";
 import ShopifyProductSyncProductsModal from "@/components/ShopifyProductSyncProductsModal.vue";
 import ShopifyProductSyncWizardView from "@/components/ShopifyProductSyncWizardView.vue";
 import { ProductStoreService } from "@/services/ProductStoreService";
 import { ShopifyService } from "@/services/ShopifyService";
-import { ShopifyProductSyncService } from "@/services/ShopifyProductSyncService";
+import { ShopifyProductSyncService, type ShopifyProductSyncDashboardSummary } from "@/services/ShopifyProductSyncService";
 import { UserService } from "@/services/UserService";
 import {
   canAdvanceProductSyncStep,
@@ -658,6 +661,7 @@ import { deleteErrorRecords } from "@/utils/storage";
 const props = defineProps(["id"]);
 const store = useStore();
 const router = useRouter();
+const route = useRoute();
 const {
   jobs,
   products,
@@ -669,33 +673,14 @@ const {
   updateJob,
   runNow
 } = useServiceJob();
-const { downloadDataManagerFile, fetchLogDetails, fetchMdmLogBySystemMessageId, fetchRecentLogsByConfigId, currentMdmLog, recentMdmLogs, errorLogs, fetchAllRecentFailedRecords, clearStorage, loading: isErrorLogsLoading } = useDataManagerLog();
-const { productUpdateHistories, fetchProductUpdateHistory } = useProductUpdateHistory();
+const { downloadDataManagerFile, fetchLogDetails, fetchRecentLogsByConfigId, currentMdmLog, recentMdmLogs, errorLogs, fetchAllRecentFailedRecords, clearStorage, loading: isErrorLogsLoading } = useDataManagerLog();
+const { productUpdateHistories, fetchProductUpdateHistory, setProductUpdateHistory } = useProductUpdateHistory();
 const { currentSyncRun, fetchSyncRun } = useShopifyProductSyncRun();
 const PRODUCT_UPDATE_SYNC_SERVICE_NAME = "sync_ShopifyProductUpdates";
 const BULK_OPERATION_SEND_JOB_NAME = "send_ProducedBulkOperationSystemMessage_ShopifyBulkQuery";
 const BULK_OPERATION_POLL_JOB_NAME = "poll_ShopifyBulkOperationResult";
 const PRODUCT_SYNC_MDM_CONFIG_ID = "SYNC_SHOPIFY_PRODUCT";
 const PRODUCT_SYNC_ERROR_LOG_LIMIT = 10;
-const SYSTEM_MESSAGE_CONSUMED_STATUSES = ["smsgconsumed", "consumed", "smsgconfirmed", "confirmed"];
-const SYSTEM_MESSAGE_RECEIVED_STATUSES = ["smsgreceived", "received"];
-const SYSTEM_MESSAGE_SENT_STATUSES = ["smsgsent", "sent"];
-const SYSTEM_MESSAGE_PRODUCED_STATUSES = ["smsgproduced", "produced"];
-const TERMINAL_MDM_LOG_STATUSES = [
-  "dmlsuccess",
-  "dmlerror",
-  "success",
-  "succeeded",
-  "complete",
-  "completed",
-  "finished",
-  "error",
-  "failed",
-  "failure",
-  "cancelled",
-  "canceled"
-];
-
 const latestSystemMessage = ref<any>(null);
 const latestConfirmedSystemMessage = ref<any>(null);
 const latestConsumedSystemMessage = ref<any>(null);
@@ -1256,6 +1241,7 @@ async function loadWizard() {
       historyPageSize: 10
     });
     assertBackendDataAvailable(setupState.value, translate("Product sync setup is unavailable."));
+    setProductUpdateHistory(setupState.value.productUpdateHistory || []);
 
     draft.value = createProductSyncWizardDraft({
       selectedProductStoreId: setupState.value.selectedProductStoreId || shop.value.productStoreId || "",
@@ -1283,6 +1269,15 @@ async function loadWizard() {
       await loadProductStoreContext(draft.value.selectedProductStoreId);
     }
 
+    // Dev override to land on a specific step
+    if (route.query.step) {
+      currentStep.value = route.query.step as ProductSyncWizardStep;
+      if (currentStep.value === "progress") {
+        const loadedProgress = await loadProgress();
+        if (loadedProgress) startProgressPolling();
+      }
+    }
+
     // Now kick off secondary data in background without blocking
     loadSecondaryData().catch((e) => logger.error("Failed to load secondary data", e));
 
@@ -1304,28 +1299,14 @@ async function loadSecondaryData() {
       systemMessageRemoteId: selectedShopSystemMessageRemoteId.value,
       shop: shop.value
     });
-
-    // Assign summary variables
-    latestSystemMessage.value = await selectTrackProgressSystemMessage(summary.syncRunState.systemMessages || []);
-    latestConfirmedSystemMessage.value = summary.syncRunState.latestConfirmedSystemMessage;
-    latestConsumedSystemMessage.value = summary.syncRunState.latestConsumedSystemMessage;
-    recentMdmLogs.value = summary.syncRunState.systemMessages;
-    lastProductUpdateSyncedAt.value = summary.syncRunState.lastSyncedAt || "";
+    applyDashboardSummary(summary);
 
     if (latestSystemMessage.value?.systemMessageId) {
-      await fetchSyncRun(latestSystemMessage.value.systemMessageId);
+      await fetchSyncRun(latestSystemMessage.value.systemMessageId, latestSystemMessage.value);
     } else {
       currentSyncRun.value = {} as any;
     }
 
-    pendingUpdateRequestsCount.value = Number(summary.pendingRequests.count || 0);
-    pendingUpdateRequestsLastCreatedAt.value = summary.pendingRequests.latestSystemMessage?.initDate ||
-      summary.pendingRequests.latestSystemMessage?.createdDate ||
-      summary.pendingRequests.latestSystemMessage?.lastUpdatedStamp || "";
-
-    runningShopifyBulkOperation.value = summary.runningOperation;
-
-    // 2. Fetch jobs
     await fetchJobs({});
     const syncJobs = jobs.value.filter((job: any) => isProductUpdateSyncServiceJob(job) || (syncJobId.value && job.jobName === syncJobId.value));
     await Promise.all(syncJobs.map(async (job: any) => {
@@ -1336,11 +1317,10 @@ async function loadSecondaryData() {
     await loadBulkOperationMonitoringJobs();
 
     await Promise.all([
-      loadShopifyShopProductCount(),
       loadSyncJobLatestRun(),
       loadBulkOperationSendJobLatestRun(),
       loadBulkOperationPollJobLatestRun(),
-      fetchProductUpdateHistory({ shopId: props.id, pageSize: 10 })
+      fetchRecentLogsByConfigId(PRODUCT_SYNC_MDM_CONFIG_ID, PRODUCT_SYNC_ERROR_LOG_LIMIT)
     ]);
 
     if (recentMdmLogs.value.length) {
@@ -1351,6 +1331,20 @@ async function loadSecondaryData() {
   } finally {
     isSecondaryLoading.value = false;
   }
+}
+
+function applyDashboardSummary(summary: ShopifyProductSyncDashboardSummary) {
+  latestSystemMessage.value = selectMostRecentSystemMessage(summary.syncRunState.systemMessages || []);
+  latestConfirmedSystemMessage.value = summary.syncRunState.latestConfirmedSystemMessage || null;
+  latestConsumedSystemMessage.value = summary.syncRunState.latestConsumedSystemMessage || null;
+  lastProductUpdateSyncedAt.value = summary.syncRunState.lastSyncedAt || "";
+  pendingUpdateRequestsCount.value = Number(summary.pendingRequests.count || 0);
+  pendingUpdateRequestsLastCreatedAt.value = summary.pendingRequests.latestSystemMessage?.initDate ||
+    summary.pendingRequests.latestSystemMessage?.createdDate ||
+    summary.pendingRequests.latestSystemMessage?.lastUpdatedStamp ||
+    "";
+  runningShopifyBulkOperation.value = summary.runningOperation;
+  shopifyShopProductCount.value = Number(summary.unsyncedUpdates?.count || 0);
 }
 
 async function loadBulkOperationMonitoringJobs() {
@@ -1409,40 +1403,6 @@ async function openStepDetails(step: any) {
     } finally {
       isStepDetailsLoading.value = false;
     }
-  }
-}
-
-async function loadShopifyShopProductCount() {
-  try {
-    const countState = await ShopifyProductSyncService.fetchShopifyShopProductCount({
-      shopId: props.id,
-      systemMessageRemoteId: selectedShopSystemMessageRemoteId.value,
-      lastSyncedAt: lastProductUpdateSyncedAt.value,
-      shop: shop.value
-    });
-    shopifyShopProductCount.value = Number(countState.count || 0);
-  } catch (error: any) {
-    logger.error(error);
-    throw error;
-  }
-}
-
-async function loadPendingUpdateRequests() {
-  try {
-    const pendingState = await ShopifyProductSyncService.fetchPendingProductUpdateRequests({
-      shopId: props.id,
-      systemMessageRemoteId: selectedShopSystemMessageRemoteId.value,
-      shop: shop.value
-    });
-    pendingUpdateRequestsCount.value = Number(pendingState.count || 0);
-    pendingUpdateRequestsLastCreatedAt.value = pendingState.latestSystemMessage?.initDate ||
-      pendingState.latestSystemMessage?.createdDate ||
-      pendingState.latestSystemMessage?.lastUpdatedStamp ||
-      "";
-  } catch (error: any) {
-    logger.error(error);
-    pendingUpdateRequestsCount.value = 0;
-    pendingUpdateRequestsLastCreatedAt.value = "";
   }
 }
 
@@ -1515,7 +1475,6 @@ async function handleSelectedProductsForSync(data: any) {
 
     showToast(getSelectedProductSyncResultMessage(result, shopifyProductIds.length));
     await loadLatestSystemMessage();
-    await loadPendingUpdateRequests();
   } catch (error: any) {
     logger.error(error);
     showToast(getErrorMessage(error, translate("Failed to sync selected products.")));
@@ -1547,19 +1506,15 @@ function getSelectedProductSyncResultMessage(result: any, requestedCount: number
 }
 
 async function loadLatestSystemMessage() {
-  const syncRunState = await ShopifyProductSyncService.fetchProductUpdateSyncRunState({
+  const summary = await ShopifyProductSyncService.fetchDashboardSummary({
     shopId: props.id,
     systemMessageRemoteId: selectedShopSystemMessageRemoteId.value,
     shop: shop.value
   });
-
-  latestSystemMessage.value = selectTrackProgressSystemMessage(syncRunState.systemMessages || []);
-  latestConfirmedSystemMessage.value = syncRunState.latestConfirmedSystemMessage || null;
-  latestConsumedSystemMessage.value = syncRunState.latestConsumedSystemMessage || null;
-  lastProductUpdateSyncedAt.value = syncRunState.lastSyncedAt || "";
+  applyDashboardSummary(summary);
 
   if (latestSystemMessage.value?.systemMessageId) {
-    await fetchSyncRun(latestSystemMessage.value.systemMessageId);
+    await fetchSyncRun(latestSystemMessage.value.systemMessageId, latestSystemMessage.value);
   } else {
     currentSyncRun.value = {} as any;
   }
@@ -1650,7 +1605,6 @@ async function resyncProduct(record: any) {
 
     showToast(getSelectedProductSyncResultMessage(result, 1));
     await loadLatestSystemMessage();
-    await loadPendingUpdateRequests();
   } catch (error: any) {
     logger.error(error);
     showToast(getErrorMessage(error, translate("Failed to resync product.")));
@@ -1658,59 +1612,6 @@ async function resyncProduct(record: any) {
     isSaving.value = false;
   }
 }
-
-function selectTrackProgressSystemMessage(systemMessages: any[]) {
-  if (!systemMessages.length) return null;
-
-  const consumedMessages = systemMessages.filter((message) => hasSystemMessageStatus(message, SYSTEM_MESSAGE_CONSUMED_STATUSES));
-  const oldestConsumedMessages = sortSystemMessagesOldestFirst(consumedMessages);
-
-  for (const message of oldestConsumedMessages) {
-    if (message.logId && !isTerminalMdmLogStatus(message.logStatusId)) {
-      return message;
-    }
-  }
-
-  return getOldestSystemMessageByStatus(systemMessages, SYSTEM_MESSAGE_RECEIVED_STATUSES) ||
-    getOldestSystemMessageByStatus(systemMessages, SYSTEM_MESSAGE_SENT_STATUSES) ||
-    getOldestSystemMessageByStatus(systemMessages, SYSTEM_MESSAGE_PRODUCED_STATUSES) ||
-    sortSystemMessagesNewestFirst(consumedMessages)[0] ||
-    null;
-}
-
-function getOldestSystemMessageByStatus(systemMessages: any[], statuses: string[]) {
-  return sortSystemMessagesOldestFirst(systemMessages.filter((message) => hasSystemMessageStatus(message, statuses)))[0];
-}
-
-function hasSystemMessageStatus(systemMessage: any, statuses: string[]) {
-  return statuses.includes(normalizeStatusValue(systemMessage?.statusId));
-}
-
-function isTerminalMdmLogStatus(statusId: string) {
-  return TERMINAL_MDM_LOG_STATUSES.includes(normalizeStatusValue(statusId));
-}
-
-function sortSystemMessagesOldestFirst(systemMessages: any[]) {
-  return [...systemMessages].sort((firstMessage, secondMessage) => {
-    return getSystemMessageTime(firstMessage) - getSystemMessageTime(secondMessage);
-  });
-}
-
-function sortSystemMessagesNewestFirst(systemMessages: any[]) {
-  return [...systemMessages].sort((firstMessage, secondMessage) => {
-    return getSystemMessageTime(secondMessage) - getSystemMessageTime(firstMessage);
-  });
-}
-
-function getSystemMessageTime(systemMessage: any) {
-  const value = systemMessage?.initDate || systemMessage?.lastUpdatedStamp || systemMessage?.processedDate;
-  return parseDateTimeValue(value)?.toMillis() || 0;
-}
-
-function normalizeStatusValue(statusId: string) {
-  return String(statusId || "").toLowerCase().replace(/[_\-\s]/g, "");
-}
-
 
 async function loadProductStoreContext(productStoreId: string) {
   try {

--- a/tests/unit/shopify-product-sync-service.test.ts
+++ b/tests/unit/shopify-product-sync-service.test.ts
@@ -37,69 +37,7 @@ function createRejectingApi() {
   return { api, calls };
 }
 
-describe("shopify product sync service failure behavior", () => {
-  test("startInitialImport uses the backend response instead of hardcoded completed success", async () => {
-    const calls: ApiCall[] = [];
-    const service = await loadService(async (request: ApiCall) => {
-      calls.push(request);
-      return {
-        data: {
-          success: true,
-          syncJobId: "SMSG_REAL_IMPORT",
-          progress: {
-            syncJobId: "SMSG_REAL_IMPORT",
-            status: "queued",
-            systemMessageState: "SmsgProduced",
-            completed: false
-          },
-          backendAvailable: true
-        }
-      };
-    });
-
-    const result = await service.startInitialImport({
-      shopId: "SHOP_10000",
-      productStoreId: "STORE_A",
-      productIdentifierEnumId: "SHOPIFY_PRODUCT_SKU",
-      systemMessageRemoteId: "SMR_REAL_SHOP"
-    });
-
-    assert.equal(calls.length, 1);
-    assert.equal(calls[0].url, "oms/shopifyShops/SHOP_10000/productSync/imports");
-    assert.equal(calls[0].method, "post");
-    assert.equal(calls[0].data.systemMessageRemoteId, "SMR_REAL_SHOP");
-    assert.equal(result.syncJobId, "SMSG_REAL_IMPORT");
-    assert.notEqual(result.syncJobId, "DUMMY_PRODUCT_SYNC_IMPORT");
-    assert.equal(result.progress?.status, "queued");
-    assert.equal(result.progress?.systemMessageState, "SmsgProduced");
-    assert.equal(result.progress?.completed, false);
-    assert.equal(result.backendAvailable, true);
-  });
-
-  test("startInitialImport rejects when the backend start call fails", async () => {
-    const { api } = createRejectingApi();
-    const service = await loadService(api);
-
-    await assert.rejects(() => service.startInitialImport({
-      shopId: "SHOP_10000",
-      productStoreId: "STORE_A",
-      productIdentifierEnumId: "SHOPIFY_PRODUCT_SKU",
-      systemMessageRemoteId: "SMR_REAL_SHOP"
-    }));
-  });
-
-  test("startInitialImport rejects before calling backend without systemMessageRemoteId", async () => {
-    const { api, calls } = createRejectingApi();
-    const service = await loadService(api);
-
-    await assert.rejects(() => service.startInitialImport({
-      shopId: "SHOP_10000",
-      productStoreId: "STORE_A",
-      productIdentifierEnumId: "SHOPIFY_PRODUCT_SKU"
-    }));
-    assert.equal(calls.length, 0);
-  });
-
+describe("shopify product sync service", () => {
   test("fetchSetupState derives returning user state from real product update history", async () => {
     const calls: ApiCall[] = [];
     const service = await loadService(async (request: ApiCall) => {
@@ -128,7 +66,6 @@ describe("shopify product sync service failure behavior", () => {
 
     assert.equal(calls.length, 1);
     assert.equal(calls[0].url, "oms/productUpdateHistory");
-    assert.equal(calls[0].url?.includes("productSync/setup"), false);
     assert.equal(calls[0].params.shopId, "SHOP_10000");
     assert.equal(calls[0].params.pageSize, 1);
     assert.equal(result.hasLinkedOmsProducts, true);
@@ -136,8 +73,6 @@ describe("shopify product sync service failure behavior", () => {
     assert.equal(result.identifierLocked, true);
     assert.equal(result.selectedProductStoreId, "STORE_A");
     assert.equal(result.selectedIdentifierEnumId, "SHOPIFY_PRODUCT_SKU");
-    assert.equal(typeof result.syncJobId, "undefined");
-    assert.equal(typeof result.completed, "undefined");
   });
 
   test("fetchSetupState returns first-time state only when product update history is really empty", async () => {
@@ -203,43 +138,125 @@ describe("shopify product sync service failure behavior", () => {
     assert.equal(calls.length, 0);
   });
 
-  test("setup, preflight, progress, reconcile, and history reject backend failures", async () => {
-    const failureCases = [
-      {
-        method: "fetchSetupState",
-        payload: { shopId: "SHOP_10000" }
-      },
-      {
-        method: "fetchPreflight",
-        payload: {
-          shopId: "SHOP_10000",
-          productStoreId: "STORE_A",
-          productIdentifierEnumId: "SHOPIFY_PRODUCT_SKU"
+  test("fetchShopifyShopProductCount reuses provided sync run state", async () => {
+    const calls: ApiCall[] = [];
+    const service = await loadService(async (request: ApiCall) => {
+      calls.push(request);
+      return {
+        data: {
+          response: {
+            productsCount: {
+              count: 12
+            }
+          }
         }
-      },
-      {
-        method: "fetchProgress",
-        payload: { shopId: "SHOP_10000", syncJobId: "SMSG_REAL_IMPORT" }
-      },
-      {
-        method: "fetchReconcile",
-        payload: { shopId: "SHOP_10000", productStoreId: "STORE_A", syncJobId: "SMSG_REAL_IMPORT" }
-      },
-      {
-        method: "fetchHistory",
-        payload: { shopId: "SHOP_10000" }
+      };
+    });
+
+    const result = await service.fetchShopifyShopProductCount({
+      systemMessageRemoteId: "SMR_10000",
+      syncRunState: {
+        lastSyncedAt: "2026-05-02T00:00:00Z"
       }
-    ];
+    });
 
-    for (const failureCase of failureCases) {
-      const { api } = createRejectingApi();
-      const service = await loadService(api);
+    assert.equal(result.count, 12);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, "shopify/graphql");
+    assert.equal(calls.some((call) => call.url === "admin/systemMessages"), false);
+    assert.equal(String(calls[0].data.queryText).includes("updated_at:>'2026-05-02T00:00:00Z'"), true);
+  });
 
-      await assert.rejects(
-        () => service[failureCase.method](failureCase.payload),
-        undefined,
-        `${failureCase.method} should reject instead of returning fallback data`
-      );
-    }
+  test("fetchDashboardSummary returns shared sync state and unsynced count without reloading system messages", async () => {
+    const calls: ApiCall[] = [];
+    const service = await loadService(async (request: ApiCall) => {
+      calls.push(request);
+
+      if (request.url === "oms/dataDocumentView" && request.data?.customParametersMap?.statusId === "SmsgProduced") {
+        return {
+          data: {
+            entityValueList: [
+              {
+                systemMessageId: "SMSG_PENDING",
+                statusId: "SmsgProduced",
+                initDate: "2026-05-02T12:00:00Z"
+              }
+            ],
+            entityValueListCount: 1
+          }
+        };
+      }
+
+      if (request.url === "oms/dataDocumentView" && request.data?.dataDocumentId === "SYSTEM_MESSAGE_DATA_MANAGER_LOG") {
+        return {
+          data: {
+            entityValueList: [
+              {
+                systemMessageId: "SMSG_CONFIRMED",
+                statusId: "SmsgConfirmed",
+                initDate: "2026-05-02T10:00:00Z",
+                processedDate: "2026-05-02T10:05:00Z",
+                logId: "LOG_1"
+              },
+              {
+                systemMessageId: "SMSG_PRODUCED",
+                statusId: "SmsgProduced",
+                initDate: "2026-05-02T11:00:00Z"
+              }
+            ],
+            entityValueListCount: 2
+          }
+        };
+      }
+
+      if (request.url === "shopify/graphql" && String(request.data?.queryText).includes("bulkOperations(first: 1")) {
+        return {
+          data: {
+            response: {
+              bulkOperations: {
+                nodes: [
+                  {
+                    id: "gid://shopify/BulkOperation/1",
+                    status: "RUNNING",
+                    type: "QUERY",
+                    createdAt: "2026-05-02T12:05:00Z",
+                    objectCount: "42"
+                  }
+                ]
+              }
+            }
+          }
+        };
+      }
+
+      if (request.url === "shopify/graphql" && String(request.data?.queryText).includes("productsCount")) {
+        return {
+          data: {
+            response: {
+              productsCount: {
+                count: 7
+              }
+            }
+          }
+        };
+      }
+
+      throw new Error(`Unexpected request: ${JSON.stringify(request)}`);
+    });
+
+    const summary = await service.fetchDashboardSummary({
+      shopId: "SHOP_10000",
+      systemMessageRemoteId: "SMR_10000",
+      shop: {
+        shopId: "SHOP_10000"
+      }
+    });
+
+    assert.equal(summary.syncRunState.lastSyncedAt, "2026-05-02T10:00:00.000Z");
+    assert.equal(summary.pendingRequests.count, 1);
+    assert.equal(summary.runningOperation?.id, "gid://shopify/BulkOperation/1");
+    assert.equal(summary.unsyncedUpdates.count, 7);
+    assert.equal(calls.filter((call) => call.url === "oms/dataDocumentView").length, 2);
+    assert.equal(calls.filter((call) => call.url === "shopify/graphql").length, 2);
   });
 });

--- a/tests/unit/shopify-product-sync.test.ts
+++ b/tests/unit/shopify-product-sync.test.ts
@@ -1,0 +1,41 @@
+
+import assert from "assert";
+import {
+  selectTrackProgressSystemMessage,
+  selectMostRecentSystemMessage,
+  SystemMessage
+} from "../../src/utils/shopifyProductSync";
+
+describe("Shopify Product Sync Selection Utilities", () => {
+  const messages: SystemMessage[] = [
+    { systemMessageId: "MSG1", statusId: "SmsgConsumed", initDate: "2026-05-01T10:00:00Z" },
+    { systemMessageId: "MSG2", statusId: "SmsgProduced", initDate: "2026-05-02T10:00:00Z" },
+    { systemMessageId: "MSG3", statusId: "SmsgReceived", initDate: "2026-05-02T11:00:00Z" }
+  ];
+
+  test("selectTrackProgressSystemMessage picks the oldest pending message with precedence", () => {
+    const selected = selectTrackProgressSystemMessage(messages);
+    // MSG3 is Received, MSG2 is Produced. Received takes precedence over Produced.
+    assert.strictEqual(selected?.systemMessageId, "MSG3");
+  });
+
+  test("selectMostRecentSystemMessage picks the absolute latest message", () => {
+    const selected = selectMostRecentSystemMessage(messages);
+    // MSG3 is the latest by date (11:00)
+    assert.strictEqual(selected?.systemMessageId, "MSG3");
+  });
+
+  test("selectMostRecentSystemMessage picks newest even if all are consumed", () => {
+    const allConsumed: SystemMessage[] = [
+      { systemMessageId: "OLD", statusId: "SmsgConsumed", initDate: "2026-05-01T10:00:00Z" },
+      { systemMessageId: "NEW", statusId: "SmsgConsumed", initDate: "2026-05-02T10:00:00Z" }
+    ];
+    const selected = selectMostRecentSystemMessage(allConsumed);
+    assert.strictEqual(selected?.systemMessageId, "NEW");
+  });
+
+  test("returns null for empty list", () => {
+    assert.strictEqual(selectTrackProgressSystemMessage([]), null);
+    assert.strictEqual(selectMostRecentSystemMessage([]), null);
+  });
+});


### PR DESCRIPTION
## Business summary
PR 97 improved product sync dashboard loading and system message resolution. This follow-up restores the migration-entry and progress flow on top of that merged branch state so store teams can use the newer product sync experience without losing the optimization work already accepted.

## What this changes
- reapplies the product sync migration flow on top of the merged PR 97 base
- keeps the PR 97 dashboard-summary and loading optimizations intact
- updates tests to validate the post-merge behavior and guard against regressions

## Verification
- `npm run test:unit`
- `npm run build`

Closes #98