### PR TITLE
feat: QuickBox 3PL connection config UI

### DIFF
--- a/docs/superpowers/plans/2026-06-11-quickbox-connection-ui.md
+++ b/docs/superpowers/plans/2026-06-11-quickbox-connection-ui.md
@@ -1,0 +1,770 @@
+# QuickBox 3PL Connection Config UI — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let admins configure the QuickBox 3PL connection (outbound API endpoint + auth, inbound webhook token, receiver URLs) from the company PWA, consistent with the Shopify integration's hub-and-modal feel.
+
+**Architecture:** One Pinia store talks to the **existing generic** `oms/systemMessageRemotes` endpoints (the same ones Klaviyo's Unigate config already uses) — **zero backend changes, one repo**. `/quickbox` is a single Shopify-style detail hub with two cards (API credentials, Inbound webhooks), each opening a credential modal. Reads never return the secret; secret fields are write-only and only written when the admin types one.
+
+**Tech Stack:** Vue 3 + Ionic + Pinia + `@common` (accxui). No backend/Moqui changes.
+
+**Spec:** `docs/superpowers/specs/2026-06-11-quickbox-connection-ui-design.md`
+
+**Branch:** `feat/quickbox-config-ui` (already checked out; the spec is committed here).
+
+**Testing note (read first):** This repo has **no unit-test harness** (Vitest was removed). So tasks use **verify-after** with exact commands — `npx vue-tsc --noEmit -p tsconfig.json` (type check) and `pnpm build`, plus a manual dogfood pass at the end — instead of test-first. The only allowed type diagnostic is the pre-existing `TS5101` baseUrl deprecation. Do not skip the verification steps.
+
+---
+
+## File Structure
+
+| File | Create/Modify | Responsibility |
+|---|---|---|
+| `src/store/quickbox.ts` | Create | `useQuickBoxStore()` — read/write the two SystemMessageRemote records via generic OMS endpoints; expose `apiConfig`, `authMode`, `webhookUrls`, `fetchStatus`. |
+| `src/store/user.ts` | Modify | Clear QuickBox store on logout. |
+| `src/router/index.ts` | Modify | Register `/quickbox` route behind `authGuard`. |
+| `src/components/Menu.vue` | Modify | Add the **QuickBox** side-menu entry. |
+| `src/views/QuickBox.vue` | Create | The `/quickbox` hub: Configuration section with two cards opening the modals. |
+| `src/components/EditQuickBoxApiCredentialsModal.vue` | Create | Edit `QuickBoxApi`: base URL + Bearer/Basic auth. |
+| `src/components/EditQuickBoxWebhookModal.vue` | Create | Show the three receiver URLs (copyable) + edit `QuickBoxWebhookIn` shared token. |
+| `src/views/Settings.vue` | Modify | Surface the store's `fetchStatus` in the Data Fetch Status card. |
+
+Task order guarantees the type-check stays green at every commit (no dangling imports): store → route+menu+scaffold → modals → full hub → settings.
+
+---
+
+## Task 1: Pinia store + logout wiring
+
+**Files:**
+- Create: `src/store/quickbox.ts`
+- Modify: `src/store/user.ts` (the `postLogout` action, lines ~166-182)
+
+- [ ] **Step 1: Create `src/store/quickbox.ts`**
+
+```typescript
+import { defineStore } from 'pinia'
+import { api, commonUtil, logger } from '@common'
+
+// The connector ships these two fixed SystemMessageRemote ids (see
+// quickbox-connector/data/QuickBoxConfigData.xml). They are the only records this UI touches.
+const QUICKBOX_API_REMOTE = 'QuickBoxApi'
+const QUICKBOX_WEBHOOK_REMOTE = 'QuickBoxWebhookIn'
+
+type FetchStatus = '' | 'pending' | 'success' | 'error'
+
+// The generic GET returns either a bare array or { systemMessageRemoteList: [...] }
+// depending on the OMS build; handle both, matching src/store/klaviyo.ts.
+const unwrapList = (data: any, key: string): any[] => {
+  if (Array.isArray(data)) return data
+  if (Array.isArray(data?.[key])) return data[key]
+  return []
+}
+
+export const useQuickBoxStore = defineStore('quickbox', {
+  state: () => ({
+    // Only ever holds non-secret fields: GET omits `password` by design.
+    apiConfig: { sendUrl: '', username: '' } as { sendUrl: string; username: string },
+    fetchStatus: {
+      connection: '' as FetchStatus,
+      lastFetched: 0 as number
+    }
+  }),
+
+  getters: {
+    isApiConfigured: (state) => !!state.apiConfig.sendUrl,
+    // username present ⇒ HTTP Basic; otherwise Bearer-token mode.
+    getAuthMode: (state): 'bearer' | 'basic' => (state.apiConfig.username ? 'basic' : 'bearer'),
+    getFetchStatus: (state) => state.fetchStatus,
+    // The three inbound endpoints QuickBox posts to, composed from the OMS base URL.
+    // getMaargURL() already includes the `/rest/s1` segment (commonUtil.ts), so we
+    // normalise the trailing slash and append `quickbox/...`.
+    getWebhookUrls: () => {
+      const base = (commonUtil.getMaargURL() || '').replace(/\/+$/, '')
+      if (!base) return { fulfillmentStatus: '', shipmentConfirm: '', inventoryAdjustment: '' }
+      return {
+        fulfillmentStatus: `${base}/quickbox/fulfillmentStatus`,
+        shipmentConfirm: `${base}/quickbox/shipmentConfirm`,
+        inventoryAdjustment: `${base}/quickbox/inventoryAdjustment`
+      }
+    }
+  },
+
+  actions: {
+    // Fetch all remotes and pick out QuickBoxApi (matches klaviyo.ts; avoids relying on
+    // list-param query serialization). Only QuickBoxApi has readable fields we use;
+    // QuickBoxWebhookIn exposes nothing readable (just an omitted password).
+    async fetchConnectionConfig() {
+      this.fetchStatus = { ...this.fetchStatus, connection: 'pending' }
+      try {
+        const resp: any = await api({ url: 'oms/systemMessageRemotes', method: 'get' })
+        const remotes = unwrapList(resp?.data, 'systemMessageRemoteList')
+        const apiRemote = remotes.find((r: any) => r?.systemMessageRemoteId === QUICKBOX_API_REMOTE)
+        this.apiConfig = {
+          sendUrl: apiRemote?.sendUrl || '',
+          username: apiRemote?.username || ''
+        }
+        this.fetchStatus = { connection: 'success', lastFetched: Date.now() }
+        return this.apiConfig
+      } catch (error) {
+        logger.error(error)
+        this.fetchStatus = { ...this.fetchStatus, connection: 'error' }
+        return null
+      }
+    },
+
+    async updateApiCredentials(payload: { sendUrl: string; authMode: 'bearer' | 'basic'; username?: string; password?: string }) {
+      const data: Record<string, any> = {
+        systemMessageRemoteId: QUICKBOX_API_REMOTE,
+        sendUrl: payload.sendUrl,
+        // Bearer mode clears any stale basic-auth username; Basic mode sets it.
+        username: payload.authMode === 'basic' ? (payload.username || '') : ''
+      }
+      // Only write the secret when the admin actually typed one — blank keeps the stored value.
+      if (payload.password) data.password = payload.password
+      const resp: any = await api({
+        url: `oms/systemMessageRemotes/${encodeURIComponent(QUICKBOX_API_REMOTE)}`,
+        method: 'put',
+        data
+      })
+      await this.fetchConnectionConfig()
+      return resp.data
+    },
+
+    async updateWebhookToken(payload: { password?: string }) {
+      const data: Record<string, any> = { systemMessageRemoteId: QUICKBOX_WEBHOOK_REMOTE }
+      if (payload.password) data.password = payload.password
+      const resp: any = await api({
+        url: `oms/systemMessageRemotes/${encodeURIComponent(QUICKBOX_WEBHOOK_REMOTE)}`,
+        method: 'put',
+        data
+      })
+      return resp.data
+    },
+
+    clearQuickBoxState() {
+      this.$reset()
+    }
+  },
+
+  persist: true
+})
+```
+
+- [ ] **Step 2: Wire `clearQuickBoxState` into logout**
+
+In `src/store/user.ts`, the `postLogout` action currently reads:
+
+```typescript
+    async postLogout() {
+      this.$reset()
+      useAuth().clearAuth()
+
+      // Reset all other persisted stores so no data leaks across sessions
+      const { useProductStore } = await import('./productStore')
+      const { useUtilStore } = await import('./util')
+      const { useNetSuiteStore } = await import('./netSuite')
+      const { useShopifyStore } = await import('./shopify')
+      const { useKlaviyoStore } = await import('./klaviyo')
+
+      useProductStore().clearProductStoreState()
+      useUtilStore().clearUtilState()
+      useNetSuiteStore().clearNetSuiteState()
+      useShopifyStore().clearShopifyState()
+      useKlaviyoStore().clear()
+    }
+```
+
+Replace it with (adds the two QuickBox lines):
+
+```typescript
+    async postLogout() {
+      this.$reset()
+      useAuth().clearAuth()
+
+      // Reset all other persisted stores so no data leaks across sessions
+      const { useProductStore } = await import('./productStore')
+      const { useUtilStore } = await import('./util')
+      const { useNetSuiteStore } = await import('./netSuite')
+      const { useShopifyStore } = await import('./shopify')
+      const { useKlaviyoStore } = await import('./klaviyo')
+      const { useQuickBoxStore } = await import('./quickbox')
+
+      useProductStore().clearProductStoreState()
+      useUtilStore().clearUtilState()
+      useNetSuiteStore().clearNetSuiteState()
+      useShopifyStore().clearShopifyState()
+      useKlaviyoStore().clear()
+      useQuickBoxStore().clearQuickBoxState()
+    }
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `npx vue-tsc --noEmit -p tsconfig.json`
+Expected: no errors (only the pre-existing `TS5101` baseUrl diagnostic, if any).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/store/quickbox.ts src/store/user.ts
+git commit -m "feat: QuickBox Pinia store (generic systemMessageRemotes client) + logout clearing"
+```
+
+---
+
+## Task 2: Route + menu entry + view scaffold
+
+**Files:**
+- Modify: `src/router/index.ts`
+- Modify: `src/components/Menu.vue`
+- Create: `src/views/QuickBox.vue` (scaffold; replaced in Task 5)
+
+- [ ] **Step 1: Create the scaffold view so the route import resolves**
+
+Create `src/views/QuickBox.vue`:
+
+```vue
+<template>
+  <ion-page>
+    <ion-content />
+  </ion-page>
+</template>
+
+<script setup lang="ts">
+import { IonContent, IonPage } from "@ionic/vue";
+</script>
+```
+
+- [ ] **Step 2: Register the route**
+
+In `src/router/index.ts`, add a lazy import alongside the other `const ... = () => import(...)` declarations (after line ~20, the `CloneProductStore` line):
+
+```typescript
+const QuickBox = () => import('@/views/QuickBox.vue')
+```
+
+Then add the route to the `routes` array, immediately after the last NetSuite route (`/netsuite/departments`, line ~50):
+
+```typescript
+  { path: '/quickbox', name: 'QuickBox', component: QuickBox, beforeEnter: authGuard },
+```
+
+- [ ] **Step 3: Add the side-menu entry**
+
+In `src/components/Menu.vue`, add `cubeOutline` to the ionicons import (line ~36):
+
+```typescript
+import { businessOutline, cartOutline, cubeOutline, mailOutline, settingsOutline, walletOutline } from "ionicons/icons";
+```
+
+Then, in the `appPages` array, insert this entry **after** the NetSuite object and **before** the Settings object (line ~70):
+
+```typescript
+  {
+    title: "QuickBox",
+    url: "/quickbox",
+    childRoutes: ["/quickbox/"],
+    iosIcon: cubeOutline,
+    mdIcon: cubeOutline,
+  },
+```
+
+- [ ] **Step 4: Type-check**
+
+Run: `npx vue-tsc --noEmit -p tsconfig.json`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/router/index.ts src/components/Menu.vue src/views/QuickBox.vue
+git commit -m "feat: QuickBox route, side-menu entry, view scaffold"
+```
+
+---
+
+## Task 3: API credentials modal
+
+**Files:**
+- Create: `src/components/EditQuickBoxApiCredentialsModal.vue`
+
+- [ ] **Step 1: Create the modal**
+
+Create `src/components/EditQuickBoxApiCredentialsModal.vue`:
+
+```vue
+<template>
+  <ion-header>
+    <ion-toolbar>
+      <ion-buttons slot="start">
+        <ion-button @click="closeModal()">
+          <ion-icon slot="icon-only" :icon="closeOutline" />
+        </ion-button>
+      </ion-buttons>
+      <ion-title>{{ translate("API credentials") }}</ion-title>
+    </ion-toolbar>
+  </ion-header>
+
+  <ion-content>
+    <ion-list>
+      <ion-item lines="none">
+        <ion-label class="ion-text-wrap">
+          <p>{{ translate("Outbound connection to the QuickBox iQ Connect API. The secret is write-only — leave it blank to keep the stored value.") }}</p>
+        </ion-label>
+      </ion-item>
+
+      <ion-item>
+        <ion-input
+          v-model="form.sendUrl"
+          :label="translate('Base URL') + ' *'"
+          label-placement="stacked"
+          placeholder="https://..."
+          autocomplete="off"
+        />
+      </ion-item>
+
+      <ion-item>
+        <ion-select v-model="form.authMode" :label="translate('Authentication')" interface="popover">
+          <ion-select-option value="bearer">{{ translate("Bearer token") }}</ion-select-option>
+          <ion-select-option value="basic">{{ translate("Basic auth") }}</ion-select-option>
+        </ion-select>
+      </ion-item>
+
+      <ion-item v-if="form.authMode === 'basic'">
+        <ion-input
+          v-model="form.username"
+          :label="translate('Username') + ' *'"
+          label-placement="stacked"
+          autocomplete="off"
+        />
+      </ion-item>
+
+      <ion-item>
+        <ion-input
+          v-model="form.password"
+          :label="form.authMode === 'basic' ? translate('Password') : translate('API token')"
+          label-placement="stacked"
+          type="password"
+          :placeholder="hasStoredSecret ? '••••••••' : ''"
+          autocomplete="off"
+        />
+      </ion-item>
+    </ion-list>
+
+    <ion-button
+      class="ion-margin"
+      expand="block"
+      :disabled="!isFormValid || isSaving"
+      @click="save()"
+    >
+      {{ translate("Save") }}
+    </ion-button>
+  </ion-content>
+</template>
+
+<script setup lang="ts">
+import {
+  IonButton, IonButtons, IonContent, IonHeader, IonIcon, IonInput,
+  IonItem, IonLabel, IonList, IonSelect, IonSelectOption, IonTitle, IonToolbar, modalController
+} from '@ionic/vue'
+import { closeOutline } from 'ionicons/icons'
+import { commonUtil, logger, translate } from '@common'
+import { useQuickBoxStore } from '@/store/quickbox'
+import { computed, reactive, ref } from 'vue'
+
+const quickBoxStore = useQuickBoxStore()
+
+// The hub fetches config before opening this modal, so apiConfig is already populated.
+const hasStoredSecret = computed(() => quickBoxStore.isApiConfigured)
+
+const form = reactive({
+  sendUrl: quickBoxStore.apiConfig.sendUrl || '',
+  authMode: quickBoxStore.getAuthMode as 'bearer' | 'basic',
+  username: quickBoxStore.apiConfig.username || '',
+  password: ''
+})
+const isSaving = ref(false)
+
+const isFormValid = computed(() =>
+  !!form.sendUrl.trim() && (form.authMode === 'bearer' || !!form.username.trim())
+)
+
+function closeModal(saved = false) {
+  modalController.dismiss({ saved })
+}
+
+async function save() {
+  isSaving.value = true
+  try {
+    await quickBoxStore.updateApiCredentials({
+      sendUrl: form.sendUrl.trim(),
+      authMode: form.authMode,
+      username: form.username.trim(),
+      password: form.password.trim() || undefined
+    })
+    commonUtil.showToast(translate("QuickBox API credentials saved"))
+    closeModal(true)
+  } catch (error) {
+    logger.error('updateQuickBoxApiCredentials', error)
+    commonUtil.showToast(translate("Failed to save QuickBox API credentials"))
+  } finally {
+    isSaving.value = false
+  }
+}
+</script>
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `npx vue-tsc --noEmit -p tsconfig.json`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/EditQuickBoxApiCredentialsModal.vue
+git commit -m "feat: QuickBox API credentials modal (base URL + Bearer/Basic auth)"
+```
+
+---
+
+## Task 4: Inbound-webhook modal
+
+**Files:**
+- Create: `src/components/EditQuickBoxWebhookModal.vue`
+
+- [ ] **Step 1: Create the modal**
+
+Create `src/components/EditQuickBoxWebhookModal.vue`:
+
+```vue
+<template>
+  <ion-header>
+    <ion-toolbar>
+      <ion-buttons slot="start">
+        <ion-button @click="closeModal()">
+          <ion-icon slot="icon-only" :icon="closeOutline" />
+        </ion-button>
+      </ion-buttons>
+      <ion-title>{{ translate("Inbound webhooks") }}</ion-title>
+    </ion-toolbar>
+  </ion-header>
+
+  <ion-content>
+    <ion-list>
+      <ion-item lines="none">
+        <ion-label class="ion-text-wrap">
+          <p>{{ translate("Give these URLs and the shared token to QuickBox so it can post events back to the OMS.") }}</p>
+        </ion-label>
+      </ion-item>
+
+      <ion-item v-for="hook in webhookList" :key="hook.key">
+        <ion-label class="ion-text-wrap">
+          {{ hook.label }}
+          <p>{{ hook.url || translate("OMS URL unavailable") }}</p>
+        </ion-label>
+        <ion-button slot="end" fill="clear" :disabled="!hook.url" @click="copyUrl(hook.url)">
+          <ion-icon slot="icon-only" :icon="copyOutline" />
+        </ion-button>
+      </ion-item>
+
+      <ion-item>
+        <ion-input
+          v-model="sharedToken"
+          :label="translate('Shared webhook token')"
+          label-placement="stacked"
+          type="password"
+          placeholder="••••••••"
+          autocomplete="off"
+        />
+      </ion-item>
+    </ion-list>
+
+    <ion-button
+      class="ion-margin"
+      expand="block"
+      :disabled="!sharedToken.trim() || isSaving"
+      @click="save()"
+    >
+      {{ translate("Save token") }}
+    </ion-button>
+  </ion-content>
+</template>
+
+<script setup lang="ts">
+import {
+  IonButton, IonButtons, IonContent, IonHeader, IonIcon, IonInput,
+  IonItem, IonLabel, IonList, IonTitle, IonToolbar, modalController
+} from '@ionic/vue'
+import { closeOutline, copyOutline } from 'ionicons/icons'
+import { commonUtil, logger, translate } from '@common'
+import { useQuickBoxStore } from '@/store/quickbox'
+import { computed, ref } from 'vue'
+
+const quickBoxStore = useQuickBoxStore()
+const sharedToken = ref("")
+const isSaving = ref(false)
+
+const webhookList = computed(() => {
+  const urls = quickBoxStore.getWebhookUrls
+  return [
+    { key: 'fulfillmentStatus', label: translate("Fulfillment status"), url: urls.fulfillmentStatus },
+    { key: 'shipmentConfirm', label: translate("Shipment confirmation"), url: urls.shipmentConfirm },
+    { key: 'inventoryAdjustment', label: translate("Inventory adjustment"), url: urls.inventoryAdjustment }
+  ]
+})
+
+function closeModal(saved = false) {
+  modalController.dismiss({ saved })
+}
+
+async function copyUrl(url: string) {
+  if (!url) return
+  try {
+    await navigator.clipboard.writeText(url)
+    commonUtil.showToast(translate("Copied to clipboard"))
+  } catch (error) {
+    logger.error('copyWebhookUrl', error)
+  }
+}
+
+async function save() {
+  isSaving.value = true
+  try {
+    await quickBoxStore.updateWebhookToken({ password: sharedToken.value.trim() })
+    commonUtil.showToast(translate("QuickBox webhook token saved"))
+    closeModal(true)
+  } catch (error) {
+    logger.error('updateQuickBoxWebhookToken', error)
+    commonUtil.showToast(translate("Failed to save QuickBox webhook token"))
+  } finally {
+    isSaving.value = false
+  }
+}
+</script>
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `npx vue-tsc --noEmit -p tsconfig.json`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/EditQuickBoxWebhookModal.vue
+git commit -m "feat: QuickBox inbound-webhook modal (receiver URLs + shared token)"
+```
+
+---
+
+## Task 5: Hub view (replace scaffold)
+
+**Files:**
+- Modify (replace scaffold): `src/views/QuickBox.vue`
+
+- [ ] **Step 1: Replace the scaffold with the full hub**
+
+Replace the entire contents of `src/views/QuickBox.vue` with:
+
+```vue
+<template>
+  <ion-page>
+    <ion-header :translucent="true">
+      <ion-toolbar>
+        <ion-menu-button slot="start" />
+        <ion-title>{{ translate("QuickBox 3PL") }}</ion-title>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content class="ion-padding-horizontal">
+      <div class="ion-margin-top">
+        <h1>{{ translate("Configuration") }}</h1>
+        <section>
+          <ion-item detail class="item-box" lines="none" button @click="openApiCredentialsModal()">
+            <ion-label class="ion-text-wrap">
+              {{ apiConfig.sendUrl || translate("Not configured") }}
+              <p>{{ translate("API credentials") }} · {{ authModeLabel }}</p>
+            </ion-label>
+          </ion-item>
+          <ion-item detail class="item-box" lines="none" button @click="openWebhookModal()">
+            <ion-label class="ion-text-wrap">
+              {{ translate("Inbound webhooks") }}
+              <p>{{ translate("Shared token and receiver URLs") }}</p>
+            </ion-label>
+          </ion-item>
+        </section>
+      </div>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script setup lang="ts">
+import { IonContent, IonHeader, IonItem, IonLabel, IonMenuButton, IonPage, IonTitle, IonToolbar, modalController, onIonViewWillEnter } from "@ionic/vue";
+import { translate } from '@common';
+import { computed } from "vue";
+import { useQuickBoxStore } from '@/store/quickbox';
+import EditQuickBoxApiCredentialsModal from "@/components/EditQuickBoxApiCredentialsModal.vue";
+import EditQuickBoxWebhookModal from "@/components/EditQuickBoxWebhookModal.vue";
+
+const quickBoxStore = useQuickBoxStore();
+const apiConfig = computed(() => quickBoxStore.apiConfig)
+const authModeLabel = computed(() =>
+  quickBoxStore.getAuthMode === 'basic' ? translate("Basic auth") : translate("Bearer token")
+)
+
+onIonViewWillEnter(async () => {
+  await quickBoxStore.fetchConnectionConfig()
+})
+
+async function openApiCredentialsModal() {
+  const modal = await modalController.create({ component: EditQuickBoxApiCredentialsModal })
+  await modal.present()
+  await modal.onWillDismiss()
+  await quickBoxStore.fetchConnectionConfig()
+}
+
+async function openWebhookModal() {
+  const modal = await modalController.create({ component: EditQuickBoxWebhookModal })
+  await modal.present()
+  await modal.onWillDismiss()
+}
+</script>
+
+<style scoped>
+.item-box::part(native) {
+  --border-radius: var(--spacer-xs);
+  border: var(--border-medium);
+}
+
+section {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: var(--spacer-sm);
+}
+
+@media screen and (min-width: 700px) {
+  ion-content {
+    --padding-start: var(--spacer-lg);
+    --padding-end: var(--spacer-lg);
+  }
+}
+</style>
+```
+
+- [ ] **Step 2: Type-check + build**
+
+Run: `npx vue-tsc --noEmit -p tsconfig.json && pnpm build`
+Expected: 0 type errors (TS5101 only); build ends with `✓ built`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/views/QuickBox.vue
+git commit -m "feat: QuickBox connection hub with API-credentials and webhook cards"
+```
+
+---
+
+## Task 6: Surface fetch status in Settings
+
+**Files:**
+- Modify: `src/views/Settings.vue`
+
+- [ ] **Step 1: Import and instantiate the store**
+
+In `src/views/Settings.vue`, after the existing util-store import line (`import { useUtilStore } from '@/store/util';`, line ~126), add:
+
+```typescript
+import { useQuickBoxStore } from '@/store/quickbox';
+```
+
+After the existing `const utilStore = useUtilStore();` line (~141), add:
+
+```typescript
+const quickBoxStore = useQuickBoxStore();
+```
+
+After the existing `const shopifyFetchStatus = computed(() => shopifyStore.fetchStatus)` line (~159), add:
+
+```typescript
+const quickBoxFetchStatus = computed(() => quickBoxStore.fetchStatus)
+```
+
+- [ ] **Step 2: Add the entry to `harmonizedFetchStatus`**
+
+In the `harmonizedFetchStatus` computed array (starts ~line 174), add this object immediately after the Shopify shops entry (the one whose `refresh: () => shopifyStore.fetchShopifyShops()`, ~line 195-198):
+
+```typescript
+  {
+    label: translate("QuickBox connection"),
+    status: quickBoxFetchStatus.value.connection,
+    refresh: () => quickBoxStore.fetchConnectionConfig()
+  },
+```
+
+(No change to the `oldestSyncTime` aggregation — QuickBox config is fetched on its own screen, not part of the initial sync window.)
+
+- [ ] **Step 3: Type-check + build**
+
+Run: `npx vue-tsc --noEmit -p tsconfig.json && pnpm build`
+Expected: 0 type errors (TS5101 only); build ends with `✓ built`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/views/Settings.vue
+git commit -m "feat: show QuickBox connection fetch status in Settings"
+```
+
+---
+
+## Task 7: Manual dogfood verification
+
+No code changes — verify the feature end to end against a local OMS running the asbeauty stack (`cd /Users/anilpatel/maarg-sd/asbeauty && ./gradlew run`, instance on `http://localhost:8080`; substitute your local admin credentials for `john.doe:moqui`). The company app must point at this OMS (its configured Maarg base URL).
+
+- [ ] **Step 1: Run the app and confirm navigation**
+
+Run: `pnpm dev` (or your usual dev command). Log in, open the side menu, click **QuickBox** → the hub loads with two cards; "API credentials" shows "Not configured" on a fresh instance.
+
+- [ ] **Step 2: Set Bearer credentials and confirm no secret leaks**
+
+In the app: open **API credentials**, set Base URL `https://example.test/iq`, Authentication = **Bearer token**, API token `tok_123`, Save. Then:
+
+```bash
+curl -s -u "john.doe:moqui" http://localhost:8080/rest/s1/oms/systemMessageRemotes | python3 -m json.tool | grep -A6 QuickBoxApi
+```
+Expected: the `QuickBoxApi` entry shows `"sendUrl": "https://example.test/iq"`, an empty/absent `username`, and **no** `password` key in the response.
+
+- [ ] **Step 3: Switch to Basic auth and confirm username set + bearer cleared**
+
+In the app: reopen **API credentials**, switch to **Basic auth**, Username `qbuser`, Password `qbpass`, Save. Then re-run the curl from Step 2.
+Expected: `"username": "qbuser"` now present; still **no** `password` in the response.
+
+- [ ] **Step 4: Confirm "blank secret keeps stored value"**
+
+In the app: reopen **API credentials**, change Base URL to `https://example.test/iq2`, leave the password field blank, Save. Then re-run the curl.
+Expected: `"sendUrl"` updated to `.../iq2`, `username` still `qbuser` — the stored password was not overwritten (no error; the record still authenticates on outbound send).
+
+- [ ] **Step 5: Webhook URLs render + token saves**
+
+In the app: open **Inbound webhooks**. Expected: three URLs render of the form `<oms-base>/rest/s1/quickbox/fulfillmentStatus`, `.../shipmentConfirm`, `.../inventoryAdjustment`, each with a working copy button. Enter a Shared webhook token `whk_123`, Save token. Then:
+
+```bash
+curl -s -u "john.doe:moqui" http://localhost:8080/rest/s1/oms/systemMessageRemotes | python3 -m json.tool | grep -A4 QuickBoxWebhookIn
+```
+Expected: the `QuickBoxWebhookIn` entry exists; response contains **no** `password` key (write succeeded, secret not echoed).
+
+- [ ] **Step 6: Settings + logout**
+
+In the app: open **Settings** → the Data Fetch Status card lists a **QuickBox connection** row with a success state and a working refresh button. Log out and back in → the QuickBox hub still reads the persisted config (no stale secret in memory; `clearQuickBoxState` ran on logout).
+
+---
+
+## Self-Review (completed by plan author)
+
+**Spec coverage:** connection & auth (QuickBoxApi) → Tasks 1, 3; webhook token + receiver URLs (QuickBoxWebhookIn) → Tasks 1, 4; generic-endpoint architecture & secret redaction → Task 1 + Task 7 curls; Shopify-style hub + two modals → Tasks 3-5; store `fetchStatus` contract + logout + menu + route + Settings → Tasks 1, 2, 6; verify-after testing → every task + Task 7. Out-of-scope items (warehouse mapping, jobs, SFTP, sendPath) intentionally absent.
+
+**Placeholder scan:** none — every step has concrete code or an exact command + expected output.
+
+**Type consistency:** store API used identically across files — `apiConfig` ({sendUrl, username}), getters `isApiConfigured` / `getAuthMode` ('bearer'|'basic') / `getWebhookUrls` ({fulfillmentStatus, shipmentConfirm, inventoryAdjustment}), actions `fetchConnectionConfig` / `updateApiCredentials({sendUrl, authMode, username?, password?})` / `updateWebhookToken({password?})` / `clearQuickBoxState`. Modal/hub usages match these signatures exactly.

--- a/docs/superpowers/specs/2026-06-11-quickbox-connection-ui-design.md
+++ b/docs/superpowers/specs/2026-06-11-quickbox-connection-ui-design.md
@@ -1,0 +1,144 @@
+# QuickBox 3PL Connection Config UI — Design
+
+**Date:** 2026-06-11
+**Status:** Approved (user-validated via brainstorming)
+**Scope decision:** v1 = **Connection & auth only**. Architecture **B — generic OMS endpoints, zero backend changes, one repo**. Structure = Shopify-style **detail hub + credential modals** (no list-of-one).
+
+## Problem
+
+The QuickBox 3PL connector (Moqui component at `maarg-sd/asbeauty/runtime/component/quickbox-connector`) is a complete bidirectional integration — orders out via the PickWave pipeline, three inbound webhooks (fulfillment status / shipment confirm / inventory adjustment), and a full QBFO lifecycle. What it has **no UI for** is the per-environment configuration an admin must set to go live. Today that means editing seed `SystemMessageRemote` rows by hand (`data/QuickBoxConfigData.xml` ships them with empty values).
+
+We want admins to configure the QuickBox connection in the **company PWA**, consistent with how they manage Shopify.
+
+## Scope
+
+QuickBox's full config surface spans connection/auth, warehouse `externalId` mapping, background-job enablement + tuning, SFTP batch credentials, and outbound endpoint paths. **v1 covers connection & auth only:**
+
+1. **`QuickBoxApi`** — outbound REST connection: `sendUrl` (iQ Connect base URL) + auth, where auth is either a Bearer token (`password` only → `Authorization: Bearer <password>`) or HTTP Basic (`username` + `password`).
+2. **`QuickBoxWebhookIn`** — shared inbound webhook token (`password`), plus **display** of the three receiver URLs to hand to QuickBox.
+
+Everything else is an explicit fast-follow (see *Out of Scope*).
+
+## Background — why this differs from Shopify and TikTok
+
+| | Shopify | QuickBox (this work) |
+|---|---|---|
+| Cardinality | Many shops, each its own `{shopId}_REMOTE` | **One fixed connection** — connector hardcodes `systemMessageRemoteId="QuickBoxApi"` in its ServiceJob parameters; backend cannot address multiple QuickBox connections |
+| Backend work | Dedicated `oms/shopifyShops/*` services | **None** — reuses the generic `oms/systemMessageRemotes` endpoints already used by Klaviyo's Unigate config |
+| UI shape | Connections list → per-shop detail hub → modals | **Single detail hub** at `/quickbox` → credential modals (no list, no "create connection") |
+
+Because QuickBox is a single fixed connection and reads are already secret-safe (below), the **NetSuite/Klaviyo single-integration model** is the structural reality, dressed in Shopify's hub-and-modal idioms for consistency.
+
+## Architecture — generic OMS endpoints (Option B)
+
+No changes to the `quickbox-connector` component or any Moqui backend. The company app talks only to endpoints that already exist and are already used by shipped company-app code:
+
+- **Read:** `GET oms/systemMessageRemotes?systemMessageRemoteId=QuickBoxApi&systemMessageRemoteId=QuickBoxWebhookIn`
+  Backed by `co.hotwax.util.UtilityServices.get#SystemMessageRemotes` (maarg-util `UtilityServices.xml`), whose `select-field` returns `systemMessageRemoteId, description, sendUrl, receiveUrl, sendServiceName, username, remoteId, remoteIdType, internalId, internalIdType, accessScopeEnumId, systemMessageTypeId` — **`password` is deliberately omitted**, so reads never leak the secret. `systemMessageRemoteId` is a `List` in-parameter, so both records come back in one call.
+- **Write:** `PUT oms/systemMessageRemotes/QuickBoxApi` and `PUT oms/systemMessageRemotes/QuickBoxWebhookIn` — the generic entity `store` (createOrUpdate) operation; upserts, so it succeeds even if the connector seed data was never loaded on the target instance.
+
+This mirrors the **shipped** Klaviyo/Unigate pattern (`klaviyo.ts` → `updateSystemMessageRemote` → `PUT oms/systemMessageRemotes/{id}`), not the still-unbuilt TikTok management-API plan.
+
+**Secret-handling behavior:** secret fields (`QuickBoxApi.password`, `QuickBoxWebhookIn.password`) load **blank** (the GET omits them). On save, a secret is written **only if the admin typed one** — an empty field is omitted from the PUT payload so the stored value is preserved. This lets an admin correct the base URL without re-entering the token. (A deliberate softening of Shopify's mandatory "rotate credentials" re-entry, appropriate because QuickBox config is touched more for endpoints than for rotation.)
+
+## Screens
+
+All in the company PWA. Mirror `ShopifyConnectionDetails.vue` (hub layout: `<h1>` section + `.item-box` grid) and `EditShopifyCredentialsModal.vue` (toolbar + close, `ion-list`, stacked labels, `type="password"` fields).
+
+### `src/views/QuickBox.vue` — hub at `/quickbox`
+
+- Header: `ion-menu-button` + title "QuickBox 3PL".
+- One **Configuration** `<h1>` section, same `.item-box` grid as Shopify, two cards:
+  - **API credentials** — sub-label shows the base URL (or "Not configured") and the inferred auth mode → opens `EditQuickBoxApiCredentialsModal`.
+  - **Inbound webhooks** — sub-label "Shared token and receiver URLs" → opens `EditQuickBoxWebhookModal`.
+- `onIonViewWillEnter` → `quickBoxStore.fetchConnectionConfig()`.
+
+### `src/components/EditQuickBoxApiCredentialsModal.vue`
+
+Fields:
+- **Base URL** (`sendUrl`).
+- **Authentication** selector (segment or `ion-select`): **Bearer token** | **Basic auth**.
+  - Bearer → single **API token** field (→ `password`).
+  - Basic → **Username** (→ `username`) + **Password** (→ `password`).
+- On open, mode is inferred from current config: `username` present ⇒ Basic, else Bearer. New/empty defaults to Bearer.
+- Save → `quickBoxStore.updateApiCredentials(...)`:
+  - Always sends `sendUrl`.
+  - Bearer mode sends `username: ''` (clears any stale basic-auth username) and `password` **only if typed**.
+  - Basic mode sends `username` and `password` **only if typed**.
+- Secret fields blank-on-load; toast + dismiss on success (`commonUtil.showToast`, accxui error pattern).
+
+### `src/components/EditQuickBoxWebhookModal.vue`
+
+- **Receiver URLs** (read-only, copy buttons) — the three endpoints QuickBox posts to:
+  - `{maargBase}/rest/s1/quickbox/fulfillmentStatus`
+  - `{maargBase}/rest/s1/quickbox/shipmentConfirm`
+  - `{maargBase}/rest/s1/quickbox/inventoryAdjustment`
+  - `maargBase` from `commonUtil.getMaargURL()`; confirm at implementation whether the helper already includes the `/rest/s1` segment and compose accordingly.
+- **Shared webhook token** field (write-only → `QuickBoxWebhookIn.password`); blank on load, written only if typed.
+- Save → `quickBoxStore.updateWebhookToken(...)`.
+
+## Store — `src/store/quickbox.ts` → `useQuickBoxStore()`
+
+```
+state:
+  apiConfig:        { sendUrl: '', username: '' }   // from GET; never holds a secret
+  fetchStatus:      { connection: '', lastFetched: 0 }   // '' | 'pending' | 'success' | 'error'
+
+getters:
+  isApiConfigured  -> !!apiConfig.sendUrl
+  authMode         -> apiConfig.username ? 'basic' : 'bearer'
+  webhookUrls      -> three composed URLs from commonUtil.getMaargURL()
+
+Note: the webhook record exposes no readable indicator (it has only `password`, which the
+GET omits, and no `sendUrl`), so there is no "webhook configured" flag — the Inbound webhooks
+card shows the URLs + a write-only token field without a configured/not-configured state.
+
+actions:
+  fetchConnectionConfig()   // GET both records in one call; set fetchStatus pending/success/error + lastFetched
+  updateApiCredentials(p)   // PUT oms/systemMessageRemotes/QuickBoxApi; refetch
+  updateWebhookToken(p)     // PUT oms/systemMessageRemotes/QuickBoxWebhookIn; refetch
+  clearQuickBoxState()      // $reset
+```
+
+- Uses `api`, `commonUtil`, `logger` from `@common`. `persist: true`.
+- accxui rules: router-instance import (no `useRouter()` in components/guards), no `src/services/`, `fetchStatus` contract present (consumed by `Settings.vue`).
+
+## Wiring
+
+- **Route:** add `{ path: '/quickbox', name: 'QuickBox', component: () => import('@/views/QuickBox.vue'), beforeEnter: authGuard }` to `src/router/index.ts`.
+- **Menu:** add a **QuickBox** entry to `appPages` in `src/components/Menu.vue` (icon `cubeOutline`), placed with the other integrations.
+- **Logout:** add `useQuickBoxStore().clearQuickBoxState()` to `user.postLogout` (alongside the existing store-clear calls).
+- **Settings:** surface the store's `fetchStatus.connection` in the Data Fetch Status card in `src/views/Settings.vue`.
+
+## Error handling & validation
+
+- Standard Moqui error responses → PWA toasts (the shipped `commonUtil.hasError` / `showToast` pattern).
+- Client-side: Save disabled until **Base URL** is non-empty; in Basic mode, **Username** required. Token/password fields are optional on edit (blank = keep existing).
+- No server-side validation is added (Option B), so the UI is the only gate; keep checks minimal and forgiving.
+
+## Out of Scope (v1) — documented fast-follows
+
+All reachable later via generic endpoints without revisiting this work:
+
+1. **Warehouse mapping** — list facility group `QUICKBOX` members, set each site's real `externalId` (QuickBox warehouse code), activate/deactivate via `FacilityGroupMember.thruDate`. Endpoints: `admin/facilities`, `admin/facilityGroups`, facility-group-member CRUD.
+2. **Job / pipeline controls** — enable/pause the connector ServiceJobs (`advance_QuickBoxPipeline`, `consume_ReceivedQuickBoxMessages`, `send_ProducedQuickBoxMessages`) and tune `picklistSize` / `maxInFlight`.
+3. **SFTP batch** — `QuickBoxSftp` host/user/key (only if the CSV-batch path is used).
+4. **Outbound endpoint paths** — editable `sendPath` on `SendQuickBoxFulfillmentOrder` / `SendQuickBoxOrderCancel`.
+
+## Testing
+
+No unit-test harness in this repo (Vitest was removed), so **verify-after** with exact commands:
+
+- **Type + build:** `npx vue-tsc --noEmit -p tsconfig.json` (0 errors; the only allowed diagnostic is the pre-existing `TS5101` baseUrl deprecation) and `pnpm build` (`✓ built`).
+- **Manual dogfood** against a local OMS running the asbeauty stack:
+  - Set API credentials (Bearer), confirm `GET oms/systemMessageRemotes?systemMessageRemoteId=QuickBoxApi` shows the new `sendUrl` and **no** `password`.
+  - Switch to Basic auth, confirm `username` is set; switch back to Bearer, confirm `username` is cleared.
+  - Edit base URL only (token left blank), confirm the stored token is preserved (outbound send still authenticates).
+  - Set the webhook token; confirm the three receiver URLs render and copy correctly.
+
+## Assumptions & dependencies
+
+1. The seed `SystemMessageRemote` rows (`QuickBoxApi`, `QuickBoxWebhookIn`) exist on the target OMS once the connector data is loaded; if not, the `store`-op PUT creates them — so the UI works regardless.
+2. `commonUtil.getMaargURL()` resolves to the OMS base that also receives the QuickBox webhooks (the connector runs in that same OMS). Confirm at implementation whether the helper includes `/rest/s1`.
+3. Permission gating reuses the company app's existing pattern (`authGuard` / app-level view permission); no new permission scheme in v1.
+4. Single-connection assumption holds while the connector hardcodes `QuickBoxApi`; multi-connection would require backend changes and is out of scope.

--- a/src/components/EditQuickBoxApiCredentialsModal.vue
+++ b/src/components/EditQuickBoxApiCredentialsModal.vue
@@ -1,0 +1,119 @@
+<template>
+  <ion-header>
+    <ion-toolbar>
+      <ion-buttons slot="start">
+        <ion-button @click="closeModal()">
+          <ion-icon slot="icon-only" :icon="closeOutline" />
+        </ion-button>
+      </ion-buttons>
+      <ion-title>{{ translate("API credentials") }}</ion-title>
+    </ion-toolbar>
+  </ion-header>
+
+  <ion-content>
+    <ion-list>
+      <ion-item lines="none">
+        <ion-label class="ion-text-wrap">
+          <p>{{ translate("Outbound connection to the QuickBox iQ Connect API. The secret is write-only — leave it blank to keep the stored value.") }}</p>
+        </ion-label>
+      </ion-item>
+
+      <ion-item>
+        <ion-input
+          v-model="form.sendUrl"
+          :label="translate('Base URL') + ' *'"
+          label-placement="stacked"
+          placeholder="https://..."
+          autocomplete="off"
+        />
+      </ion-item>
+
+      <ion-item>
+        <ion-select v-model="form.authMode" :label="translate('Authentication')" interface="popover">
+          <ion-select-option value="bearer">{{ translate("Bearer token") }}</ion-select-option>
+          <ion-select-option value="basic">{{ translate("Basic auth") }}</ion-select-option>
+        </ion-select>
+      </ion-item>
+
+      <ion-item v-if="form.authMode === 'basic'">
+        <ion-input
+          v-model="form.username"
+          :label="translate('Username') + ' *'"
+          label-placement="stacked"
+          autocomplete="off"
+        />
+      </ion-item>
+
+      <ion-item>
+        <ion-input
+          v-model="form.password"
+          :label="form.authMode === 'basic' ? translate('Password') : translate('API token')"
+          label-placement="stacked"
+          type="password"
+          :placeholder="isConfigured ? '••••••••' : ''"
+          autocomplete="off"
+        />
+      </ion-item>
+    </ion-list>
+
+    <ion-button
+      class="ion-margin"
+      expand="block"
+      :disabled="!isFormValid || isSaving"
+      @click="save()"
+    >
+      {{ translate("Save") }}
+    </ion-button>
+  </ion-content>
+</template>
+
+<script setup lang="ts">
+import {
+  IonButton, IonButtons, IonContent, IonHeader, IonIcon, IonInput,
+  IonItem, IonLabel, IonList, IonSelect, IonSelectOption, IonTitle, IonToolbar, modalController
+} from '@ionic/vue'
+import { closeOutline } from 'ionicons/icons'
+import { commonUtil, logger, translate } from '@common'
+import { useQuickBoxStore } from '@/store/quickbox'
+import { computed, reactive, ref } from 'vue'
+
+const quickBoxStore = useQuickBoxStore()
+
+const isConfigured = computed(() => quickBoxStore.isApiConfigured)
+
+const form = reactive({
+  sendUrl: quickBoxStore.apiConfig.sendUrl || '',
+  // Snapshot of current config — the hub awaits fetchConnectionConfig() before opening this modal.
+  authMode: quickBoxStore.getAuthMode as 'bearer' | 'basic',
+  username: quickBoxStore.apiConfig.username || '',
+  password: ''
+})
+const isSaving = ref(false)
+
+const isFormValid = computed(() =>
+  !!form.sendUrl.trim() && (form.authMode === 'bearer' || !!form.username.trim())
+)
+
+function closeModal(saved = false) {
+  modalController.dismiss({ saved })
+}
+
+async function save() {
+  isSaving.value = true
+  try {
+    await quickBoxStore.updateApiCredentials({
+      sendUrl: form.sendUrl.trim(),
+      authMode: form.authMode,
+      username: form.authMode === 'basic' ? form.username.trim() : '',
+      password: form.password.trim() || undefined
+    })
+    commonUtil.showToast(translate("QuickBox API credentials saved"))
+    closeModal(true)
+  } catch (error) {
+    logger.error('updateQuickBoxApiCredentials', error)
+    commonUtil.showToast(translate("Failed to save QuickBox API credentials"))
+  } finally {
+    isSaving.value = false
+  }
+}
+</script>

--- a/src/components/EditQuickBoxWebhookModal.vue
+++ b/src/components/EditQuickBoxWebhookModal.vue
@@ -1,0 +1,105 @@
+<template>
+  <ion-header>
+    <ion-toolbar>
+      <ion-buttons slot="start">
+        <ion-button @click="closeModal()">
+          <ion-icon slot="icon-only" :icon="closeOutline" />
+        </ion-button>
+      </ion-buttons>
+      <ion-title>{{ translate("Inbound webhooks") }}</ion-title>
+    </ion-toolbar>
+  </ion-header>
+
+  <ion-content>
+    <ion-list>
+      <ion-item lines="none">
+        <ion-label class="ion-text-wrap">
+          <p>{{ translate("Give these URLs and the shared token to QuickBox so it can post events back to the OMS.") }}</p>
+        </ion-label>
+      </ion-item>
+
+      <ion-item v-for="hook in webhookList" :key="hook.key">
+        <ion-label class="ion-text-wrap">
+          {{ hook.label }}
+          <p>{{ hook.url || translate("OMS URL unavailable") }}</p>
+        </ion-label>
+        <ion-button slot="end" fill="clear" :disabled="!hook.url" @click="copyUrl(hook.url)">
+          <ion-icon slot="icon-only" :icon="copyOutline" />
+        </ion-button>
+      </ion-item>
+
+      <ion-item>
+        <ion-input
+          v-model="sharedToken"
+          :label="translate('Shared webhook token')"
+          label-placement="stacked"
+          type="password"
+          placeholder="••••••••"
+          autocomplete="off"
+        />
+      </ion-item>
+    </ion-list>
+
+    <ion-button
+      class="ion-margin"
+      expand="block"
+      :disabled="!sharedToken.trim() || isSaving"
+      @click="save()"
+    >
+      {{ translate("Save token") }}
+    </ion-button>
+  </ion-content>
+</template>
+
+<script setup lang="ts">
+import {
+  IonButton, IonButtons, IonContent, IonHeader, IonIcon, IonInput,
+  IonItem, IonLabel, IonList, IonTitle, IonToolbar, modalController
+} from '@ionic/vue'
+import { closeOutline, copyOutline } from 'ionicons/icons'
+import { commonUtil, logger, translate } from '@common'
+import { useQuickBoxStore } from '@/store/quickbox'
+import { computed, ref } from 'vue'
+
+const quickBoxStore = useQuickBoxStore()
+const sharedToken = ref("")
+const isSaving = ref(false)
+
+const webhookList = computed(() => {
+  const urls = quickBoxStore.getWebhookUrls
+  return [
+    { key: 'fulfillmentStatus', label: translate("Fulfillment status"), url: urls.fulfillmentStatus },
+    { key: 'shipmentConfirm', label: translate("Shipment confirmation"), url: urls.shipmentConfirm },
+    { key: 'inventoryAdjustment', label: translate("Inventory adjustment"), url: urls.inventoryAdjustment }
+  ]
+})
+
+function closeModal(saved = false) {
+  modalController.dismiss({ saved })
+}
+
+async function copyUrl(url: string) {
+  if (!url) return
+  try {
+    await navigator.clipboard.writeText(url)
+    commonUtil.showToast(translate("Copied to clipboard"))
+  } catch (error) {
+    logger.error('copyWebhookUrl', error)
+    commonUtil.showToast(translate("Could not copy to clipboard"))
+  }
+}
+
+async function save() {
+  isSaving.value = true
+  try {
+    await quickBoxStore.updateWebhookToken({ password: sharedToken.value.trim() })
+    commonUtil.showToast(translate("QuickBox webhook token saved"))
+    closeModal(true)
+  } catch (error) {
+    logger.error('updateQuickBoxWebhookToken', error)
+    commonUtil.showToast(translate("Failed to save QuickBox webhook token"))
+  } finally {
+    isSaving.value = false
+  }
+}
+</script>

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -33,7 +33,7 @@ import {
   IonMenuToggle,
 } from "@ionic/vue";
 import { computed } from "vue";
-import { businessOutline, cartOutline, mailOutline, settingsOutline, walletOutline } from "ionicons/icons";
+import { businessOutline, cartOutline, cubeOutline, mailOutline, settingsOutline, walletOutline } from "ionicons/icons";
 import { useAuth } from '@common/composables/useAuth';
 import router from "@/router";
 import { translate } from '@common';
@@ -67,6 +67,13 @@ const appPages = [
     childRoutes: ["/netsuite/"],
     iosIcon: walletOutline,
     mdIcon: walletOutline
+  },
+  {
+    title: "QuickBox",
+    url: "/quickbox",
+    childRoutes: ["/quickbox/"],
+    iosIcon: cubeOutline,
+    mdIcon: cubeOutline,
   },
   {
     title: "Settings",

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -18,6 +18,7 @@ const ShopifyConnectionDetails = () => import('@/views/ShopifyConnectionDetails.
 const Klaviyo = () => import('@/views/Klaviyo.vue')
 const KlaviyoConnectionDetails = () => import('@/views/KlaviyoConnectionDetails.vue')
 const CloneProductStore = () => import('@/views/CloneProductStore.vue')
+const QuickBox = () => import('@/views/QuickBox.vue')
 
 const authGuard = async () => {
   if (!useAuth().isAuthenticated.value) {
@@ -48,6 +49,7 @@ const routes: Array<RouteRecordRaw> = [
   { path: '/netsuite/payment-methods', name: 'PaymentMethods', component: PaymentMethods, beforeEnter: authGuard },
   { path: '/netsuite/sales-channel', name: 'SalesChannel', component: SalesChannel, beforeEnter: authGuard },
   { path: '/netsuite/departments', name: 'Departments', component: Departments, beforeEnter: authGuard },
+  { path: '/quickbox', name: 'QuickBox', component: QuickBox, beforeEnter: authGuard },
   { path: '/create-product-store', name: 'CreateProductStore', component: CreateProductStore, beforeEnter: authGuard },
   {
     path: '/add-configurations/:productStoreId',

--- a/src/store/quickbox.ts
+++ b/src/store/quickbox.ts
@@ -1,0 +1,106 @@
+import { defineStore } from 'pinia'
+import { api, commonUtil, logger } from '@common'
+
+// The connector ships these two fixed SystemMessageRemote ids (see
+// quickbox-connector/data/QuickBoxConfigData.xml). They are the only records this UI touches.
+const QUICKBOX_API_REMOTE = 'QuickBoxApi'
+const QUICKBOX_WEBHOOK_REMOTE = 'QuickBoxWebhookIn'
+
+type FetchStatus = '' | 'pending' | 'success' | 'error'
+
+// The generic GET returns either a bare array or { systemMessageRemoteList: [...] }
+// depending on the OMS build; handle both, matching src/store/klaviyo.ts.
+const unwrapList = (data: any, key: string): any[] => {
+  if (Array.isArray(data)) return data
+  if (Array.isArray(data?.[key])) return data[key]
+  return []
+}
+
+export const useQuickBoxStore = defineStore('quickbox', {
+  state: () => ({
+    // Only ever holds non-secret fields: GET omits `password` by design.
+    apiConfig: { sendUrl: '', username: '' } as { sendUrl: string; username: string },
+    fetchStatus: {
+      connection: '' as FetchStatus,
+      lastFetched: 0 as number
+    }
+  }),
+
+  getters: {
+    isApiConfigured: (state) => !!state.apiConfig.sendUrl,
+    // username present ⇒ HTTP Basic; otherwise Bearer-token mode.
+    getAuthMode: (state): 'bearer' | 'basic' => (state.apiConfig.username ? 'basic' : 'bearer'),
+    getFetchStatus: (state) => state.fetchStatus,
+    // The three inbound endpoints QuickBox posts to, composed from the OMS base URL.
+    // getMaargURL() already includes the `/rest/s1` segment (commonUtil.ts), so we
+    // normalise the trailing slash and append `quickbox/...`.
+    getWebhookUrls: () => {
+      const base = (commonUtil.getMaargURL() || '').replace(/\/+$/, '')
+      if (!base) return { fulfillmentStatus: '', shipmentConfirm: '', inventoryAdjustment: '' }
+      return {
+        fulfillmentStatus: `${base}/quickbox/fulfillmentStatus`,
+        shipmentConfirm: `${base}/quickbox/shipmentConfirm`,
+        inventoryAdjustment: `${base}/quickbox/inventoryAdjustment`
+      }
+    }
+  },
+
+  actions: {
+    // Fetch all remotes and pick out QuickBoxApi (matches klaviyo.ts; avoids relying on
+    // list-param query serialization). Only QuickBoxApi has readable fields we use;
+    // QuickBoxWebhookIn exposes nothing readable (just an omitted password).
+    async fetchConnectionConfig() {
+      this.fetchStatus = { ...this.fetchStatus, connection: 'pending' }
+      try {
+        const resp: any = await api({ url: 'oms/systemMessageRemotes', method: 'get' })
+        const remotes = unwrapList(resp?.data, 'systemMessageRemoteList')
+        const apiRemote = remotes.find((r: any) => r?.systemMessageRemoteId === QUICKBOX_API_REMOTE)
+        this.apiConfig = {
+          sendUrl: apiRemote?.sendUrl || '',
+          username: apiRemote?.username || ''
+        }
+        this.fetchStatus = { ...this.fetchStatus, connection: 'success', lastFetched: Date.now() }
+        return this.apiConfig
+      } catch (error) {
+        logger.error(error)
+        this.fetchStatus = { ...this.fetchStatus, connection: 'error' }
+        return null
+      }
+    },
+
+    async updateApiCredentials(payload: { sendUrl: string; authMode: 'bearer' | 'basic'; username?: string; password?: string }) {
+      const data: Record<string, any> = {
+        systemMessageRemoteId: QUICKBOX_API_REMOTE,
+        sendUrl: payload.sendUrl,
+        // Bearer mode clears any stale basic-auth username; Basic mode sets it.
+        username: payload.authMode === 'basic' ? (payload.username || '') : ''
+      }
+      // Only write the secret when the admin actually typed one — blank keeps the stored value.
+      if (payload.password) data.password = payload.password
+      const resp: any = await api({
+        url: `oms/systemMessageRemotes/${encodeURIComponent(QUICKBOX_API_REMOTE)}`,
+        method: 'put',
+        data
+      })
+      await this.fetchConnectionConfig()
+      return resp.data
+    },
+
+    async updateWebhookToken(payload: { password?: string }) {
+      const data: Record<string, any> = { systemMessageRemoteId: QUICKBOX_WEBHOOK_REMOTE }
+      if (payload.password) data.password = payload.password
+      const resp: any = await api({
+        url: `oms/systemMessageRemotes/${encodeURIComponent(QUICKBOX_WEBHOOK_REMOTE)}`,
+        method: 'put',
+        data
+      })
+      return resp.data
+    },
+
+    clearQuickBoxState() {
+      this.$reset()
+    }
+  },
+
+  persist: true
+})

--- a/src/store/quickbox.ts
+++ b/src/store/quickbox.ts
@@ -82,7 +82,6 @@ export const useQuickBoxStore = defineStore('quickbox', {
         method: 'put',
         data
       })
-      await this.fetchConnectionConfig()
       return resp.data
     },
 

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -173,12 +173,14 @@ export const useUserStore = defineStore('user', {
       const { useNetSuiteStore } = await import('./netSuite')
       const { useShopifyStore } = await import('./shopify')
       const { useKlaviyoStore } = await import('./klaviyo')
+      const { useQuickBoxStore } = await import('./quickbox')
 
       useProductStore().clearProductStoreState()
       useUtilStore().clearUtilState()
       useNetSuiteStore().clearNetSuiteState()
       useShopifyStore().clearShopifyState()
       useKlaviyoStore().clear()
+      useQuickBoxStore().clearQuickBoxState()
     }
   },
 

--- a/src/views/QuickBox.vue
+++ b/src/views/QuickBox.vue
@@ -1,0 +1,9 @@
+<template>
+  <ion-page>
+    <ion-content />
+  </ion-page>
+</template>
+
+<script setup lang="ts">
+import { IonContent, IonPage } from "@ionic/vue";
+</script>

--- a/src/views/QuickBox.vue
+++ b/src/views/QuickBox.vue
@@ -1,9 +1,82 @@
 <template>
   <ion-page>
-    <ion-content />
+    <ion-header :translucent="true">
+      <ion-toolbar>
+        <ion-menu-button slot="start" />
+        <ion-title>{{ translate("QuickBox 3PL") }}</ion-title>
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content class="ion-padding-horizontal">
+      <div class="ion-margin-top">
+        <h1>{{ translate("Configuration") }}</h1>
+        <section>
+          <ion-item detail class="item-box" lines="none" button @click="openApiCredentialsModal()">
+            <ion-label class="ion-text-wrap">
+              {{ apiConfig.sendUrl || translate("Not configured") }}
+              <p>{{ translate("API credentials") }} · {{ authModeLabel }}</p>
+            </ion-label>
+          </ion-item>
+          <ion-item detail class="item-box" lines="none" button @click="openWebhookModal()">
+            <ion-label class="ion-text-wrap">
+              {{ translate("Inbound webhooks") }}
+              <p>{{ translate("Shared token and receiver URLs") }}</p>
+            </ion-label>
+          </ion-item>
+        </section>
+      </div>
+    </ion-content>
   </ion-page>
 </template>
 
 <script setup lang="ts">
-import { IonContent, IonPage } from "@ionic/vue";
+import { IonContent, IonHeader, IonItem, IonLabel, IonMenuButton, IonPage, IonTitle, IonToolbar, modalController, onIonViewWillEnter } from "@ionic/vue";
+import { translate } from '@common';
+import { computed } from "vue";
+import { useQuickBoxStore } from '@/store/quickbox';
+import EditQuickBoxApiCredentialsModal from "@/components/EditQuickBoxApiCredentialsModal.vue";
+import EditQuickBoxWebhookModal from "@/components/EditQuickBoxWebhookModal.vue";
+
+const quickBoxStore = useQuickBoxStore();
+const apiConfig = computed(() => quickBoxStore.apiConfig)
+const authModeLabel = computed(() =>
+  quickBoxStore.getAuthMode === 'basic' ? translate("Basic auth") : translate("Bearer token")
+)
+
+onIonViewWillEnter(async () => {
+  await quickBoxStore.fetchConnectionConfig()
+})
+
+async function openApiCredentialsModal() {
+  const modal = await modalController.create({ component: EditQuickBoxApiCredentialsModal })
+  await modal.present()
+  await modal.onWillDismiss()
+  await quickBoxStore.fetchConnectionConfig()
+}
+
+async function openWebhookModal() {
+  const modal = await modalController.create({ component: EditQuickBoxWebhookModal })
+  await modal.present()
+  await modal.onWillDismiss()
+}
 </script>
+
+<style scoped>
+.item-box::part(native) {
+  --border-radius: var(--spacer-xs);
+  border: var(--border-medium);
+}
+
+section {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: var(--spacer-sm);
+}
+
+@media screen and (min-width: 700px) {
+  ion-content {
+    --padding-start: var(--spacer-lg);
+    --padding-end: var(--spacer-lg);
+  }
+}
+</style>

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -124,6 +124,7 @@ import { useUserStore } from '@/store/user';
 import { useProductStore } from '@/store/productStore';
 import { useShopifyStore } from '@/store/shopify';
 import { useUtilStore } from '@/store/util';
+import { useQuickBoxStore } from '@/store/quickbox';
 import { useAuth } from '@common/composables/useAuth';
 import TimeZoneModal from "@/components/TimezoneModal.vue";
 import Image from "@/components/Image.vue"
@@ -139,6 +140,7 @@ const userStore = useUserStore();
 const productStoreStore = useProductStore();
 const shopifyStore = useShopifyStore();
 const utilStore = useUtilStore();
+const quickBoxStore = useQuickBoxStore();
 const { isAuthenticated } = useAuth();
 const { jobs, loading: loadingJobs, fetchJobs } = useServiceJob();
 const maargInfo = computed(() => utilStore.maargInfo)
@@ -157,13 +159,15 @@ const fetchStatus = computed(() => utilStore.fetchStatus)
 const userFetchStatus = computed(() => userStore.fetchStatus)
 const productStoreFetchStatus = computed(() => productStoreStore.fetchStatus)
 const shopifyFetchStatus = computed(() => shopifyStore.fetchStatus)
+const quickBoxFetchStatus = computed(() => quickBoxStore.fetchStatus)
 
 const oldestSyncTime = computed(() => {
   const timestamps = [
     userFetchStatus.value.lastFetched,
     fetchStatus.value.lastFetched,
     productStoreFetchStatus.value.lastFetched,
-    shopifyFetchStatus.value.lastFetched
+    shopifyFetchStatus.value.lastFetched,
+    quickBoxFetchStatus.value.lastFetched
   ].filter(t => t > 0);
   
   if (!timestamps.length) return '';
@@ -195,6 +199,11 @@ const harmonizedFetchStatus = computed(() => [
     status: shopifyFetchStatus.value.shops,
     count: shopifyStore.shops?.length || 0,
     refresh: () => shopifyStore.fetchShopifyShops()
+  },
+  {
+    label: translate("QuickBox Connection"),
+    status: quickBoxFetchStatus.value.connection,
+    refresh: () => quickBoxStore.fetchConnectionConfig()
   },
   {
     label: translate("Statuses"),


### PR DESCRIPTION
## Summary

Adds a **QuickBox 3PL connection configuration** screen to the company PWA so admins can configure the QuickBox integration without hand-editing `SystemMessageRemote` rows. **Zero backend changes** — it reads/writes the connector's two fixed records (`QuickBoxApi`, `QuickBoxWebhookIn`) through the *existing* generic `oms/systemMessageRemotes` endpoints (the same pattern Klaviyo's Unigate config already ships with).

- New `/quickbox` hub (Shopify-style detail hub) with a **Configuration** section of two cards.
- **API credentials** modal — base URL + Bearer-token / Basic-auth selector.
- **Inbound webhooks** modal — the three receiver URLs (read-only, copyable) + the shared webhook token.
- Pinia store `useQuickBoxStore` (read-all-and-filter; `fetchStatus` contract; `persist`), logout clearing, side-menu entry, and a QuickBox row in Settings → Data Fetch Status.
- **Secrets are write-only:** the GET omits `password`; the PUT sends a secret only when the admin types one (blank keeps the stored value). Bearer mode clears any stale Basic-auth username.

v1 scope is **connection & auth only**. Warehouse/`externalId` mapping, job/pipeline controls, SFTP batch creds, and editable outbound `sendPath` are documented fast-follows in the spec.

Spec: `docs/superpowers/specs/2026-06-11-quickbox-connection-ui-design.md`
Plan: `docs/superpowers/plans/2026-06-11-quickbox-connection-ui.md`

## Test Plan

Static gates (run, green): `npx vue-tsc --noEmit -p tsconfig.json` (only the pre-existing TS5101) and `pnpm build` (`✓ built`).

Manual dogfood against a local OMS (not yet run — needs admin creds + dev server pointed at the OMS):

- [ ] `/quickbox` loads; shows "Not configured" on a fresh instance.
- [ ] Set Bearer creds → `GET oms/systemMessageRemotes` shows the new `sendUrl`, empty `username`, and **no** `password`.
- [ ] Switch to Basic auth → `username` set; switch back to Bearer → `username` cleared.
- [ ] Edit base URL with the secret left blank → stored token preserved (outbound send still authenticates).
- [ ] Inbound webhooks modal renders the three `.../rest/s1/quickbox/{fulfillmentStatus,shipmentConfirm,inventoryAdjustment}` URLs with working copy buttons; save the shared token.
- [ ] Settings → Data Fetch Status shows a **QuickBox Connection** row with a working refresh; logout/login preserves config with no secret retained in memory.