### PR TITLE
[codex] Add live dashboard refresh for product sync

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,3 +3,4 @@
 - [Shopify Product Sync First-Time Wizard](./shopify-product-sync-first-time-wizard.md)
 - [Shopify Product Sync App-to-Shopify API Calls](./shopify-product-sync-shopify-api-calls.md)
 - [Shopify Product Sync Migration Scope](./shopify-product-sync-migration-scope.md)
+- [Shopify Product Sync Live Dashboard](./shopify-product-sync-live-dashboard.md)

--- a/docs/shopify-product-sync-live-dashboard.md
+++ b/docs/shopify-product-sync-live-dashboard.md
@@ -1,0 +1,89 @@
+# Shopify Product Sync — Live Dashboard
+
+This document describes the intended behavior of the Shopify Product Sync page (`/shopify-connection-details/:shopId/product-sync`) as a live, dashboard-feel surface. It supersedes the ad-hoc auto-refresh logic currently in [`src/views/ShopifyProductSync.vue`](../src/views/ShopifyProductSync.vue) (`progressPoll`, `nextSyncRefreshPoll`, `refreshScheduledJobStateIfNeeded`), which will be refactored to match this spec.
+
+## 1. Goal & principles
+
+The page should feel like a live dashboard: data arrives in place, the UI never blanks out on refresh, and nothing visibly "reloads".
+
+- **Zero layout shift.** Containers reserve space; no element collapses or jumps when stale data is replaced with fresh data.
+- **No skeletons or spinners on refresh.** Once a section has rendered real data at least once, it never shows a skeleton or spinner again for the rest of the session. Cold start is the exception — see §4a.
+- **Organic transitions.** Numbers tween (count-up/down), lists FLIP, badges fade between states.
+- **Refresh cadence is driven by what the data is**, not a single global interval.
+
+## 2. Data tiers
+
+Each tier has its own cadence and refresh strategy.
+
+| Tier | Examples | Refresh strategy |
+| --- | --- | --- |
+| Always-live | In-flight run progress, current step, next-run countdown | Short tick (5s) while a run is active; tick is paused when nothing is running. |
+| Event-driven | Product update history, MDM error logs, recent sync runs | Refetched when a tier-1 signal changes (run started, run ended, new activity detected by the probe in §3). |
+| Slow-moving | Shop config, system message types, webhook subscriptions | Fetched on mount; refreshed only on user action or a major event (e.g. webhook toggle). |
+
+## 3. Refresh triggers
+
+Replaces the single 15s `nextSyncRefreshPoll` interval with a layered set of triggers:
+
+- **Time-based.** Short tick (5s) only while a run is active. Long tick (60s) drives the "next run in X min" countdown labels. No tick when nothing is happening.
+- **Scheduled-run boundary.** When a tracked job's `nextRunTime` passes, kick a single refresh and open a short grace window (~2 min) to catch backend lag.
+- **Activity probe.** A lightweight `serviceJobRuns?pageSize=1` poll detects new `startTime`/`endTime` on the sync job. Only when a change is observed do we trigger a heavier tier-2 refetch.
+- **User intent.** Page visibility change (tab refocus), manual refresh button, action completion (e.g. "run now", webhook toggle).
+
+Tracked jobs are the dedup'd set of: `syncJob`, `bulkOperationSendJob`, `bulkOperationPollJob`, and any currently-open job-details job. Paused jobs are excluded.
+
+## 4. UI mechanics — the "feel" rules
+
+These apply once data has been loaded at least once.
+
+- **Counts and durations** use a `useAnimatedNumber` composable that rAF-tweens from old → new value (~400ms ease-out). This covers totals, success counts, failed-record counts, elapsed/remaining time.
+- **Lists** use `<transition-group name="list">` with FLIP. New items enter from the top, removed items fade out, position changes animate. The "Recently synced product updates" and "Parsed error details" sections are the primary consumers.
+- **Cards** have a fixed `min-height` matching their populated layout, so transitioning from empty → filled never reflows surrounding sections.
+- **Stale data stays visible during a refresh.** A subtle section-level indicator (thin progress line on the section header) signals that work is in progress, but the content itself is never replaced with a loader.
+- **Empty states are first-class cards** — an intentional icon + short copy + optional CTA, sized to roughly match a populated card. They are not "No data" filler.
+- **Badges and status pills** fade between states rather than hard-swapping.
+
+### 4a. Cold start (no prior data)
+
+The "no skeletons or spinners" rule applies to refreshes, not to first paint. On cold start the user *should* see what's loading.
+
+- View-enter renders each section with a **skeleton** (for lists) or **spinner** (for single values), sized to match the populated layout so the swap to real data is in-place — not a reflow.
+- Skeletons/spinners are **per section**, not page-wide. Sections fill in independently as their fetches resolve.
+- Once a section has rendered real data once in the session, it flips into stale-while-revalidate mode and never shows a skeleton or spinner again — future refreshes keep the last-known-good data visible and update in place.
+- Last-known-good data per tier is persisted in composable state, so navigating away and back skips cold-start skeletons.
+
+## 5. State model
+
+Each tier exposes a uniform shape:
+
+```ts
+{
+  data: T,
+  lastFetchedAt: number | null,
+  isFetching: boolean,
+  hasEverLoaded: boolean,
+}
+```
+
+- The UI binds to `data` for rendering.
+- `hasEverLoaded` selects the render mode:
+  - `false` → skeleton (list) or spinner (single value).
+  - `true` → render `data` with live transitions; `isFetching` drives only the section-level subtle indicator, never replaces content.
+- `lastFetchedAt` and `isFetching` are surfaced for debugging and for the activity probe to decide whether a tier needs a refresh.
+
+A single `useLiveDashboard` composable owns the tickers (§3) and exposes per-tier refs to the view. Views never own intervals directly.
+
+## 6. What's being replaced
+
+Pointers to the current implementation in [`src/views/ShopifyProductSync.vue`](../src/views/ShopifyProductSync.vue), for reference during the refactor:
+
+- `progressPoll` (5s `setInterval` around `loadProgress`) — kept conceptually, but gated to active runs only via the tier-1 ticker.
+- `nextSyncRefreshPoll` (15s `setInterval` + `refreshScheduledJobStateIfNeeded` heuristic) — replaced by the layered triggers in §3.
+- `isSecondaryLoading` skeleton paths inside `ShopifyProductSyncReturningView.vue` — kept for cold start, removed from refresh paths.
+- Inline `isScheduledJobRefreshInFlight`, `lastKnownJobRunStartTime`, `lastKnownJobRunEndTime`, `scheduledJobRefreshAtMs`, `scheduledJobRefreshGraceUntilMs` module-level state — moved into the composable.
+
+## 7. Non-goals
+
+- **Real-time push (SSE/websockets).** Out of scope for v1; polling-only.
+- **Changing list ordering semantics.** Order rules don't change — only the transition between states.
+- **Cross-page live updates.** Scope is the Product Sync page only; other pages keep their existing fetch-on-enter behavior.

