### PR TITLE
feat: consume entity-engine master shapes (agent + conversation reads)

### DIFF
--- a/src/store/composer.ts
+++ b/src/store/composer.ts
@@ -104,8 +104,10 @@ export const useComposerStore = defineStore('composer', {
       if (!this.agentId) return
       const resp = await api({ url: `ai/agents/${encodeURIComponent(this.agentId)}`, method: 'get' }) as any
       if (hasError(resp)) throw resp.data
-      const current: any[] = resp.data.toolList || []
-      this.statusId = resp.data.agent?.statusId || this.statusId
+      // GET /agents/{id} now returns the AiAgent 'detail' master: agent fields at top level + `grants`
+      // (each grant carries toolId + requiresApprovalOverride, same fields we diff on).
+      const current: any[] = resp.data.grants || []
+      this.statusId = resp.data.statusId || this.statusId
 
       for (const cur of current) {
         if (!this.selectedTools.some((tool) => tool.toolId === cur.toolId)) {

--- a/src/store/workforce.ts
+++ b/src/store/workforce.ts
@@ -16,15 +16,23 @@ export type WorkforceConversation = {
 
 function toChatItems(detail: any): ChatItem[] {
   const items: ChatItem[] = []
-  const userName = detail?.conversation?.userId || 'User'
-  for (const msg of detail?.messageList || []) {
+  // detail is the AiConversation 'detail' master: conversation fields at top level, plus nested
+  // agent, messages, and runs (each with its tool-call requests).
+  const userName = detail?.userId || 'User'
+  // The master does not guarantee message order; sort by the (zero-padded) sequence id.
+  const messages = [...(detail?.messages || [])].sort(
+    (a: any, b: any) => String(a.messageSeqId).localeCompare(String(b.messageSeqId)))
+  for (const msg of messages) {
     if (msg.role === 'user') {
       items.push({ id: `msg-${msg.messageSeqId}`, type: 'message', userName, content: msg.content })
     } else if (msg.role === 'assistant') {
-      if (msg.toolCalls?.length) {
+      // toolCalls is stored as a JSON string; the backend no longer pre-parses it, so parse here.
+      let toolCalls: any[] = []
+      if (msg.toolCalls) { try { toolCalls = JSON.parse(msg.toolCalls) } catch { toolCalls = [] } }
+      if (toolCalls.length) {
         // Key by position, not toolCall.id: the id is provider-supplied and not guaranteed present, so two
         // calls on one message could otherwise collapse to duplicate Vue keys (`tc-5-undefined`).
-        msg.toolCalls.forEach((toolCall: any, index: number) => {
+        toolCalls.forEach((toolCall: any, index: number) => {
           items.push({ id: `tc-${msg.messageSeqId}-${index}`, type: 'toolCall', toolName: toolCall.name,
             args: JSON.stringify(toolCall.arguments ?? {}, null, 2) })
         })
@@ -35,14 +43,20 @@ function toChatItems(detail: any): ChatItem[] {
     }
     // role 'tool' results are not rendered as bubbles; the tool-call card carries the action
   }
-  for (const req of detail?.pendingRequestList || []) {
+  // Pending-approval cards + any error bubble come from the latest run (master nests runs -> requests).
+  const runs: any[] = detail?.runs || []
+  const latestRun = runs.length
+    ? runs.reduce((a: any, b: any) => ((b.startedDate || 0) > (a.startedDate || 0) ? b : a))
+    : null
+  const pendingRequests = (latestRun?.toolCallRequests || []).filter((r: any) => r.statusId === 'AI_TCREQ_PENDING')
+  for (const req of pendingRequests) {
     let args = req.arguments
     try { args = JSON.stringify(JSON.parse(req.arguments), null, 2) } catch { /* keep raw string */ }
     items.push({ id: `perm-${req.toolCallRequestId}`, type: 'permission', permissionId: req.toolCallRequestId,
       toolName: req.toolName, message: `${req.toolName}\n${args}` })
   }
-  if (detail?.latestRun?.errorText && ['AI_RUN_FAILED', 'AI_RUN_ABORTED', 'AI_RUN_TRUNCATED'].includes(detail?.latestRun?.statusId)) {
-    items.push({ id: `err-${detail.latestRun.agentRunId}`, type: 'agentMessage', content: detail.latestRun.errorText })
+  if (latestRun?.errorText && ['AI_RUN_FAILED', 'AI_RUN_ABORTED', 'AI_RUN_TRUNCATED'].includes(latestRun?.statusId)) {
+    items.push({ id: `err-${latestRun.agentRunId}`, type: 'agentMessage', content: latestRun.errorText })
   }
   return items
 }


### PR DESCRIPTION
Pairs with **hotwax/moqui-ai `feat/ai-entity-master-reads`**, where the agent + conversation reads moved from bespoke services to the entity engine (masters). This updates the PWA to the new response shapes.

## What changed
- **composer `syncGrants`**: `GET /agents/{id}` now returns the `AiAgent` 'detail' master — read `grants` (each grant has `toolId` + `requiresApprovalOverride`) instead of `toolList`, and top-level `statusId` instead of `agent.statusId`.
- **workforce `toChatItems`**: `GET /conversations/{id}` now returns the `AiConversation` 'detail' master — conversation fields are top-level (`userId`); messages live under `messages` (sorted by `messageSeqId`); `message.toolCalls` is a raw JSON string the client parses; the latest run + its PENDING tool-call requests are derived from `runs` (each nesting `toolCallRequests`).

`Workforce.vue`'s `detail.agent.agentName` is unchanged (the master nests `agent`).

## Notes
- **Stacked on #161** (`feat/agent-ux-wiring`): base is set to that branch so the diff shows only this work. Re-target to `main` once #161 merges.
- Does not touch #161.