### PR TITLE
Fix webhook‑subscription endpoint and remove redundant endPoint

### DIFF
--- a/src/services/ShopifyProductSyncService.ts
+++ b/src/services/ShopifyProductSyncService.ts
@@ -1414,7 +1414,7 @@ const fetchDashboardSummary = async (payload: any): Promise<ShopifyProductSyncDa
 
 const fetchWebhookSubscriptions = async (payload: any): Promise<any> => {
   const response = await requestBackend<any>({
-    url: "shopify/webhook",
+    url: "shopify/webhook-subscription",
     method: "get",
     params: {
       systemMessageRemoteId: payload.systemMessageRemoteId,
@@ -1429,7 +1429,7 @@ const fetchWebhookSubscriptions = async (payload: any): Promise<any> => {
 
 const subscribeWebhook = async (payload: any): Promise<any> => {
   return await requestBackend<any>({
-    url: "shopify/webhook",
+    url: "shopify/webhook-subscription",
     method: "post",
     data: {
       systemMessageRemoteId: payload.systemMessageRemoteId,
@@ -1440,7 +1440,7 @@ const subscribeWebhook = async (payload: any): Promise<any> => {
 
 const unsubscribeWebhook = async (payload: any): Promise<any> => {
   return await requestBackend<any>({
-    url: "shopify/webhook",
+    url: "shopify/webhook-subscription",
     method: "delete",
     data: {
       systemMessageRemoteId: payload.systemMessageRemoteId,

--- a/src/views/ShopifyProductSync.vue
+++ b/src/views/ShopifyProductSync.vue
@@ -3560,7 +3560,6 @@ async function toggleWebhookSubscription(subscribe: boolean) {
       await ShopifyProductSyncService.subscribeWebhook({
         systemMessageRemoteId: selectedShopSystemMessageRemoteId.value,
         topic: "BULK_OPERATIONS_FINISH",
-        endPoint: "shopify/webhook/payload"
       });
       showToast(translate("Subscribed to bulk operations finish webhook."));
     } else {


### PR DESCRIPTION
#### Closes
- #117 

• Updated ShopifyProductSyncService to call shopify/webhook-subscription instead of shopify/webhook.
• Modified ShopifyProductSync.vue to stop sending the unused `endPoint` field.  