--- a/src/components/ShopifyProductSyncReturningView.vue
+++ b/src/components/ShopifyProductSyncReturningView.vue
@@ -83,7 +83,31 @@
             </ion-label>
             <ion-badge slot="end" :color="currentSyncRun.systemMessage?.statusColor || 'medium'">{{ currentSyncRun.systemMessage?.statusLabel || translate("Pending") }}</ion-badge>
           </ion-item>
-          <ion-item v-if="systemMessageFsmState.nextJob || systemMessageFsmState.primaryAction || systemMessageFsmState.secondaryActions.length" lines="none">
+          <ion-item v-if="hasNextStepBar" lines="none">
+            <ion-progress-bar :value="nextStepProgressValue" />
+            <ion-buttons slot="end">
+              <ion-button
+                v-if="systemMessageFsmState.primaryAction"
+                :disabled="!!systemMessageActionLoadingId"
+                @click="emit('run-system-message-action', systemMessageFsmState.primaryAction.id)"
+              >
+                <ion-spinner v-if="systemMessageActionLoadingId === systemMessageFsmState.primaryAction.id" name="crescent" />
+                <template v-else>{{ systemMessageFsmState.primaryAction.label }}</template>
+              </ion-button>
+              <ion-button
+                v-for="action in systemMessageFsmState.secondaryActions"
+                :key="action.id"
+                fill="clear"
+                color="medium"
+                :disabled="!!systemMessageActionLoadingId"
+                @click="emit('run-system-message-action', action.id)"
+              >
+                <ion-spinner v-if="systemMessageActionLoadingId === action.id" name="crescent" />
+                <span v-else>{{ action.label }}</span>
+              </ion-button>
+            </ion-buttons>
+          </ion-item>
+          <ion-item v-else-if="systemMessageFsmState.nextJob || systemMessageFsmState.primaryAction || systemMessageFsmState.secondaryActions.length" lines="none">
             <ion-label>
               {{ translate("Next step") }}
               <p>{{ systemMessageFsmState.nextJobReason }}</p>
@@ -277,6 +301,7 @@
   </section>
 
   <section class="sync-stat">
+    <ion-progress-bar v-if="isRefreshing" type="indeterminate" />
     <div class="stat-header">
       <ion-item class="stat-title" lines="none">
         <ion-label>
@@ -393,13 +418,13 @@
 
 
   <section class="sync-stat">
+    <ion-progress-bar v-if="isRefreshing || isErrorLogsLoading" type="indeterminate" />
     <div class="stat-header">
         <ion-item class="stat-title" lines="none">
           <ion-label>
             <h2>{{ translate("Parsed error details") }}</h2>
             <p>{{ failedRecords.length }} {{ translate("of") }} {{ totalDetailedErrorsCount }} {{ translate("failed objects") }}</p>
           </ion-label>
-          <ion-spinner v-if="isErrorLogsLoading" name="crescent" class="ion-margin-start" />
         </ion-item>
       <ion-buttons slot="end" v-if="hasDetailedErrors">
         <ion-button color="medium" @click="emit('refresh-errors')">
@@ -408,42 +433,41 @@
       </ion-buttons>
       <ion-searchbar :value="detailedErrorQuery" @ionInput="emit('update:detailed-error-query', $event.detail.value)" :placeholder="translate('Search by ID, Name or Handle')" />
     </div>
-    <div class="stat-data" v-if="failedRecords.length">
-      <ion-card v-for="record in failedRecords" :key="record.id">
-        <ion-item lines="full">
-          <ion-label class="ion-text-wrap">
-            <h3>{{ record.title }}</h3>
-            <p v-if="record.handle">{{ record.handle }}</p>
-          </ion-label>
-        </ion-item>
-        <ion-card-content>
-          <p class="ion-no-margin">
-            <strong>{{ translate("Product ID") }}:</strong> {{ record.numericId || 'N/A' }}
-          </p>
-          <p class="ion-no-margin ion-margin-top">
-            {{ record.error }}
-          </p>
-          <div class="ion-margin-top">
-            <ion-button fill="clear" size="small" class="ion-no-padding" @click="emit('show-error-modal', record)">
-              {{ translate("View details") }}
-            </ion-button>
-            <ion-button fill="clear" size="small" color="primary" @click="emit('resync-product', record)">
-              {{ translate("Retry") }}
-            </ion-button>
-          </div>
-        </ion-card-content>
-      </ion-card>
-      
-      </div>
-    <div class="stat-data" v-else>
-      <ion-card>
-        <ion-item lines="none">
-          <ion-label class="ion-text-center">
-            <p v-if="detailedErrorQuery">{{ translate("No records match your search.") }}</p>
-            <p v-else>{{ translate("All caught up! No recent errors found.") }}</p>
-          </ion-label>
-        </ion-item>
-      </ion-card>
+    <div class="stat-data">
+      <transition-group name="list" tag="div" class="list-transition-group">
+        <ion-card v-for="record in failedRecords" :key="record.id">
+          <ion-item lines="full">
+            <ion-label class="ion-text-wrap">
+              <h3>{{ record.title }}</h3>
+              <p v-if="record.handle">{{ record.handle }}</p>
+            </ion-label>
+          </ion-item>
+          <ion-card-content>
+            <p class="ion-no-margin">
+              <strong>{{ translate("Product ID") }}:</strong> {{ record.numericId || 'N/A' }}
+            </p>
+            <p class="ion-no-margin ion-margin-top">
+              {{ record.error }}
+            </p>
+            <div class="ion-margin-top">
+              <ion-button fill="clear" size="small" class="ion-no-padding" @click="emit('show-error-modal', record)">
+                {{ translate("View details") }}
+              </ion-button>
+              <ion-button fill="clear" size="small" color="primary" @click="emit('resync-product', record)">
+                {{ translate("Retry") }}
+              </ion-button>
+            </div>
+          </ion-card-content>
+        </ion-card>
+        <ion-card v-if="!failedRecords.length" key="no-failed-records-card">
+          <ion-item lines="none">
+            <ion-label class="ion-text-center">
+              <p v-if="detailedErrorQuery">{{ translate("No records match your search.") }}</p>
+              <p v-else>{{ translate("All caught up! No recent errors found.") }}</p>
+            </ion-label>
+          </ion-item>
+        </ion-card>
+      </transition-group>
     </div>
   </section>
 
@@ -473,7 +497,7 @@ import {
   IonSpinner
 } from "@ionic/vue";
 import { translate } from "@/i18n";
-import { computed, defineEmits, defineProps, ref } from "vue";
+import { computed, defineEmits, defineProps, onBeforeUnmount, onMounted, ref } from "vue";
 import { checkmarkCircleOutline, ellipsisVerticalOutline, flashOutline, openOutline, pauseCircleOutline, refreshOutline, timeOutline } from "ionicons/icons";
 import { popoverController } from "@ionic/vue";
 import AnimatedNumber from "@/components/AnimatedNumber.vue";
@@ -530,6 +554,7 @@ const props = defineProps<{
   hasCurrentShopifyRequest?: boolean
   syncJobObj?: any
   isSecondaryLoading?: boolean
+  isRefreshing?: boolean
   isErrorLogsLoading?: boolean
   errorRecordCount: number | string
   failedRecords: Array<{ id: string, numericId?: string, logId?: string, title: string, vendor?: string, handle?: string, productType?: string, sku?: string, barcode?: string, error: string }>
@@ -572,6 +597,34 @@ async function openActionsPopover(event: Event) {
 
 const updatesQuery = ref("");
 const visibleChangeSummaryCount = 4;
+
+// Bar between now and the next scheduled run of the next-step job.
+// Driven by `nextStepNowMs` which ticks every 500ms while the component is mounted.
+const nextStepNowMs = ref(Date.now());
+let nextStepTickHandle: number | undefined;
+onMounted(() => {
+  nextStepTickHandle = window.setInterval(() => { nextStepNowMs.value = Date.now(); }, 500);
+});
+onBeforeUnmount(() => {
+  if (nextStepTickHandle) window.clearInterval(nextStepTickHandle);
+});
+
+const hasNextStepBar = computed(() => {
+  const job = props.systemMessageFsmState?.nextJob;
+  if (!job || job.paused) return false;
+  if (!job.nextRunAtMs || !job.previousRunAtMs) return false;
+  return job.nextRunAtMs > job.previousRunAtMs;
+});
+
+const nextStepProgressValue = computed(() => {
+  const job = props.systemMessageFsmState?.nextJob;
+  if (!job?.nextRunAtMs || !job?.previousRunAtMs) return 0;
+  const total = job.nextRunAtMs - job.previousRunAtMs;
+  if (total <= 0) return 0;
+  const remaining = job.nextRunAtMs - nextStepNowMs.value;
+  if (remaining <= 0) return 0;
+  return Math.min(1, Math.max(0, remaining / total));
+});
 
 function getDetailActionLabel(type: string) {
   return type === "added" ? translate("Added") : translate("Removed");
@@ -727,4 +780,5 @@ ion-buttons {
 .list-move {
   transition: transform 0.5s ease;
 }
+
 </style>

--- a/src/composables/useLiveDashboard.ts
+++ b/src/composables/useLiveDashboard.ts
@@ -1,0 +1,100 @@
+import { onBeforeUnmount, ref } from "vue";
+import logger from "@/logger";
+
+export interface LiveDashboardOptions {
+  /** How often the tick callback fires while the dashboard is active. Defaults to 15s. */
+  tickIntervalMs?: number;
+  /** Fires on every tick. Receives the current epoch ms used by the view for relative-time labels. */
+  onTick?: (ctx: { currentTimeMs: number }) => void | Promise<void>;
+  /** Fires when the tab becomes visible again. Use to trigger an immediate refresh. */
+  onVisible?: () => void | Promise<void>;
+}
+
+/**
+ * Owns the timing + in-flight guard for a live, dashboard-feel page.
+ *
+ * - Drives a single `currentTimeMs` ref the view binds to for relative-time labels.
+ * - Calls `onTick` on each interval so the view can decide whether a refresh is needed.
+ * - Calls `onVisible` when the tab regains focus.
+ * - Exposes `runRefresh()` which guards against overlapping refreshes.
+ *
+ * The view supplies the trigger logic (e.g. scheduled-run boundary, activity probe) inside `onTick`
+ * and calls `runRefresh(loadFn)` to perform the work — this composable does not own the data tiers.
+ */
+export function useLiveDashboard(options: LiveDashboardOptions = {}) {
+  const tickIntervalMs = options.tickIntervalMs ?? 15000;
+  const currentTimeMs = ref(Date.now());
+  const isRefreshInFlight = ref(false);
+
+  let tickHandle: number | undefined;
+  let visibilityListener: (() => void) | null = null;
+  let stopped = true;
+
+  async function fireTick() {
+    currentTimeMs.value = Date.now();
+    try {
+      await options.onTick?.({ currentTimeMs: currentTimeMs.value });
+    } catch (err) {
+      logger.error("useLiveDashboard onTick failed", err);
+    }
+  }
+
+  function start() {
+    stop();
+    stopped = false;
+    currentTimeMs.value = Date.now();
+    tickHandle = window.setInterval(() => { void fireTick(); }, tickIntervalMs);
+
+    if (typeof document !== "undefined") {
+      visibilityListener = () => {
+        if (stopped) return;
+        if (document.visibilityState === "visible") {
+          currentTimeMs.value = Date.now();
+          try {
+            const result = options.onVisible?.();
+            if (result && typeof (result as Promise<void>).catch === "function") {
+              (result as Promise<void>).catch((err) => logger.error("useLiveDashboard onVisible failed", err));
+            }
+          } catch (err) {
+            logger.error("useLiveDashboard onVisible failed", err);
+          }
+        }
+      };
+      document.addEventListener("visibilitychange", visibilityListener);
+    }
+  }
+
+  function stop() {
+    stopped = true;
+    if (tickHandle) {
+      window.clearInterval(tickHandle);
+      tickHandle = undefined;
+    }
+    if (visibilityListener) {
+      document.removeEventListener("visibilitychange", visibilityListener);
+      visibilityListener = null;
+    }
+  }
+
+  /** Guarded refresh — drops the call if another refresh is already in flight. */
+  async function runRefresh(refresh: () => Promise<void>) {
+    if (isRefreshInFlight.value) return false;
+    isRefreshInFlight.value = true;
+    try {
+      await refresh();
+      return true;
+    } finally {
+      isRefreshInFlight.value = false;
+    }
+  }
+
+  onBeforeUnmount(() => stop());
+
+  return {
+    currentTimeMs,
+    isRefreshInFlight,
+    start,
+    stop,
+    runRefresh,
+  };
+}

--- a/src/utils/shopifyProductSyncFsm.ts
+++ b/src/utils/shopifyProductSyncFsm.ts
@@ -14,6 +14,10 @@ export interface ProductSyncFsmNextJob {
   nextRunLabel: string;
   relativeNextRunLabel: string;
   paused: boolean;
+  /** Epoch ms of the next scheduled run, if known. Drives the depleting progress bar. */
+  nextRunAtMs: number | null;
+  /** Epoch ms of the previous run (or previous cron firing), used as the bar's start point. */
+  previousRunAtMs: number | null;
 }
 
 export interface ProductSyncFsmState {
@@ -32,8 +36,12 @@ interface ProductSyncFsmInput {
   pollJob?: any;
   sendJobNextRunLabel?: string;
   sendJobRelativeNextRunLabel?: string;
+  sendJobNextRunAtMs?: number | null;
+  sendJobPreviousRunAtMs?: number | null;
   pollJobNextRunLabel?: string;
   pollJobRelativeNextRunLabel?: string;
+  pollJobNextRunAtMs?: number | null;
+  pollJobPreviousRunAtMs?: number | null;
   isSendJobPaused?: boolean;
   isPollJobPaused?: boolean;
 }
@@ -42,7 +50,15 @@ function normalizeStatusId(statusId = "") {
   return String(statusId || "").trim();
 }
 
-function buildNextJob(job: any, label: string, nextRunLabel: string, relativeNextRunLabel: string, paused: boolean): ProductSyncFsmNextJob | null {
+function buildNextJob(
+  job: any,
+  label: string,
+  nextRunLabel: string,
+  relativeNextRunLabel: string,
+  paused: boolean,
+  nextRunAtMs: number | null = null,
+  previousRunAtMs: number | null = null
+): ProductSyncFsmNextJob | null {
   if (!job?.jobName) return null;
 
   return {
@@ -50,7 +66,9 @@ function buildNextJob(job: any, label: string, nextRunLabel: string, relativeNex
     label,
     nextRunLabel: nextRunLabel || translate("Not scheduled"),
     relativeNextRunLabel: relativeNextRunLabel || "",
-    paused
+    paused,
+    nextRunAtMs,
+    previousRunAtMs
   };
 }
 
@@ -72,7 +90,9 @@ export function getProductSyncFsmState(input: ProductSyncFsmInput): ProductSyncF
           translate("Send update request"),
           input.sendJobNextRunLabel || "",
           input.sendJobRelativeNextRunLabel || "",
-          !!input.isSendJobPaused
+          !!input.isSendJobPaused,
+          input.sendJobNextRunAtMs ?? null,
+          input.sendJobPreviousRunAtMs ?? null
         ),
         nextJobReason: translate("The next logical step is to send the produced bulk query to Shopify.")
       };
@@ -88,7 +108,9 @@ export function getProductSyncFsmState(input: ProductSyncFsmInput): ProductSyncF
           translate("Import completed requests"),
           input.pollJobNextRunLabel || "",
           input.pollJobRelativeNextRunLabel || "",
-          !!input.isPollJobPaused
+          !!input.isPollJobPaused,
+          input.pollJobNextRunAtMs ?? null,
+          input.pollJobPreviousRunAtMs ?? null
         ),
         nextJobReason: translate("The next logical step is to check whether Shopify finished the bulk operation.")
       };

--- a/src/views/ShopifyProductSync.vue
+++ b/src/views/ShopifyProductSync.vue
@@ -36,6 +36,7 @@
         <shopify-product-sync-returning-view
           v-if="activeExperienceMode === 'returning'"
           :is-secondary-loading="isSecondaryLoading"
+          :is-refreshing="isRefreshInFlight"
           :is-sync-scheduled="isSyncScheduled"
           :is-sync-paused="isSyncJobPaused"
           :last-sync-label="lastSyncLabel"
@@ -770,6 +771,7 @@ import { downloadTextFile, formatDateTime, getDownloadFileContent, hasError, par
 import logger from "@/logger";
 import useServiceJob from "@/composables/useServiceJob";
 import { useDataManagerLog } from "@/composables/useDataManagerLog";
+import { useLiveDashboard } from "@/composables/useLiveDashboard";
 import { useProductUpdateHistory } from "@/composables/useProductUpdateHistory";
 import { useShopifyProductSyncRun } from "@/composables/useShopifyProductSyncRun";
 import { getSystemMessageBulkOperationId } from "@/utils/shopifyBulkOperation";
@@ -801,9 +803,9 @@ const latestSystemMessage = ref<any>(null);
 const latestConfirmedSystemMessage = ref<any>(null);
 const latestConsumedSystemMessage = ref<any>(null);
 const lastProductUpdateSyncedAt = ref("");
-const currentTimeMs = ref(Date.now());
 const isLoading = ref(true);
 const isSecondaryLoading = ref(false);
+const hasEverLoadedSecondary = ref(false);
 const loadErrorMessage = ref("");
 const isSaving = ref(false);
 const isReviewLoading = ref(false);
@@ -904,10 +906,17 @@ const webhookSubscriptions = ref<any[]>([]);
 const isWebhookLoading = ref(false);
 const isWebhookSupported = ref(false);
 let progressPoll: number | undefined;
-let nextSyncRefreshPoll: number | undefined;
 let scheduledJobRefreshAtMs: number | null = null;
 let scheduledJobRefreshGraceUntilMs: number | null = null;
-let isScheduledJobRefreshInFlight = false;
+let lastKnownJobRunStartTime = 0;
+let lastKnownJobRunEndTime = 0;
+
+const liveDashboard = useLiveDashboard({
+  tickIntervalMs: 15000,
+  onTick: () => evaluateScheduledRefresh(),
+  onVisible: () => evaluateScheduledRefresh({ forceProbe: true })
+});
+const { currentTimeMs, isRefreshInFlight } = liveDashboard;
 
 const shop = computed(() => store.getters["shopify/getShopById"](props.id) || {});
 const userProfile = computed(() => store.getters["user/getUserProfile"] || {});
@@ -1099,11 +1108,23 @@ const systemMessageSendJobNextRunLabel = computed(() => {
 const systemMessageSendJobRelativeNextRunLabel = computed(() => {
   return getRelativeNextRunLabel(bulkOperationSendJob.value);
 });
+const systemMessageSendJobNextRunAtMs = computed(() => {
+  return getNextRunMillis(bulkOperationSendJob.value);
+});
+const systemMessageSendJobPreviousRunAtMs = computed(() => {
+  return getJobLatestRunMillis(bulkOperationSendJobRecentRuns.value);
+});
 const bulkOperationPollJobNextRunLabel = computed(() => {
   return getJobNextRunLabel(bulkOperationPollJob.value);
 });
 const bulkOperationPollJobRelativeNextRunLabel = computed(() => {
   return getRelativeNextRunLabel(bulkOperationPollJob.value);
+});
+const bulkOperationPollJobNextRunAtMs = computed(() => {
+  return getNextRunMillis(bulkOperationPollJob.value);
+});
+const bulkOperationPollJobPreviousRunAtMs = computed(() => {
+  return getJobLatestRunMillis(bulkOperationPollJobRecentRuns.value);
 });
 const systemMessageFsmState = computed(() => {
   return getProductSyncFsmState({
@@ -1113,8 +1134,12 @@ const systemMessageFsmState = computed(() => {
     pollJob: bulkOperationPollJob.value,
     sendJobNextRunLabel: systemMessageSendJobNextRunLabel.value,
     sendJobRelativeNextRunLabel: systemMessageSendJobRelativeNextRunLabel.value,
+    sendJobNextRunAtMs: systemMessageSendJobNextRunAtMs.value,
+    sendJobPreviousRunAtMs: systemMessageSendJobPreviousRunAtMs.value,
     pollJobNextRunLabel: bulkOperationPollJobNextRunLabel.value,
     pollJobRelativeNextRunLabel: bulkOperationPollJobRelativeNextRunLabel.value,
+    pollJobNextRunAtMs: bulkOperationPollJobNextRunAtMs.value,
+    pollJobPreviousRunAtMs: bulkOperationPollJobPreviousRunAtMs.value,
     isSendJobPaused: isBulkOperationSendJobPaused.value,
     isPollJobPaused: isBulkOperationPollJobPaused.value
   });
@@ -1708,8 +1733,14 @@ async function loadWizard() {
   }
 }
 
-async function loadSecondaryData() {
-  isSecondaryLoading.value = true;
+async function loadSecondaryData(opts: { silent?: boolean } = {}) {
+  // On cold start we surface skeletons via isSecondaryLoading. Every subsequent
+  // refresh keeps the last-known-good data visible — the subtle indicator driven
+  // by liveDashboard.isRefreshInFlight is the only loading affordance.
+  const isColdStart = !hasEverLoadedSecondary.value;
+  if (isColdStart && !opts.silent) {
+    isSecondaryLoading.value = true;
+  }
   latestPauseAuditByJobName.value = {};
   try {
     const summary = await ShopifyProductSyncService.fetchDashboardSummary({
@@ -1777,6 +1808,7 @@ async function loadSecondaryData() {
     logger.error("Error loading secondary data", error);
   } finally {
     isSecondaryLoading.value = false;
+    hasEverLoadedSecondary.value = true;
     updateScheduledJobRefreshAt();
   }
 }
@@ -2235,7 +2267,7 @@ async function refreshAfterRunNow(job: any) {
   const refreshTasks = [loadSyncJobLatestRun()];
 
   if (activeExperienceMode.value === "returning") {
-    refreshTasks.push(loadSecondaryData());
+    refreshTasks.push(loadSecondaryData({ silent: true }));
   }
 
   if (!syncJobDetailsDirty.value && selectedSyncJobDetailsJob.value?.jobName === job?.jobName) {
@@ -2823,7 +2855,7 @@ async function refreshAfterSystemMessageAction() {
   const refreshTasks: Promise<any>[] = [loadProgress()];
 
   if (activeExperienceMode.value === "returning") {
-    refreshTasks.push(loadSecondaryData());
+    refreshTasks.push(loadSecondaryData({ silent: true }));
   }
 
   await Promise.all(refreshTasks);
@@ -2832,43 +2864,34 @@ async function refreshAfterSystemMessageAction() {
 async function runSystemMessageAction(actionId: ProductSyncFsmActionId) {
   if (systemMessageActionLoadingId.value) return;
 
+  // Send / Poll route through the same run-now flow as the job modal so the
+  // backend cron job is what produces or polls — not a direct service call.
+  if (actionId === "send") {
+    await runSyncJob(bulkOperationSendJob.value);
+    return;
+  }
+  if (actionId === "poll") {
+    await runSyncJob(bulkOperationPollJob.value);
+    return;
+  }
+
+  // Cancel is a system-message-level discard with no corresponding job.
   const systemMessageId = currentSyncRun.value?.systemMessageId || progressState.value?.systemMessageId;
-  if (!systemMessageId && actionId === "cancel") {
+  if (!systemMessageId) {
     showToast(translate("System message is not available."));
     return;
   }
 
-  if (actionId === "cancel") {
-    const confirmed = await confirmCancelSystemMessage();
-    if (!confirmed) return;
-  }
+  const confirmed = await confirmCancelSystemMessage();
+  if (!confirmed) return;
 
   systemMessageActionLoadingId.value = actionId;
   try {
-    if (actionId === "send") {
-      await ShopifyProductSyncService.sendShopifyBulkQueryMessage({
-        systemMessageRemoteId: selectedShopSystemMessageRemoteId.value,
-        queryText: currentSyncRun.value?.systemMessage?.messageText
-      });
-      showToast(translate("Product export request sent to Shopify."));
-    } else if (actionId === "poll") {
-      await ShopifyProductSyncService.pollBulkOperationResult({
-        parentSystemMessageTypeId: "ShopifyBulkQuery"
-      });
-      showToast(translate("Shopify bulk operation polled."));
-    } else if (actionId === "cancel") {
-      await ShopifyProductSyncService.cancelSystemMessage(systemMessageId);
-      showToast(translate("Product sync run cancelled."));
-    }
-
+    await ShopifyProductSyncService.cancelSystemMessage(systemMessageId);
+    showToast(translate("Product sync run cancelled."));
     await refreshAfterSystemMessageAction();
   } catch (err) {
-    const actionLabel = actionId === "send"
-      ? translate("send the product export request")
-      : actionId === "poll"
-        ? translate("poll the Shopify bulk operation")
-        : translate("cancel the product sync run");
-    showToast(getErrorMessage(err, translate("Failed to {actionLabel}.", { actionLabel })));
+    showToast(getErrorMessage(err, translate("Failed to {actionLabel}.", { actionLabel: translate("cancel the product sync run") })));
     logger.error(err);
   } finally {
     systemMessageActionLoadingId.value = "";
@@ -3046,20 +3069,12 @@ function stopProgressPolling() {
 }
 
 function startNextSyncRefreshPolling() {
-  stopNextSyncRefreshPolling();
-  currentTimeMs.value = Date.now();
   updateScheduledJobRefreshAt();
-  nextSyncRefreshPoll = window.setInterval(() => {
-    currentTimeMs.value = Date.now();
-    void refreshScheduledJobStateIfNeeded();
-  }, 15000);
+  liveDashboard.start();
 }
 
 function stopNextSyncRefreshPolling() {
-  if (nextSyncRefreshPoll) {
-    window.clearInterval(nextSyncRefreshPoll);
-    nextSyncRefreshPoll = undefined;
-  }
+  liveDashboard.stop();
   scheduledJobRefreshAtMs = null;
   scheduledJobRefreshGraceUntilMs = null;
 }
@@ -3088,10 +3103,9 @@ function updateScheduledJobRefreshAt() {
   }
 }
 
-let lastKnownJobRunStartTime = 0;
-let lastKnownJobRunEndTime = 0;
+async function evaluateScheduledRefresh(opts: { forceProbe?: boolean } = {}) {
+  if (isRefreshInFlight.value) return;
 
-async function refreshScheduledJobStateIfNeeded() {
   const shouldRefreshForScheduledRun = !!scheduledJobRefreshAtMs && currentTimeMs.value >= scheduledJobRefreshAtMs;
   const shouldRefreshDuringGraceWindow = !!scheduledJobRefreshGraceUntilMs && currentTimeMs.value <= scheduledJobRefreshGraceUntilMs;
 
@@ -3114,11 +3128,10 @@ async function refreshScheduledJobStateIfNeeded() {
         const latestRun = recentRuns[0];
         const runStartTime = latestRun.startTime ? new Date(latestRun.startTime).getTime() : 0;
         const runEndTime = latestRun.endTime ? new Date(latestRun.endTime).getTime() : 0;
-        
+
         let hasNewActivity = false;
 
         if (lastKnownJobRunStartTime === 0) {
-          // Initialize without triggering refresh
           lastKnownJobRunStartTime = runStartTime;
           lastKnownJobRunEndTime = runEndTime;
         } else {
@@ -3131,12 +3144,12 @@ async function refreshScheduledJobStateIfNeeded() {
             hasNewActivity = true;
           }
         }
-        
+
         if (hasNewActivity) {
           const infoMessage = latestRun.infoMessage || latestRun.errorMessages || latestRun.messages || "";
-          const hasNoActivity = infoMessage.includes("No bulk operation currently in progress") || 
+          const hasNoActivity = infoMessage.includes("No bulk operation currently in progress") ||
                                 infoMessage.includes("Aborting, no ShopifyBulkQuery Operation System Messages found to process");
-                                
+
           if (!hasNoActivity || !runEndTime) {
             needsRefresh = true;
           }
@@ -3147,30 +3160,31 @@ async function refreshScheduledJobStateIfNeeded() {
     }
   }
 
-  if (!needsRefresh || isScheduledJobRefreshInFlight) {
-    return;
+  // Tab-focus refresh: once we've loaded once in this session, returning to the tab kicks a refresh
+  // so the user sees fresh state without waiting for the next tick.
+  if (!needsRefresh && opts.forceProbe && hasEverLoadedSecondary.value) {
+    needsRefresh = true;
   }
 
-  isScheduledJobRefreshInFlight = true;
-  const scheduledRefreshAtMs = scheduledJobRefreshAtMs;
-  if (shouldRefreshForScheduledRun && scheduledRefreshAtMs) {
-    scheduledJobRefreshGraceUntilMs = scheduledRefreshAtMs + 2 * 60 * 1000;
+  if (!needsRefresh) return;
+
+  if (shouldRefreshForScheduledRun && scheduledJobRefreshAtMs) {
+    scheduledJobRefreshGraceUntilMs = scheduledJobRefreshAtMs + 2 * 60 * 1000;
   }
   scheduledJobRefreshAtMs = null;
-  try {
-    if (activeExperienceMode.value === "returning" && !isLoading.value) {
-      await loadSecondaryData();
-    }
 
+  await liveDashboard.runRefresh(async () => {
+    if (activeExperienceMode.value === "returning" && !isLoading.value) {
+      await loadSecondaryData({ silent: true });
+    }
     if (showSyncJobDetailsModal.value && selectedSyncJobDetailsJob.value?.jobName && !syncJobDetailsDirty.value) {
       await refreshSyncJobDetails();
     }
-  } finally {
-    isScheduledJobRefreshInFlight = false;
-    updateScheduledJobRefreshAt();
-    if (!scheduledJobRefreshAtMs && scheduledJobRefreshGraceUntilMs && currentTimeMs.value > scheduledJobRefreshGraceUntilMs) {
-      scheduledJobRefreshGraceUntilMs = null;
-    }
+  });
+
+  updateScheduledJobRefreshAt();
+  if (!scheduledJobRefreshAtMs && scheduledJobRefreshGraceUntilMs && currentTimeMs.value > scheduledJobRefreshGraceUntilMs) {
+    scheduledJobRefreshGraceUntilMs = null;
   }
 }
 
@@ -3212,6 +3226,20 @@ function getCronDescription(cronExpression: string) {
   } catch (error) {
     return "";
   }
+}
+
+function getNextRunMillis(job: any): number | null {
+  if (!job?.jobName || !job?.cronExpression || isJobPaused(job)) return null;
+  const nextRun = getNextRunDateTime(job);
+  return nextRun?.toMillis() ?? null;
+}
+
+function getJobLatestRunMillis(runs: any[]): number | null {
+  if (!runs?.length) return null;
+  const started = getSyncJobRunStartedAt(runs[0]);
+  if (!started) return null;
+  const parsed = parseDateTimeValue(started);
+  return parsed?.isValid ? parsed.toMillis() : null;
 }
 
 function getNextRunDateTime(job: any) {


### PR DESCRIPTION
## Business summary

Improves the Shopify Product Sync page for returning users by making it behave more like a live operations dashboard. The page keeps existing sync data visible during background refreshes, reacts to scheduled job boundaries, and gives users clearer next-step timing for send/poll jobs.

Closes #113.

## What changed

- Added `useLiveDashboard` to own dashboard ticking, visibility refreshes, and overlapping-refresh guards.
- Updated Shopify Product Sync secondary refreshes to use stale-while-refresh behavior after cold start.
- Routed send and poll next-step actions through the existing run-now job flow instead of direct system-message service calls.
- Extended the product-sync FSM with next/previous run timestamps for the UI progress affordance.
- Added docs for the intended Shopify Product Sync live dashboard behavior and linked them from the docs index.

## Validation

- `npm run lint -- --no-fix src/views/ShopifyProductSync.vue src/components/ShopifyProductSyncReturningView.vue src/utils/shopifyProductSyncFsm.ts src/composables/useLiveDashboard.ts`
- `npm run build`

Build completed with one existing warning in `src/views/KlaviyoConnectionDetails.vue` for unused `getStateLabel`.