### PR TITLE
Add product store onboarding preview shell

### DIFF
--- a/docs/product-store-onboarding-discovery-flow.md
+++ b/docs/product-store-onboarding-discovery-flow.md
@@ -1,0 +1,517 @@
+# Product Store Onboarding Discovery Flow
+
+## Purpose
+
+Model product store onboarding after a HotWax discovery conversation. The user should answer business process questions, and the app should translate those answers into the product store settings that matter while skipping irrelevant settings.
+
+This is a working discovery log. It is intended to become a Mermaid flow diagram later.
+
+## Discovery Questions
+
+### 1. Solution Interest
+
+**Question**
+
+What solutions are you most interested in?
+
+**Answer choices**
+
+- Order routing
+- Ship from Store
+- Buy online pickup in store
+- Store Inventory Management
+- Pre-orders
+
+**Intent**
+
+Identify which HotWax operating capabilities are relevant before asking configuration questions. This should control which follow-up sections appear in onboarding.
+
+**Configuration direction**
+
+- Order routing should lead into routing, brokering, fulfillment source, and order approval questions.
+- Ship from Store should lead into facility fulfillment, inventory reservation, rejection, packing, and fulfillment notification questions.
+- Buy online pickup in store should lead into BOPIS, pickup rejection, pickup readiness, and customer pickup-change questions.
+- Store Inventory Management should lead into inventory visibility, inventory count, reservation, and systemic QOH questions.
+- Pre-orders should lead into preorder inventory holding, preorder facility groups, split behavior, and release behavior questions.
+
+**Notes**
+
+- This should likely be multi-select.
+- The app should not expose unrelated setting categories after this answer.
+- The selected solutions should create a tailored onboarding path and a clear summary of skipped areas.
+
+## Cold-Start Setup Backbone
+
+This section pivots from value discovery to setup discovery. Assume a new Shopify retailer is onboarding into a cold-start HotWax/Moqui instance where backend seed data exists, but retailer-specific operating data does not.
+
+### Absolutely Required Before Any Solution Works
+
+These are the minimum setup areas that must exist before Order Routing, Ship from Store, BOPIS, Store Inventory Management, or Pre-orders can be useful.
+
+| Setup area | Why it is required | App should ask | Configuration/output |
+| --- | --- | --- | --- |
+| Organization identity | Product stores need a company/pay-to organization context. | What is your company or retail brand name? | Organization record, `ProductStore.companyName`, `ProductStore.payToPartyId` |
+| Product store identity | Every solution is scoped to a product store. | What Shopify storefront or retail brand is this HotWax store for? | `ProductStore.productStoreId`, `storeName`, `defaultCurrencyUomId`, `orderNumberPrefix` |
+| Shopify connection | Shopify is the sales channel, even if credentials are added later. | Is Shopify connected now, or should this store be prepared for Shopify later? | `ShopifyShop`, `ShopifyShop.productStoreId`, SystemMessage remote if connected |
+| Facilities | Routing, fulfillment, pickup, inventory, and preorder need places. | What physical locations are in scope: stores, warehouses, hubs, or pickup locations? | Facility records, facility groups, product-store/facility relationships |
+| Shopify location mapping | Shopify locations must line up with HotWax facilities for inventory and fulfillment. | Which Shopify location maps to each HotWax facility? | Shopify location mapping records |
+| Product identity | Orders, inventory, scanning, and product sync need a stable identifier. | What identifier is reliable across Shopify and stores: SKU, UPC/barcode, variant ID, or another ID? | `productIdentifierEnumId`, `PRDT_IDEN_PREF`, `BARCODE_IDEN_PREF` if needed |
+| Inventory source | Store Inventory, routing, SFS, BOPIS, and preorder all depend on available quantity. | Where will HotWax get inventory quantities from? | Inventory import/source setup, inventory jobs, facility-level QOH |
+| Users and roles | Store operations need people with app access. | Which teams will use HotWax: store associates, managers, inventory, fulfillment, admins? | Security groups/permissions by app and task |
+| Service jobs and sync cadence | Shopify and inventory flows need scheduled or event-driven jobs. | Which syncs should run automatically and how often? | Product-store-scoped service jobs, Shopify jobs, inventory/order/fulfillment jobs |
+
+### Setup Order
+
+1. Create or confirm organization identity.
+2. Create Product Store identity.
+3. Connect or reserve a future Shopify connection.
+4. Create/import facilities.
+5. Map Shopify locations to HotWax facilities.
+6. Choose product identity and barcode identity.
+7. Load or schedule product and inventory data.
+8. Enable selected solution modules.
+9. Assign users/roles.
+10. Review settings, mappings, and required follow-up setup.
+
+### Solution Setup: Order Routing
+
+**Setup questions**
+
+1. Which locations can fulfill online orders: stores, warehouses, hubs, or selected groups?
+2. Should HotWax route automatically, or should orders start in review?
+3. What should routing optimize for: available inventory, proximity, fulfillment capacity, warehouse priority, or product rules?
+4. Are there products that should route only to specific location types?
+5. Can an order be split across multiple locations?
+6. What should happen if the selected location rejects or cannot fulfill?
+
+**Settings and setup touched**
+
+| Area | Configuration/output |
+| --- | --- |
+| ProductStore | `enableBrokering`, `allowSplit`, `reserveInventory`, `checkInventory`, possibly `requireInventory` |
+| ProductStoreSetting | `PRE_SLCTD_FAC_TAG`, `ORD_ITM_SHIP_FAC`, `ORD_ITM_SHIP_METH`, possible exception settings |
+| Setup outside ProductStore | Facility groups, routing rules, product/facility eligibility, routing jobs |
+
+### Solution Setup: Ship From Store
+
+**Setup questions**
+
+1. Which stores are allowed to ship online orders?
+2. Do stores need HotWax to show assigned shipping orders?
+3. Should store teams scan items before packing or shipping?
+4. Should stores print picklists, packing slips, and shipping labels?
+5. Should HotWax send fulfillment notifications back to Shopify?
+6. What should happen when a store rejects an item or cannot fulfill the full order?
+
+**Settings and setup touched**
+
+| Area | Configuration/output |
+| --- | --- |
+| ProductStore | `enableBrokering`, `reserveInventory`, `allowSplit` if multi-location fulfillment is allowed |
+| ProductStoreSetting | `SHOW_SHIPPING_ORDERS`, `FULFILL_NOTIF`, `FULFILL_FORCE_SCAN`, `FULFILL_PART_ODR_REJ`, `AFFECT_QOH_ON_REJ`, `REJ_ITM_CC_CRT`, `FF_COLLATERAL_REJ` |
+| Setup outside ProductStore | Store fulfillment permissions, carrier/shipment method mappings, label provider, Shopify fulfillment jobs |
+
+### Solution Setup: BOPIS
+
+**Setup questions**
+
+1. Which stores allow pickup?
+2. Does Shopify checkout already show pickup options, or should HotWax support pickup routing after order import?
+3. How does HotWax identify pickup orders: shipment method, Shopify delivery method, pickup facility property, or location mapping?
+4. Should stores print picklists or packing slips for pickup orders?
+5. Can customers change pickup location, delivery method, address, or cancel before fulfillment?
+6. What should happen if a pickup store partially rejects an order?
+
+**Settings and setup touched**
+
+| Area | Configuration/output |
+| --- | --- |
+| ProductStore | `enableBrokering`, `reserveInventory`, `checkInventory` |
+| ProductStoreSetting | `BOPIS_PART_ODR_REJ`, `DEFULT_PKG_BOPIS_ORD`, `SHOW_SHIPPING_ORDERS`, `PRINT_PACKING_SLIPS`, `PRINT_PICKLISTS`, `ENABLE_TRACKING`, `ORD_ITM_PICKUP_FAC`, customer self-service settings |
+| Setup outside ProductStore | Pickup facility mapping, Shopify pickup/location mapping, pickup shipment methods, BOPIS app permissions |
+
+### Solution Setup: Store Inventory Management
+
+**Setup questions**
+
+1. Which stores need inventory counts, receiving, transfers, or adjustments?
+2. What system currently owns inventory: Shopify, ERP, WMS, or HotWax?
+3. How will starting inventory be loaded?
+4. What product identifier do store teams scan?
+5. Should store teams see systemic quantity during counts?
+6. Who can approve adjustments, receive transfers, or resolve discrepancies?
+
+**Settings and setup touched**
+
+| Area | Configuration/output |
+| --- | --- |
+| ProductStore | `productIdentifierEnumId`, `inventoryFacilityId`, `oneInventoryFacility`, `reserveInventory` when online orders should hold stock |
+| ProductStoreSetting | `BARCODE_IDEN_PREF`, `RECEIVE_FORCE_SCAN`, possibly `EX_INV_BY_PRD_TYPE` |
+| Setup outside ProductStore | Facilities, inventory import jobs, transfer jobs, inventory count permissions, adjustment permissions |
+
+### Solution Setup: Pre-orders
+
+**Setup questions**
+
+1. How are preorder products identified: Shopify tag, product type, metafield, SKU list, or manual setup?
+2. Where should preorder inventory live: global pool, warehouse, store, or preorder facility group?
+3. Should HotWax hold physical inventory for preorders?
+4. Can preorder items split from in-stock items?
+5. How should preorder orders be released when inventory arrives?
+6. Should preorder routing use the same rules as normal orders or a separate routing group?
+
+**Settings and setup touched**
+
+| Area | Configuration/output |
+| --- | --- |
+| ProductStore | `allowSplit`, `reserveInventory` depending on preorder behavior |
+| ProductStoreSetting | `HOLD_PRORD_PHYCL_INV`, `PRE_ORDER_GROUP_ID`, `REL_PREORD_ROUGRP_ID`, possibly `EX_INV_BY_PRD_TYPE` |
+| Setup outside ProductStore | Preorder product identification, PO/inbound inventory source, preorder routing jobs, release jobs |
+
+### Settings Not Earned By Setup Questions
+
+Any product store fields or `ProductStoreSetting` IDs not touched by one of the selected solution setup flows should be left out of the guided onboarding path. They can remain available later in an advanced settings registry.
+
+## Topic Flow: Order Routing + Ship From Store
+
+This flow applies when the user selects:
+
+- Order routing
+- Ship from Store
+
+The goal is to discover how HotWax should route Shopify orders and whether stores participate as fulfillment locations.
+
+### 2. Routing Problems
+
+**Question**
+
+What routing problems are you trying to solve?
+
+**Answer choices**
+
+- Some products should only ship from warehouses
+- We want to ship from stores but protect safety stock
+- We do not use Shopify POS, and stores need a place to see online orders
+- We do not have warehouses
+- Something else
+
+**Intent**
+
+Capture the retailer's real routing pain before asking them to configure fulfillment behavior. These answers should decide which follow-up questions appear and which settings are even eligible for onboarding.
+
+**Settings and setup areas touched**
+
+| Routing problem | Settings touched | Setup area | Value direction |
+| --- | --- | --- | --- |
+| Products should only ship from warehouses | No product-store setting confirmed yet | Product/facility routing rules | Ask how warehouse-only products are identified |
+| Ship from stores with safety stock | No product-store setting confirmed yet | Inventory availability / routing safety stock rules | Ask whether safety stock is global, per store, or per product |
+| Stores need a place to see online orders without Shopify POS | `SHOW_SHIPPING_ORDERS` candidate | Store fulfillment app visibility | likely `true`, pending validation |
+| No warehouses | `enableBrokering`, `reserveInventory` | Store-only fulfillment network | likely `Y` for both if HotWax owns routing and inventory reservation |
+
+**Follow-up branches**
+
+- Warehouse-only products: ask how products are classified and whether the rule is product-level, product-type-level, or tag/category-driven.
+- Safety stock: ask whether the buffer is the same across all stores or varies by store/product.
+- No Shopify POS: ask whether store teams need HotWax to show only assigned shipping orders, all open online orders, or both.
+- No warehouses: skip warehouse fallback questions and focus on store eligibility, inventory reservation, and exception handling.
+- Something else: capture free-text notes and route to manual setup review.
+
+**Notes**
+
+- This question should likely appear immediately after the selected solutions, before detailed routing configuration.
+- Not every routing problem maps to a `ProductStore` field or `ProductStoreSetting`. Some should create setup requirements instead of flipping settings.
+- The onboarding summary should separate "settings configured" from "setup required outside product store settings."
+
+### 3. Fulfillment Network
+
+**Question**
+
+Where should HotWax look when deciding how to fulfill Shopify orders?
+
+**Answer choices**
+
+- Stores only
+- Warehouses only
+- Stores and warehouses
+- A specific set of stores or regions
+- Not sure yet
+
+**Intent**
+
+Determine whether routing/brokering should be enabled and whether the user needs location-group setup before routing can be configured confidently.
+
+**Settings touched**
+
+| Setting | Source | When touched | Value direction |
+| --- | --- | --- | --- |
+| `enableBrokering` | `ProductStore` | Stores only, stores and warehouses, or specific stores/regions | `Y` |
+| `enableBrokering` | `ProductStore` | Warehouses only | likely `N` unless routing is still needed across warehouses |
+| `PRE_ORDER_GROUP_ID` | `ProductStoreSetting` | Not touched in this topic | Leave out for this flow |
+
+**Follow-up branches**
+
+- If stores are included, continue to Ship from Store eligibility.
+- If only warehouses are included, skip most Ship from Store questions.
+- If specific stores or regions are selected, ask how locations should be grouped.
+- If the user said "we do not have warehouses," default this answer to stores only and do not ask warehouse fallback questions.
+- If not sure, keep routing as a pending recommendation instead of forcing settings.
+
+### 4. Ship From Store Eligibility
+
+**Question**
+
+Should every store be allowed to ship online orders, or only selected stores?
+
+**Answer choices**
+
+- Every store can ship online orders
+- Only selected stores can ship online orders
+- Stores can ship only for nearby customers
+- Stores should not ship online orders yet
+
+**Intent**
+
+Identify whether store fulfillment is globally enabled or needs a constrained fulfillment group/rule before orders can be routed to stores.
+
+**Settings touched**
+
+| Setting | Source | When touched | Value direction |
+| --- | --- | --- | --- |
+| `enableBrokering` | `ProductStore` | Any store shipping option except "not yet" | `Y` |
+| `ORD_ITM_SHIP_FAC` | `ProductStoreSetting` | Not touched by the basic answer | Ask later only if Shopify tags/properties preselect fulfillment locations |
+| `PRE_SLCTD_FAC_TAG` | `ProductStoreSetting` | Not touched by the basic answer | Ask later only if Shopify tags/properties preselect fulfillment locations |
+
+**Follow-up branches**
+
+- Every store can ship: continue to inventory reservation.
+- Only selected stores: capture a location group requirement before flipping detailed routing rules.
+- Nearby customers: mark routing strategy as distance/zone based; this likely needs a routing rule setup outside the product store settings alone.
+- Not yet: skip Ship from Store settings and record Ship from Store as future setup.
+
+### 5. Store Order Visibility
+
+**Question**
+
+Do store teams need HotWax to show them online orders to fulfill?
+
+**Answer choices**
+
+- Yes, because we do not use Shopify POS for store fulfillment
+- Yes, even though Shopify POS is also used
+- No, store teams already work from another system
+- Not sure yet
+
+**Intent**
+
+Determine whether HotWax needs to expose shipping orders directly to stores as part of the Ship from Store flow.
+
+**Settings touched**
+
+| Setting | Source | When touched | Value direction |
+| --- | --- | --- | --- |
+| `SHOW_SHIPPING_ORDERS` | `ProductStoreSetting` | Store teams need HotWax to show online shipping orders | likely `true`, pending runtime validation |
+| `SHOW_SHIPPING_ORDERS` | `ProductStoreSetting` | Store teams use another system | likely leave unset |
+
+**Follow-up branches**
+
+- If HotWax must show online orders, ask whether stores should only see orders assigned to them or also unassigned/open orders.
+- If another system is used, skip store-order visibility settings for onboarding.
+
+### 6. Inventory Reservation
+
+**Question**
+
+When Shopify orders are imported, should HotWax reserve store inventory before fulfillment?
+
+**Answer choices**
+
+- Yes, reserve inventory when the order is imported
+- No, only reduce inventory when fulfillment happens
+- Only reserve inventory for routed orders
+- Not sure yet
+
+**Intent**
+
+Decide whether HotWax should hold inventory against orders before fulfillment work starts.
+
+**Settings touched**
+
+| Setting | Source | When touched | Value direction |
+| --- | --- | --- | --- |
+| `reserveInventory` | `ProductStore` | Yes | `Y` |
+| `reserveInventory` | `ProductStore` | No | `N` |
+| `reserveInventory` | `ProductStore` | Only routed orders | Needs more validation; ProductStore field may be too broad |
+
+**Follow-up branches**
+
+- If reserve inventory is enabled, ask whether split/backorder behavior is allowed.
+- If inventory is not reserved, skip preorder holding and reservation-dependent questions for this topic.
+- If only routed orders, flag as a more advanced routing/inventory design rather than a simple product store setting.
+
+### 7. Safety Stock
+
+**Question**
+
+When routing to stores, should HotWax keep a safety-stock buffer so stores do not sell their last units online?
+
+**Answer choices**
+
+- Yes, use the same buffer for every store
+- Yes, but each store can have a different buffer
+- Yes, but buffer depends on the product
+- No safety-stock buffer
+- Not sure yet
+
+**Intent**
+
+Capture safety-stock requirements without pretending this is a simple product store setting. This is a routing/inventory availability requirement that should drive later setup.
+
+**Settings touched**
+
+| Setting | Source | When touched | Value direction |
+| --- | --- | --- | --- |
+| None confirmed | Product store settings | Any safety-stock answer | Do not flip a product store setting from this alone |
+
+**Follow-up branches**
+
+- Global buffer: capture the buffer quantity and mark as routing/inventory setup.
+- Store-specific buffer: require facility-level setup.
+- Product-specific buffer: require product/category-level setup.
+- No buffer: skip safety-stock setup.
+
+### 8. Warehouse-Only Product Rules
+
+**Question**
+
+How do you identify products that should only ship from a warehouse?
+
+**Answer choices**
+
+- Product type
+- Product tag/category
+- Specific SKU/product list
+- Shopify product data
+- Not sure yet
+
+**Intent**
+
+Identify whether warehouse-only routing can be modeled by product attributes, product groups, Shopify data, or manual lists.
+
+**Settings touched**
+
+| Setting | Source | When touched | Value direction |
+| --- | --- | --- | --- |
+| None confirmed | Product store settings | Warehouse-only product rules | Do not flip a product store setting from this alone |
+| `EX_INV_BY_PRD_TYPE` | `ProductStoreSetting` | Product type is used for inventory exclusion | Candidate only; validate whether the desired behavior is inventory sync exclusion or fulfillment routing |
+
+**Follow-up branches**
+
+- Product type: validate whether this means excluding inventory sync or restricting fulfillment routing.
+- Product tag/category or SKU list: create routing-rule setup requirements.
+- Shopify product data: ask which Shopify field is reliable.
+
+### 9. Order Splitting
+
+**Question**
+
+If one location cannot fulfill the full Shopify order, should HotWax split the order across locations?
+
+**Answer choices**
+
+- Yes, split orders across locations when needed
+- No, keep each order together at one location
+- Only split preorder or backorder items
+- Not sure yet
+
+**Intent**
+
+Determine whether partial location assignment is acceptable for the retailer's operations.
+
+**Settings touched**
+
+| Setting | Source | When touched | Value direction |
+| --- | --- | --- | --- |
+| `allowSplit` | `ProductStore` | Yes | `Y` |
+| `allowSplit` | `ProductStore` | No | `N` |
+| `allowSplit` | `ProductStore` | Only preorder/backorder items | Possibly `Y`, but should be paired with preorder flow questions |
+
+**Follow-up branches**
+
+- If splitting is allowed, ask how strict the shipment threshold should be.
+- If splitting is not allowed, skip shipment-threshold questions.
+- If only preorder/backorder items, defer final value until the Pre-orders topic flow.
+
+### 10. Shipment Split Threshold
+
+**Question**
+
+Should HotWax avoid splitting small orders unless the shipment value is above a minimum threshold?
+
+**Answer choices**
+
+- No threshold; split whenever routing recommends it
+- Use a minimum shipment value
+- Not sure yet
+
+**Intent**
+
+Control whether brokering should use a minimum shipment-value threshold before splitting.
+
+**Settings touched**
+
+| Setting | Source | When touched | Value direction |
+| --- | --- | --- | --- |
+| None confirmed | Product store settings | Minimum shipment value selected | Do not flip a product store setting from this alone |
+| `BRK_SHPMNT_THRESHOLD` | Removed product-store setting | Any answer | Do not present; local settings study says no supported runtime owner |
+
+**Follow-up branches**
+
+- If minimum value is selected, ask for the currency amount.
+- If no threshold, skip.
+
+### 11. Fulfillment Rejection
+
+**Question**
+
+If a store cannot fulfill an assigned order, what should happen?
+
+**Answer choices**
+
+- Route the order to another location
+- Cancel or reject the unavailable items
+- Send the order to manual review
+- Not sure yet
+
+**Intent**
+
+Understand exception handling for Ship from Store assignments. Some behavior may live outside product store settings, but this question determines whether rejection-related settings matter.
+
+**Settings touched**
+
+| Setting | Source | When touched | Value direction |
+| --- | --- | --- | --- |
+| `BOPIS_PART_ODR_REJ` | `ProductStoreSetting` | Not touched in Ship from Store unless pickup is also selected | Leave for BOPIS flow |
+| `FULFILL_PART_ODR_REJ` | Backend setting not currently in Company guided UI | If cancel/reject unavailable items | Candidate future setting, not currently in create flow |
+| `FULFILL_NOTIF` | `ProductStoreSetting` | Not decided by rejection alone | Ask in Shopify notification question |
+
+**Follow-up branches**
+
+- Route elsewhere: confirm brokering/rerouting behavior.
+- Cancel/reject items: include advanced exception handling settings if supported.
+- Manual review: route to order review/approval topic.
+
+## Settings Covered So Far
+
+| Setting | Covered by topic flow? | Notes |
+| --- | --- | --- |
+| `enableBrokering` | Yes | Order routing / Ship from Store |
+| `reserveInventory` | Yes | Inventory reservation for imported/routed orders |
+| `allowSplit` | Yes | Multi-location fulfillment and split behavior |
+| `SHOW_SHIPPING_ORDERS` | Candidate | Relevant when stores need HotWax to show online shipping orders |
+| `BRK_SHPMNT_THRESHOLD` | No | Removed from product-store settings; no supported runtime owner found |
+| `ORD_ITM_SHIP_FAC` | Conditional | Only if Shopify sends a selected ship facility property |
+| `PRE_SLCTD_FAC_TAG` | Conditional | Only if Shopify tags/properties preselect facility routing |
+| `EX_INV_BY_PRD_TYPE` | Candidate | Only if product-type inventory exclusion matches the warehouse-only-product problem |
+| `FULFILL_PART_ODR_REJ` | Candidate | Backend setting exists but is not part of current guided Company UI |
+| `BOPIS_PART_ODR_REJ` | No | Leave for BOPIS topic flow |
+| `PRE_ORDER_GROUP_ID` | No | Leave for Pre-orders topic flow |

--- a/docs/product-store-onboarding-rest-endpoint-gaps.md
+++ b/docs/product-store-onboarding-rest-endpoint-gaps.md
@@ -1,0 +1,504 @@
+# Product Store Onboarding REST Endpoint Gaps
+
+## Purpose
+
+Track REST endpoints needed for the product store onboarding/setup assistant. This is a running research document: each endpoint should stay marked as candidate, existing, gap, or needs more research until verified against the live backend and source REST files.
+
+The goal is to keep a simple list of backend APIs needed for setup flows, especially APIs that do not exist today or are not bounded enough for a self-serve onboarding UI.
+
+## Status Legend
+
+| Status | Meaning |
+| --- | --- |
+| Existing | A bounded REST endpoint exists today and appears suitable. |
+| Gap | No suitable bounded REST endpoint found yet. |
+| Candidate | A possible endpoint exists, but payload, semantics, or ownership need validation. |
+| Composite | The setup action spans multiple existing endpoints and may need a purpose-built orchestration endpoint. |
+| Defer | Too complex to define as a single endpoint yet; needs separate breakdown. |
+
+## Endpoint Inventory
+
+### 1. Update Product Store Entity
+
+| Field | Value |
+| --- | --- |
+| Status | Existing |
+| Existing endpoint | `PUT /rest/s1/admin/productStores/{productStoreId}` |
+| Source evidence | `hotwax-maarg-util/service/admin.rest.xml` has `admin/productStores/{productStoreId}` with `put` on `ProductStore`. Company app already calls `admin/productStores/${productStoreId}`. |
+| Notes | This covers raw ProductStore field updates. Guided setup should group fields by topic in the UI and write through this endpoint; do not add feature-specific ProductStore update endpoints. |
+
+### 2. Generate OMS JWT Token For App Handoff
+
+| Field | Value |
+| --- | --- |
+| Status | Candidate |
+| Existing current-user auth endpoint | `POST /rest/s1/admin/login` |
+| Existing backend primitives | `co.hotwax.auth.JWTManager.createJwt(...)`; deprecated helper `co.hotwax.util.MaargUtil.getOmsJwtToken(...)`; `OmsRestServiceRunner` also signs OMS REST calls with this JWT manager. |
+| OFBiz precedent | `generateJwtToken` service plus `CreateJwtToken` screen creates long-lived JWTs for integration users; `CommerceAuthEvents.goToLaunchpad` creates short-lived current-user handoff tokens. |
+| Proposed endpoint | `POST /rest/s1/admin/jwtTokens` |
+| Purpose | Generate a general OMS/Maarg JWT directly from Moqui for an integration/service user. This should not call OFBiz REST and should not be owned by the Shopify bridge. |
+| Draft payload | `subjectUserLoginId`, `expireIn`, `purpose`, `category`; default `category` should probably be `INTEGRATION` for integration-user tokens. |
+| Notes | The original wording "Shopify app token" was misleading. If the UI only needs to launch another browser app as the current user, no new minting endpoint is needed; use the current Moqui token from `admin/login`/`commonUtil.getToken()`. If onboarding needs a server-side credential for Nifi, Shopify, MDM, or another integration, create a Moqui-native admin/auth REST wrapper around `JWTManager.createJwt(...)` and permission it like OFBiz `JWT_TOKEN_CREATE`. |
+
+### 3. Update Shopify Shop Type Table
+
+| Field | Value |
+| --- | --- |
+| Status | Existing |
+| Existing endpoints | `GET /rest/s1/oms/shopifyShops/typeMappings`, `POST /rest/s1/oms/shopifyShops/typeMappings` |
+| Source evidence | Company app reads and stores mappings through `oms/shopifyShops/typeMappings`; OMS REST exposes GET list and POST `store` for `ShopifyShopTypeMapping`. |
+| Notes | No new endpoint appears necessary. The POST is a `store` operation, so onboarding can reuse the current table-mapping contract instead of adding `PUT /typeMappings/{mappingId}`. If a mapping key changes, the existing UI pattern is replace-by-delete-and-store rather than partial update. |
+
+### 4. Update Shopify Shop Read And Write Access
+
+| Field | Value |
+| --- | --- |
+| Status | Existing primitive |
+| Existing endpoint | `PUT /rest/s1/oms/systemMessageRemotes/{systemMessageRemoteId}` |
+| Existing read endpoint | `GET /rest/s1/oms/systemMessageRemotes` |
+| Owner | `moqui.service.message.SystemMessageRemote.accessScopeEnumId` |
+| Purpose | Update Shopify read/write access state for the Shopify remote tied to a shop. |
+| Notes | Active Shopify access scope is managed on `SystemMessageRemote`, not on `ShopifyShop`. `ShopifyShop` has no `accessScopeEnumId`. `ShopifyConfig.accessScopeEnumId` exists in the older/config model and appears through `ShopifyShopAndConfig`, but the current Shopify remote setup and runtime write-access checks use `SystemMessageRemote.accessScopeEnumId`. Onboarding can use the existing system-message-remote update endpoint if it has resolved the correct remote. A shop-level wrapper is only needed if we want the backend to resolve the remote from `shopId` and prevent updating unrelated remote fields. |
+
+### 5. Create Facility
+
+| Field | Value |
+| --- | --- |
+| Status | Existing |
+| Existing endpoint | `POST /rest/s1/admin/facilities` |
+| Source evidence | `hotwax-maarg-util/service/admin.rest.xml` has `admin/facilities` POST on `Facility`. |
+| Notes | This creates the base facility. Full onboarding may also need address, facility roles, facility/product-store association, Shopify location mapping, and facility group membership. |
+
+### 6. Import/Create Facilities CSV From MDM
+
+| Field | Value |
+| --- | --- |
+| Status | Existing |
+| Existing upload endpoint | `POST /rest/s1/admin/uploadDataManagerFile` |
+| Required upload fields | Multipart `contentFile`, `configId=<facility-import DataManagerConfig>` |
+| Companion endpoints | `GET /rest/s1/admin/dataManager`, `GET /rest/s1/admin/dataManager/{configId}`, `GET /rest/s1/admin/dataManager/{configId}/downloadTemplate`, `GET /rest/s1/admin/dataManager/details` |
+| Notes | Do not add a bespoke `admin/mdm/facility-imports` endpoint. Company should clone the Job Manager manual upload flow and scope the available configs to the facility-import task. The remaining work is identifying the correct facility import `configId`, required CSV columns, and any optional `parameters` needed by the import service. |
+
+### 7. Upload Inventory Reset To MDM
+
+| Field | Value |
+| --- | --- |
+| Status | Gap |
+| Existing upload endpoint | `POST /rest/s1/admin/uploadDataManagerFile` |
+| Existing merged Moqui reset primitive | `co.hotwax.poorti.FulfillmentServices.create#ExternalInventoryReset` exists in `hotwax-poorti` and creates `ExternalInventoryReset` plus an `InventoryItemDetail` diff after resolving the facility/product inventory item. Current `origin/main` shape requires `externalATP`, `externalQOH`, and `unitCost`. |
+| Branch-only generic reset candidate | `origin/netsuite-external-inventory-reset` in `hotwax-poorti` adds `co.hotwax.poorti.FulfillmentServices.reset#InventoryItem` and improves `create#ExternalInventoryReset` to accept exactly one of `externalATP` or `externalQOH`, validate a reason, skip no-op resets, and link `resetItemId`/`reasonEnumId` onto the inventory detail. This branch is not merged to `origin/main`. |
+| Existing merged DataManager precedent | `mantle-netsuite-connector` has `DataManagerConfig configId="STORE_INV_RESET"` pointing to `co.hotwax.netsuite.InventoryServices.process#ExternalInventoryReset`. This is NetSuite-specific: it reads a NetSuite reset/import row and records variance data in `co.netsuite.integration.NetsuiteInventoryReset`; it does not provide a generic Shopify/OMS inventory reset file import. |
+| Missing generic DataManager config | Need a generic Moqui `DataManagerConfig` for onboarding inventory reset, likely reusing the Poorti reset primitive instead of the NetSuite-specific service. No generic `RESET_INVENTORY` or Shopify-ready reset config was found in `oms`, `hotwax-maarg-util`, `hotwax-poorti`, or `hotwax-shopify-oms-bridge`. |
+| Missing generic file import wrapper | Need a file-consuming service that maps CSV rows to product/facility identity and calls the generic reset service. The likely target should be the branch-style `reset#InventoryItem` contract, or an equivalent merged version of `create#ExternalInventoryReset` that supports QOH-only resets. |
+| Existing lower-level Moqui primitives | `co.hotwax.oms.product.ProductServices.findOrCreate#FacilityInventoryItem`, `co.hotwax.oms.product.InventoryServices.create#InventoryItemDetail`, and `co.hotwax.oms.product.InventoryServices.update#InventoryItemFromDetail` remain the low-level building blocks. |
+| Legacy OFBiz precedent | Old OFBiz OMS has `RESET_INVENTORY` -> `resetInventoryByIdentification`, where `resetByATP=false` dispatches to `resetInHandInventory`. This is not a Moqui OMS endpoint/config. |
+| Required upload fields | TBD after choosing the generic reset service shape. Likely fields: external facility id or facility id, product identity type/value or product id, reset quantity, reset mode (`QOH` for onboarding), reason, and optional description/import id. |
+| Companion endpoints | `GET /rest/s1/admin/dataManager/{configId}/downloadTemplate`, `GET /rest/s1/admin/dataManager/details`, `GET /rest/s1/admin/dataManager/downloadDataManagerFile` |
+| Notes | Do not add a bespoke `admin/mdm/inventory-resets` endpoint for CSV upload. The onboarding UI should present inventory reset as a task-specific wrapper over the generic DataManager upload/log schema, with guardrails in UI copy, config selection, and confirmation. Backend work is still needed to merge/finish the generic reset service shape and seed a generic file-consuming DataManager config. |
+
+### 8. Import Inventory From Shopify And Reset OMS
+
+| Field | Value |
+| --- | --- |
+| Status | Composite |
+| Candidate Shopify source | Admin GraphQL `bulkOperationRunQuery` over `inventoryItems { inventoryLevels { quantities } }` |
+| Proposed orchestration endpoint | `POST /rest/s1/shopify/shops/{shopId}/inventory/reset-file-from-shopify` |
+| Implementation pattern | Mirror the product import bulk-operation pattern: produce a Shopify bulk-query system message, send through the shared bulk-operation sender, poll the exact Shopify bulk operation id, then continue into file processing/DataManager import. |
+| Purpose | Pull Shopify inventory in bulk, transform it into the OMS inventory reset CSV shape, and then feed the file into the generic DataManager upload/log flow. |
+| Reset quantity | Use Shopify `on_hand`. The goal is to load physical on-hand stock into OMS, then let HotWax ATP, safety stock, and routing rules calculate sellable inventory. |
+| Notes | This should not be modeled as a raw file upload from the user, but the output should still become a normal DataManager inventory reset file/log. Needs careful semantics: source shop, product store, Shopify location-to-OMS facility mapping, SKU/product mapping, dry run, irreversible-write confirmation, and suppression of outbound Shopify inventory echo if `ExternalInventoryReset` creation triggers Shopify bridge SECAs. |
+
+#### Shopify Bulk Inventory Export Candidate
+
+Shopify Admin GraphQL bulk operations can fetch inventory asynchronously as JSONL. The validated candidate query shape is:
+
+```graphql
+mutation StartInventoryResetExport {
+  bulkOperationRunQuery(
+    groupObjects: false
+    query: """
+    {
+      inventoryItems(first: 250) {
+        edges {
+          node {
+            id
+            legacyResourceId
+            sku
+            tracked
+            inventoryLevels(first: 250) {
+              edges {
+                node {
+                  id
+                  location {
+                    id
+                    name
+                    legacyResourceId
+                  }
+                  quantities(names: ["available", "on_hand", "committed", "reserved", "incoming", "safety_stock"]) {
+                    name
+                    quantity
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+  ) {
+    bulkOperation {
+      id
+      status
+    }
+    userErrors {
+      field
+      message
+    }
+  }
+}
+```
+
+The runtime should follow the same pattern as Shopify product import:
+
+1. Create/queue an inventory bulk-query system message for the shop.
+2. Let the shared Shopify bulk-operation sender submit the `bulkOperationRunQuery` when Shopify has an open bulk-operation slot.
+3. Store the Shopify bulk operation id on the Moqui system message, the same way product import tracks the remote bulk operation.
+4. Poll the exact operation with `bulkOperation(id: ...)`, not a generic `currentBulkOperation` lookup.
+5. When Shopify returns the JSONL URL, transform each inventory item/location row into the inventory reset CSV.
+6. For each row, use the `on_hand` quantity as the reset quantity.
+7. Submit the generated file through `POST /rest/s1/admin/uploadDataManagerFile` with the inventory reset `configId`, so the result is a normal DataManager log with imported/error files.
+
+### 9. Download MDM Template Files
+
+| Field | Value |
+| --- | --- |
+| Status | Existing |
+| Existing endpoints | `GET /rest/s1/admin/dataManager`, `GET /rest/s1/admin/dataManager/{configId}`, `GET /rest/s1/admin/dataManager/{configId}/downloadTemplate` |
+| Source evidence | `hotwax-maarg-util/service/admin.rest.xml` has DataManager config list/detail plus `admin/dataManager/{configId}/downloadTemplate`. Job Manager uses the same template endpoint from `ImportDetail.vue`. |
+| Notes | No template-download endpoint gap. Company should expose a friendly onboarding task catalog that maps each task to the correct DataManager `configId`, then call the generic template endpoint. |
+
+### 10. Create User And Associate To Security Group
+
+| Field | Value |
+| --- | --- |
+| Status | Gap |
+| Proposed endpoint | `POST /rest/s1/admin/users/setup` |
+| Purpose | Create user, attach security groups, and optionally associate facilities/product stores in one setup-safe call. |
+| Notes | Old Users app uses legacy `service/*` calls and `performFind`; this onboarding flow should use bounded REST. Need payload for user profile, login, groups, facility roles, product store roles, and invitation/reset-password behavior. |
+
+### 11. Import Users From CSV
+
+| Field | Value |
+| --- | --- |
+| Status | Existing |
+| Existing upload endpoint | `POST /rest/s1/admin/uploadDataManagerFile` |
+| Required upload fields | Multipart `contentFile`, `configId=<user-import DataManagerConfig>` |
+| Companion endpoints | `GET /rest/s1/admin/dataManager/{configId}/downloadTemplate`, `GET /rest/s1/admin/dataManager/details`, `GET /rest/s1/admin/dataManager/downloadDataManagerFile` |
+| Notes | Do not add `admin/users/imports` for CSV upload. User CSV import should be another curated DataManager upload task. The remaining work is confirming the user import config, required role/security-group columns, duplicate behavior, and whether facility/product-store associations can be handled by the import service or need a post-import setup step. |
+
+### 12. Clone Order Routing To Product Store
+
+| Field | Value |
+| --- | --- |
+| Status | Defer |
+| Candidate existing endpoint | `POST /rest/s1/order-routing/routings/{orderRoutingId}/clone` |
+| Proposed onboarding endpoint | `POST /rest/s1/admin/productStores/{productStoreId}/orderRouting/clone` |
+| Notes | Existing order-routing clone is not necessarily product-store onboarding ready. Need break down source routing selection, target product store scoping, rule/action/filter copying, schedule/jobs, and conflict behavior. |
+
+### 13. Copy ATP Rules
+
+| Field | Value |
+| --- | --- |
+| Status | Defer |
+| Proposed endpoint | `POST /rest/s1/admin/productStores/{productStoreId}/atpRules/clone` |
+| Notes | Needs separate breakdown. Must identify source app/API ownership in Available to Promise, rule groups, inventory channels, facility groups, and product-store scope. |
+
+### 14. Setup Shopify Jobs
+
+| Field | Value |
+| --- | --- |
+| Status | Composite |
+| Existing endpoints | `GET/POST/PUT /rest/s1/admin/serviceJobs`, `POST /rest/s1/admin/serviceJobs/{jobName}/clone` |
+| Existing webhook primitive | `co.hotwax.shopify.webhook.ShopifyWebhookServices.create#WebhookSubscription` can create Shopify webhook subscriptions and accepts an EventBridge ARN as the `endPoint`/`uri`. Company has precedent for `shopify/webhook-subscription` calls in product sync, but the order onboarding wrapper still needs to accept and validate the destination ARN. |
+| Existing setup precedent | `hotwax-shopify-oms-bridge/screen/ShopifyOmsBridge/ShopifyOrderIntegrationSetup.xml` is Purushottam's Moqui setup screen. It checks integration health, updates AWS SQS credentials, edits/clones fallback and history jobs, subscribes webhooks, and shows manual AWS setup instructions. It does not provision AWS EventBridge/SQS resources. |
+| Proposed umbrella endpoint | `POST /rest/s1/admin/productStores/{productStoreId}/shopifyJobs/setup` |
+| Notes | Existing service-job CRUD/clone exists. Onboarding needs task-oriented setup endpoints that know the draft job names, set `systemMessageRemoteId`/queue parameters safely, validate access scopes, and activate only the selected job families. |
+
+#### Shopify Job Families
+
+This onboarding area should help a Shopify retailer clone and configure only the draft jobs they selected:
+
+1. Sync Shopify sales orders into HotWax.
+2. Sync HotWax inventory to Shopify.
+3. Configure Amazon EventBridge/SQS so Shopify order events can be imported in near real time.
+
+| Job family | Proposed endpoint | Status | Current primitives | Setup writes |
+| --- | --- | --- | --- | --- |
+| Shopify sales order sync, fallback/batch | `POST /rest/s1/admin/productStores/{productStoreId}/shopifyJobs/orderImport/setup` | Gap wrapper over existing jobs | Draft job `queue_ShopifyOrderSync` queues `ShopifyOrderSync` messages. Draft job `sync_ShopifyOrderHistory` uses `BULK_ORDER_HISTORY`. Both eventually stage orders through the same DataManager order import path. | Clone draft jobs to the selected shop/product store, set `systemMessageRemoteId`, set schedule/cadence, set launch/history dates, ensure `SYNC_SHOPIFY_ORDER`, `UPDATE_SHOPIFY_ORDER`, and `BULK_ORDER_HISTORY` DataManager configs exist, then optionally unpause. |
+| Shopify sales order sync, realtime SQS | `POST /rest/s1/admin/productStores/{productStoreId}/shopifyJobs/orderImport/realtimeSqs/setup` | Gap wrapper plus possible AWS provisioning gap | Existing consumer job `consume_ShopifyOrders_SQS` calls `co.hotwax.shopify.order.SqsOrderImport.consume#SQSOrderMessages`. It reads EventBridge messages from SQS, resolves the Shopify remote from the message shop domain, stages orders, and deletes consumed messages. | Decide whether to use one instance-wide consumer job or clone one per shop. Store AWS SQS connection in `SystemMessageRemote` such as `AWS_CONFIG`, set `queueName` and `systemMessageRemoteId` on the consumer job, create Shopify webhook subscriptions for order topics using the EventBridge ARN, then unpause after validation. |
+| Inventory sync to Shopify | `POST /rest/s1/admin/productStores/{productStoreId}/shopifyJobs/inventoryToShopify/setup` | Gap wrapper over existing bridge behavior | Draft job `resetShopifyInventoryQoh` queues `ResetInventoryQoh`. Inventory SECAs in the Shopify bridge post inventory updates only when `ProductStoreSetting SHOPIFY_INV_SYNC=Y`. The bridge service uses Shopify `inventorySetQuantities` with `name=on_hand`. | Clone/configure `resetShopifyInventoryQoh`, set `systemMessageRemoteId`, enable `ProductStoreSetting SHOPIFY_INV_SYNC=Y`, validate Shopify `write_inventory` access, validate `ShopifyShopLocation` mappings, and confirm HotWax is intended to be the inventory source of truth before unpausing. |
+| Inventory import from Shopify to reset OMS | `POST /rest/s1/shopify/shops/{shopId}/inventory/reset-file-from-shopify` | Already tracked in section 8 | This is not the same as syncing HotWax inventory to Shopify. It should run a Shopify bulk operation, transform Shopify `on_hand` into an OMS inventory reset file, and feed the generic DataManager reset flow. | Keep this separate from `inventoryToShopify/setup` so first-time setup does not accidentally echo Shopify-sourced reset quantities back to Shopify. |
+
+#### Realtime Order Import: Shopify EventBridge + AWS SQS
+
+Current backend reality:
+
+- Moqui already has an SQS consumer path for Shopify order events: `consume_ShopifyOrders_SQS` -> `co.hotwax.shopify.order.SqsOrderImport.consume#SQSOrderMessages`.
+- `AwsSqsTool` can validate and consume SQS queues using an AWS access key, secret, and SQS URL stored on `SystemMessageRemote`.
+- `ShopifyWebhookServices.create#WebhookSubscription` can register an EventBridge ARN as the Shopify webhook destination.
+- No current Moqui code was found that creates AWS partner event buses, SQS queues, EventBridge rules, targets, queue policies, or DLQs.
+
+Recommended onboarding shape for v1:
+
+| Mode | What user provides | What HotWax validates/does | Why |
+| --- | --- | --- | --- |
+| Assisted manual AWS setup | AWS region, AWS account id, EventBridge partner event source/bus ARN, SQS queue URL/name, SQS queue ARN, optional DLQ ARN, AWS access key/secret for SQS consume, selected Shopify order topics. | Validate SQS connectivity with `AwsSqsTool.canConnect`, register Shopify webhook subscription to the EventBridge ARN, configure/clone the consumer job, show a health checklist. | This matches what the backend can do today and avoids giving Moqui broad AWS resource-creation permissions before we design the security model. |
+| Fully automated AWS provisioning | AWS credentials or role with EventBridge/SQS management permissions, desired queue/rule names, region/account, selected Shopify order topics. | Create/associate partner event bus, create SQS/DLQ, create EventBridge rule, set SQS target, attach queue policy, store metadata, register Shopify webhook subscription, configure/clone jobs. | Cleaner UX later, but this is a real backend gap because current code only consumes SQS. |
+
+Fully automated provisioning would require a new AWS setup service, likely outside the Shopify bridge or in a narrow integration setup package. Minimum AWS actions to design around:
+
+| Area | Required capability |
+| --- | --- |
+| EventBridge partner source | The Shopify partner event source must be created/available for the AWS account, then associated to a partner event bus. Events sent before association are dropped by EventBridge. |
+| EventBridge management | `events:CreateEventBus` with `--event-source-name`, `events:DescribeEventSource`, `events:PutRule`, `events:PutTargets`, `events:DescribeRule`, `events:ListTargetsByRule`, plus cleanup actions if onboarding supports rollback. |
+| SQS management | `sqs:CreateQueue`, `sqs:GetQueueUrl`, `sqs:GetQueueAttributes`, `sqs:SetQueueAttributes`, and DLQ/redrive-policy management if we create a DLQ. |
+| SQS consume runtime | `sqs:ReceiveMessage`, `sqs:DeleteMessage`, `sqs:ChangeMessageVisibility`, `sqs:GetQueueAttributes`. These are the runtime permissions the Moqui consumer needs after setup. |
+| SQS target permission | The SQS queue policy must allow the EventBridge service principal `events.amazonaws.com` to call `sqs:SendMessage`, restricted by the EventBridge rule ARN using `aws:SourceArn`. |
+| Encryption | If the queue uses a customer-managed KMS key, the consumer needs `kms:Decrypt`; the producer path also needs the KMS permissions required for the service delivering to SQS. |
+| Shopify access | Webhook topics require Shopify app access scopes. For order import, start with `ORDERS_CREATE` and `ORDERS_UPDATED`; `ORDERS_CREATE` requires `read_orders` or `read_marketplace_orders`, while `ORDERS_UPDATED` can also require `read_buyer_membership_orders` depending on the selected scope model. |
+
+Candidate backend endpoints:
+
+| Endpoint | Status | Purpose |
+| --- | --- | --- |
+| `GET /rest/s1/admin/productStores/{productStoreId}/shopifyJobs/status` | Gap | Return selected shop, access scopes, draft job status, cloned job status, webhook subscriptions, AWS config health, SQS connectivity, and missing prerequisites. |
+| `POST /rest/s1/admin/productStores/{productStoreId}/shopifyJobs/cloneDrafts` | Gap | Clone only the requested draft job families to the shop/product store and set common parameters. |
+| `PUT /rest/s1/admin/productStores/{productStoreId}/shopifyJobs/orderImport` | Gap | Configure fallback/history order import jobs and dates. |
+| `PUT /rest/s1/admin/productStores/{productStoreId}/shopifyJobs/inventoryToShopify` | Gap | Configure outbound inventory sync job plus `SHOPIFY_INV_SYNC` setting after source-of-truth confirmation. |
+| `PUT /rest/s1/admin/productStores/{productStoreId}/shopifyJobs/realtimeOrders/awsSqs` | Gap | Store or validate AWS SQS connection, queue name, EventBridge ARN, order topics, and consumer-job parameters. |
+| `POST /rest/s1/admin/productStores/{productStoreId}/shopifyJobs/realtimeOrders/awsResources` | Future gap | Optional later endpoint to provision EventBridge/SQS resources if we decide Moqui should create AWS infrastructure. |
+| `POST /rest/s1/admin/productStores/{productStoreId}/shopifyWebhooks/orderImport` | Gap wrapper | Create/update Shopify order webhook subscriptions with an explicit EventBridge ARN destination and selected topics. |
+
+Product decision to keep explicit:
+
+- For self-serve onboarding, the cleanest v1 is assisted AWS setup plus validation. The user performs or pastes the AWS resources, and HotWax validates, stores, subscribes, and clones jobs.
+- Fully automated AWS creation is a separate backend feature. It needs IAM/credential design, resource naming, rollback behavior, DLQ policy, secret rotation, and audit before it should be exposed to users.
+- We should not merge "inventory from Shopify to reset OMS" with "inventory sync to Shopify". They are opposite directions and can create loops if the reset import triggers outbound inventory SECAs.
+
+### 15. Configure Product Store Fields And Settings By Topic
+
+| Field | Value |
+| --- | --- |
+| Status | Existing endpoints; UI/topic grouping work |
+| ProductStore endpoint | `PUT /rest/s1/admin/productStores/{productStoreId}` |
+| ProductStoreSetting endpoint | `POST /rest/s1/admin/productStores/{productStoreId}/settings` |
+| Existing grouping source | `src/views/AddConfigurations.vue` and `src/views/CloneProductStore.vue` already group ProductStore fields and ProductStoreSetting enum IDs by setup topic. If there is a separate canonical Markdown settings catalog, link it here when found. |
+| Notes | Do not create one backend endpoint per feature such as BOPIS, Ship from Store, Store Inventory Management, or Pre-orders. The backend already has the needed raw writes for this part. Onboarding should present curated topic groups, write ProductStore fields/settings through the existing endpoints, and leave untouched settings out of the flow. |
+
+#### Topic Groups
+
+| Topic | ProductStore fields | ProductStoreSetting enum IDs | UI implication |
+| --- | --- | --- | --- |
+| Order configurations | `autoApproveOrder`, `orderNumberPrefix` | `SAVE_BILL_TO_INF`, `RETURN_DEADLINE_DAYS` | Ask only the order-numbering and approval questions needed for the selected setup path. |
+| Brokering rules | `enableBrokering`, `allowSplit` | `PRE_SLCTD_FAC_TAG`, `ORD_ITM_SHIP_FAC`, `BRK_SHPMNT_THRESHOLD` | Present routing/brokering controls as a setup topic, not as a feature-specific REST contract. Revalidate whether every existing setting in this group should remain visible in guided onboarding. |
+| Fulfillment settings | `daysToCancelNonPay` | `FULFILL_NOTIF`, `BOPIS_PART_ODR_REJ` | Covers fulfillment notification behavior and BOPIS partial-rejection behavior when those flows are selected. |
+| Inventory settings | `reserveInventory` | `INV_CNT_VIEW_QOH`, `HOLD_PRORD_PHYCL_INV`, `PRE_ORDER_GROUP_ID` | Covers inventory reservation, store inventory visibility, and preorder inventory behavior. |
+| Product configurations | `productIdentifierEnumId` | `PRDT_IDEN_PREF` | Keep product identity setup as a first-class onboarding topic because downstream imports and Shopify mappings depend on it. |
+| Order edit permissions | None in current map | `CUST_DLVRMTHD_UPDATE`, `RF_SHIPPING_METHOD`, `CUST_DLVRADR_UPDATE`, `CUST_PCKUP_UPDATE`, `CUST_ALLOW_CNCL` | Present as customer/order-edit permissions; these are settings-only writes. |
+
+## Current Existing Endpoint Evidence
+
+These endpoints are currently known to exist and should not be listed as gaps unless the onboarding UI needs a stricter workflow wrapper.
+
+| Endpoint | Use |
+| --- | --- |
+| `GET /rest/s1/admin/productStores` | List product stores. |
+| `POST /rest/s1/admin/productStores` | Create product store. |
+| `GET /rest/s1/admin/productStores/{productStoreId}` | Read product store. |
+| `PUT /rest/s1/admin/productStores/{productStoreId}` | Update product store. |
+| `GET /rest/s1/admin/productStores/{productStoreId}/settings` | List product store settings. |
+| `POST /rest/s1/admin/productStores/{productStoreId}/settings` | Store product store setting. |
+| `POST /rest/s1/admin/facilities` | Create facility. |
+| `PUT /rest/s1/admin/facilities/{facilityId}` | Update facility. |
+| `POST /rest/s1/admin/facilityGroups` | Create facility group. |
+| `POST /rest/s1/admin/facilityGroups/{facilityGroupId}/facilities/{facilityId}/association` | Store facility group member association. |
+| `POST /rest/s1/admin/productStores/{productStoreId}/facilities/{facilityId}/association` | Store product-store facility association. |
+| `GET/POST/PUT /rest/s1/admin/serviceJobs` | Service job list/create/update. |
+| `POST /rest/s1/admin/serviceJobs/{jobName}/clone` | Clone service job. |
+| `GET /rest/s1/admin/dataManager` | List DataManager configs. |
+| `GET /rest/s1/admin/dataManager/{configId}` | Read one DataManager config. |
+| `POST /rest/s1/admin/uploadDataManagerFile` | Generic DataManager file upload. |
+| `GET /rest/s1/admin/dataManager/{configId}/downloadTemplate` | Download DataManager template. |
+| `GET /rest/s1/admin/dataManager/details` | Read DataManager log details, including imported/error content metadata and record counts. |
+| `GET /rest/s1/admin/dataManager/downloadDataManagerFile` | Download imported or error file content for a DataManager log. |
+| `GET/PUT/DELETE /rest/s1/admin/dataManager/logs/{logId}` | Read, update, or delete a DataManager log. |
+| `GET/POST /rest/s1/oms/shopifyShops/shops` | Shopify shop list/create. |
+| `PUT /rest/s1/oms/shopifyShops/shops/{shopId}` | Shopify shop update. |
+| `GET/POST /rest/s1/oms/shopifyShops/typeMappings` | Shopify type mapping list/store. |
+| `GET/POST /rest/s1/oms/shopifyShops/locations` | Shopify location mapping list/store. |
+| `GET/POST /rest/s1/oms/shopifyShops/carrierShipments` | Shopify shipping method/carrier mapping. |
+| `POST /rest/s1/admin/login` | Existing Maarg auth endpoint. Accepts username/password or an OMS JWT and returns the current app token, expiration time, and login key. |
+
+## Existing Backend Primitives Without Onboarding REST Wrappers
+
+These are not gaps in backend capability, but may still need bounded REST contracts before the onboarding UI can use them safely.
+
+| Capability | Existing owner | Onboarding implication |
+| --- | --- | --- |
+| JWT signing/validation | `hotwax-maarg-util` `co.hotwax.auth.JWTManager` | Do not reimplement in Shopify bridge. Add a small admin/auth wrapper only if users must generate an integration or app-handoff token from Company. |
+| OFBiz-style integration token creation | `hotwax-oms` `generateJwtToken` service and `CreateJWTToken.ftl` | Moqui should mirror this as an admin/auth endpoint if we need self-serve integration-token creation. |
+| App login with OMS JWT | `POST /rest/s1/admin/login` | If the token is only used to launch another HotWax app, the receiving app can exchange/accept the token through the existing login path. |
+
+## Generic DataManager File Upload Contract
+
+All onboarding file imports should use the same DataManager upload/log schema that Job Manager uses for manual uploads. Company should clone that flow instead of creating one-off REST endpoints for each CSV import.
+
+### Flow
+
+| Step | Endpoint | UI behavior |
+| --- | --- | --- |
+| Choose import task | `GET /rest/s1/admin/dataManager` or a curated local task-to-`configId` map | Show onboarding tasks such as facilities, inventory reset, or users instead of exposing raw config IDs. |
+| Read task config | `GET /rest/s1/admin/dataManager/{configId}` | Display the config description/script title and use it to label the task. |
+| Download template | `GET /rest/s1/admin/dataManager/{configId}/downloadTemplate` | Download the exact CSV template for the selected task. |
+| Upload file | `POST /rest/s1/admin/uploadDataManagerFile` | Send multipart form data with `contentFile`, `configId`, and optional `parameters`. The backend creates a pending `DataManagerLog` and returns `logId`. |
+| Track result | `GET /rest/s1/admin/dataManager/details?logId=...` or `?configId=...` | Poll or refresh log status, counts, and imported/error content metadata. |
+| Download files | `GET /rest/s1/admin/dataManager/downloadDataManagerFile?configId=...&logContentId=...` | Download the imported file or error file for a log. Company already has helpers for this in `useDataManagerLog`. |
+| Cancel/update log | `PUT /rest/s1/admin/dataManager/logs/{logId}` | Update `statusId`, such as canceling a pending log. Job Manager currently has a singular `log` path in its store, but the REST source defines `logs/{logId}`; verify the route before copying cancel behavior. |
+
+### Shared payload shape
+
+```text
+POST /rest/s1/admin/uploadDataManagerFile
+Content-Type: multipart/form-data
+
+contentFile=<csv file>
+configId=<DataManagerConfig.configId>
+parameters=<optional task-specific parameter map/list>
+```
+
+Backend behavior comes from `co.hotwax.util.UtilityServices.upload#DataManagerFile`: it verifies the config exists, stores the file under `runtime://datamanager/imported/{configId}`, creates a `DataManagerLog` with `statusId=DmlsPending`, links imported file content, stores optional parameters, and returns `logId`.
+
+### Company onboarding implication
+
+The Company app needs a reusable "DataManager upload task" UI, not new REST endpoints. Each onboarding section should supply:
+
+- Task label and description.
+- `configId`.
+- Template download action.
+- Upload action.
+- Recent log/progress panel.
+- Error-record download and review action.
+- Optional parameters required by that import service.
+
+The current backend gap is only the curated mapping of onboarding tasks to the correct DataManager configs and required parameters. If a needed config is missing from seed data, that is a seed/config gap, not a new upload endpoint gap.
+
+## Moqui-Native JWT Token Issuance Spec
+
+Use this spec for `POST /rest/s1/admin/jwtTokens` if onboarding needs to create an integration token without sending the user to OFBiz.
+
+### Required distinction
+
+| Use case | Endpoint | Behavior |
+| --- | --- | --- |
+| Current user signs into Company or another HotWax app | `POST /rest/s1/admin/login` | Existing endpoint. Accepts username/password or a valid OMS JWT and returns a current-user token, expiration time, and login key. |
+| Admin creates a long-lived token for an integration/service user | `POST /rest/s1/admin/jwtTokens` | New endpoint. Authenticated admin action that signs a JWT directly in Moqui for a selected subject user. |
+
+### Proposed request
+
+```json
+{
+  "subjectUserLoginId": "nifi",
+  "category": "INTEGRATION",
+  "purpose": "NIFI_PRODUCT_IMPORT",
+  "expireIn": 2592000
+}
+```
+
+### Proposed response
+
+```json
+{
+  "token": "eyJ...",
+  "expirationTime": 1760000000000,
+  "expireIn": 2592000,
+  "issuedTo": "nifi",
+  "issuedBy": "admin",
+  "category": "INTEGRATION",
+  "purpose": "NIFI_PRODUCT_IMPORT"
+}
+```
+
+### Validation rules
+
+- Caller must be authenticated and must have a Moqui/OFBiz permission equivalent to `JWT_TOKEN_CREATE`.
+- `subjectUserLoginId` is required. Tokens should never be issued without a concrete user principal.
+- `subjectUserLoginId` must resolve to an enabled `org.apache.ofbiz.security.login.UserLogin` because JWT auth and permissions still resolve through `userLoginId`.
+- The same identity should exist as `moqui.security.UserAccount.username` or `externalUserId`; otherwise Moqui JWT login/app-auth may fail even if the token can be signed.
+- For `category=INTEGRATION`, the subject user should be a member of the `INTEGRATION` security group. This mirrors the OFBiz token screen, which only lists users from `UserLoginSecurityGroup` where `groupId=INTEGRATION`.
+- Reject disabled users and users where `requirePasswordChange=Y`.
+- Set or verify `hasLoggedOut=N` for the subject user before issuing the token, matching the OFBiz workaround for integration tokens.
+- Do not accept arbitrary claims from the UI. The service should own the allowed claim set.
+
+### Claims to mint
+
+| Claim | Source | Notes |
+| --- | --- | --- |
+| `userLoginId` | `subjectUserLoginId` | Required. This is the identity downstream auth uses. |
+| `userId` | `moqui.security.UserAccount.userId` | Useful for Moqui apps, but `userLoginId` remains the compatibility key. |
+| `issuedBy` | Current authenticated user | Audit/display only. |
+| `purpose` | Request body | Required human-readable reason, capped like OFBiz currently caps purpose. |
+| `category` | Request body, default `INTEGRATION` | Should be an enum/allow-list, not free-form trust. |
+
+### Security notes
+
+- The endpoint should not store the plaintext token. Return it once.
+- If revocation is needed before expiry, disable the subject user or mark it logged out. There is no token-specific revocation list in the current model.
+- Default expiry should be conservative. OFBiz supports 30 days, 6 months, 1 year, and 5 years; onboarding should default to 30 days and require deliberate selection for longer periods.
+- This endpoint belongs in `hotwax-maarg-util` under `admin/auth` or `admin/jwtTokens`; it should not live in `hotwax-shopify-oms-bridge`.
+
+## Research Log
+
+| Date | Finding |
+| --- | --- |
+| 2026-06-12 | Initial pass from Company app calls plus local REST XML. ProductStore, facility, service job, DataManager template/upload/log, and Shopify mapping primitives exist. Feature-level setup endpoints and direct user setup are still gaps. |
+| 2026-06-12 | Rechecked OFBiz `hotwax-oms` and Maarg. JWT generation is general auth/integration infrastructure, not Shopify bridge infrastructure. Maarg already has `JWTManager.createJwt(...)` and `admin/login` can accept OMS JWTs; the remaining gap is a bounded admin/auth REST wrapper if onboarding must create long-lived integration tokens. |
+| 2026-06-12 | Refined JWT spec: Moqui can issue tokens directly with `JWTManager.createJwt(...)`; the token still must be issued against a real `userLoginId`/`UserAccount` principal so auth, permissions, and audit resolve correctly. For integration tokens, the subject should be a service user such as `nifi` and should belong to `INTEGRATION`. |
+| 2026-06-12 | Reclassified Shopify shop type mappings as existing/no-change. Existing `GET/POST /rest/s1/oms/shopifyShops/typeMappings` is enough for onboarding because POST is an entity `store` operation. |
+| 2026-06-12 | Confirmed Shopify read/write access scope is operationally managed on `moqui.service.message.SystemMessageRemote.accessScopeEnumId`. `ShopifyShop` does not have this field; `ShopifyConfig.accessScopeEnumId` exists but current remote creation/update and write-access checks use the system-message-remote row. |
+| 2026-06-12 | Reclassified MDM file imports. Facility CSV import, inventory reset CSV upload, template download, and user CSV import should all clone Job Manager's generic DataManager upload/log flow in Company instead of adding bespoke REST endpoints. |
+| 2026-06-12 | Validated that Shopify inventory can be fetched through Admin GraphQL bulk operations using `inventoryItems` with nested `inventoryLevels` and `quantities`. The reset-from-Shopify flow should be treated as bulk export, transform to inventory reset CSV, then generic DataManager upload/log. |
+| 2026-06-12 | Product-store onboarding decision: Shopify-sourced inventory reset should mirror the existing Shopify product import bulk-operation pattern and load Shopify `on_hand` as the OMS reset quantity. |
+| 2026-06-12 | Corrected inventory reset research boundary. `RESET_INVENTORY`, `resetInventoryByIdentification`, and `resetInHandInventory` are old OFBiz OMS artifacts from `hotwax-oms`, not Moqui OMS. Moqui has a merged reset primitive in `hotwax-poorti` (`create#ExternalInventoryReset`), but current `origin/main` does not have a generic inventory-reset DataManager config. |
+| 2026-06-12 | Found Chinmay's branch candidate in `hotwax-poorti`: `origin/netsuite-external-inventory-reset` adds `reset#InventoryItem` and improves `create#ExternalInventoryReset` for QOH-only or ATP-only reset semantics. The branch is not merged to `origin/main`, so onboarding cannot depend on it until it is merged or recreated. |
+| 2026-06-12 | Found merged NetSuite DataManager precedent: `mantle-netsuite-connector` seeds `STORE_INV_RESET` -> `co.hotwax.netsuite.InventoryServices.process#ExternalInventoryReset`. This confirms the DataManager upload pattern, but the implementation is NetSuite-specific and writes `NetsuiteInventoryReset` variance records rather than providing a generic Shopify/OMS reset import. |
+| 2026-06-12 | Found Shopify bridge side effect: `hotwax-shopify-oms-bridge` has a SECA on `create#org.apache.ofbiz.product.inventory.ExternalInventoryReset` that calls `post#ShopifyExternalInventoryReset`. A Shopify-sourced inventory reset flow needs an origin/skip mechanism so importing Shopify `on_hand` into OMS does not immediately echo an adjustment back to Shopify. |
+| 2026-06-12 | Expanded Shopify job-family setup. Existing backend can clone/edit service jobs, subscribe Shopify webhooks to an EventBridge ARN, and consume SQS messages through `consume_ShopifyOrders_SQS`, but it does not provision AWS EventBridge partner buses, rules, SQS queues, queue policies, or DLQs. |
+| 2026-06-12 | Confirmed Purushottam's Shopify order integration setup screen is a Moqui health/setup screen, not a Company onboarding flow. It edits AWS SQS credentials, consumer/fallback/history jobs, and webhooks, while instructing the user to create SQS/EventBridge manually. |
+| 2026-06-12 | Split inventory job directionality. `resetShopifyInventoryQoh` and `SHOPIFY_INV_SYNC=Y` are outbound HotWax-to-Shopify inventory sync, while the Shopify bulk inventory reset flow is inbound Shopify-to-OMS and should stay separate to avoid reset echo loops. |
+| 2026-06-12 | AWS/EventBridge setup decision: v1 onboarding should probably be assisted manual AWS setup plus validation because current Moqui only consumes SQS. Fully automated provisioning is a separate backend gap requiring AWS EventBridge/SQS management clients, least-privilege IAM, queue policies, DLQ handling, rollback, and audit. |
+| 2026-06-12 | Corrected feature-settings scope. We do not need per-feature settings endpoints; ProductStore fields and ProductStoreSetting enum IDs should be grouped by setup topic in the UI and saved through the existing ProductStore and ProductStoreSetting endpoints. Existing Company category maps already provide the topic grouping shape. |
+
+## Open Questions
+
+- For non-settings setup actions, should onboarding call low-level existing endpoints directly, or should backend expose solution setup endpoints that perform multiple writes atomically?
+- Which integration users should cold-start onboarding create by default, if any: `nifi`, Shopify app user, MDM import user, or none until that integration is selected?
+- Should `POST /rest/s1/admin/jwtTokens` require the subject user to already exist, or should it call the future user setup endpoint to create the service user first?
+- For Shopify access updates, should onboarding call `PUT /rest/s1/oms/systemMessageRemotes/{systemMessageRemoteId}` directly, or should backend expose a narrow shop-level wrapper that only updates `accessScopeEnumId` after resolving the correct remote?
+- Which curated DataManager config IDs should onboarding expose for facility import, inventory reset, and user import?
+- Should we merge/recreate Chinmay's `reset#InventoryItem` branch service before building onboarding, or should the generic DataManager import call today's `create#ExternalInventoryReset` directly?
+- What should the generic Moqui inventory reset DataManager config and file-consuming service be named, and where should they be seeded?
+- How should Shopify-origin inventory reset suppress outbound Shopify echo from the `ExternalInventoryReset` SECA?
+- Which optional DataManager upload `parameters` are required for each onboarding import task, such as product store, shop, owner party, facility group, or security group?
+- Are any required DataManager configs missing from seed data, and if so should they be seeded before the onboarding UI exposes the task?
+- Which Shopify location mapping is authoritative for inventory reset: Shopify `Location.id`, `Location.legacyResourceId`, or an existing `ShopifyShopLocation` mapping row?
+- Should user setup live under `admin/users` or a dedicated onboarding namespace?
+- Should the realtime SQS order consumer remain one instance-wide `consume_ShopifyOrders_SQS` job, or should onboarding clone a per-shop/per-product-store consumer job?
+- Should v1 support only assisted manual AWS setup, or should we build automated EventBridge/SQS provisioning before exposing realtime order import?
+- Where should onboarding persist AWS/EventBridge metadata beyond the SQS connection: event source ARN, partner event bus name, EventBridge rule ARN, queue ARN, DLQ ARN, and selected webhook topics?
+- Which Shopify order topics should the standard setup enable: `ORDERS_CREATE`, `ORDERS_UPDATED`, `ORDERS_CANCELLED`, `REFUNDS_CREATE`, or a narrower first pass?
+- Should order webhook subscriptions be app-specific config, shop-specific Admin GraphQL subscriptions, or shop-specific only when each merchant has a different EventBridge ARN?
+- What should the least-privilege AWS credential story be: customer-owned AWS access key, assume-role into customer AWS account, HotWax-owned AWS account per tenant, or manual resources with only SQS consume credentials stored in Moqui?
+- How should AWS credentials and Shopify webhook destinations be rotated, tested, and audited from the onboarding UI?
+- What failure/retry contract should realtime order import expose: DLQ inspection, replay, fallback batch job, or "run order sync now" from a date?
+- Which preorder job/setup actions are already owned by OMS and should be wrapped rather than rewritten, separate from ProductStore field/settings grouping?

--- a/docs/product-store-settings-study.md
+++ b/docs/product-store-settings-study.md
@@ -1,0 +1,174 @@
+# Product Store Settings Study
+
+## Purpose
+
+The Company app should be the place operators use to stand up an OMS and manage organization-level behavior. For product stores, that means the app should not hide settings simply because they are advanced or obscure. Every setting needs a home.
+
+This study separates:
+
+- Direct `ProductStore` fields edited by Company today.
+- `ProductStoreSetting` records backed by `PROD_STR_STNG` enum IDs.
+- The broader backend setting universe that is not yet represented in the Company UI.
+
+## Current Company Surface
+
+Company currently manages 22 editable product store values on the detail/setup flows:
+
+- 8 direct `ProductStore` fields.
+- 14 `ProductStoreSetting` records.
+
+### Direct ProductStore fields
+
+| Field | Current purpose |
+| --- | --- |
+| `defaultCurrencyUomId` | Store currency used by pricing, product, and order flows. |
+| `orderNumberPrefix` | Prefix added to generated sales order IDs. |
+| `autoApproveOrder` | Whether imported or authorized orders can auto-approve. |
+| `daysToCancelNonPay` | Days before unpaid/unfulfilled orders are auto-cancelled. |
+| `reserveInventory` | Whether inventory reservation is enabled for this store. |
+| `enableBrokering` | Whether brokering behavior is enabled for this store. |
+| `allowSplit` | Whether preorder/backorder items can split from the full order. |
+| `productIdentifierEnumId` | Global product identifier used for Shopify product matching. |
+
+### ProductStoreSetting records managed today
+
+| Setting ID | Current purpose |
+| --- | --- |
+| `SAVE_BILL_TO_INF` | Save Shopify billing information on imported orders. |
+| `RETURN_DEADLINE_DAYS` | Limit how far back orders remain eligible for return creation. |
+| `PRE_SLCTD_FAC_TAG` | Shopify order tag that enables preselected facility logic. |
+| `ORD_ITM_SHIP_FAC` | Shopify line item property name for selected ship facility. |
+| `FULFILL_NOTIF` | Send fulfillment notifications back to Shopify. |
+| `BOPIS_PART_ODR_REJ` | Allow partial rejection of BOPIS orders. |
+| `HOLD_PRORD_PHYCL_INV` | Treat physical preorder inventory as held when preorder queue exists. |
+| `PRE_ORDER_GROUP_ID` | Facility group used for multi-channel preorder inventory. |
+| `PRDT_IDEN_PREF` | JSON preference for primary and secondary product identifiers. |
+| `CUST_DLVRMTHD_UPDATE` | Allow customers to change delivery method in reroute fulfillment. |
+| `RF_SHIPPING_METHOD` | Shipping method used by reroute fulfillment. |
+| `CUST_DLVRADR_UPDATE` | Allow customers to change delivery address in reroute fulfillment. |
+| `CUST_PCKUP_UPDATE` | Allow customers to change pickup location in reroute fulfillment. |
+| `CUST_ALLOW_CNCL` | Allow customers to cancel before fulfillment. |
+
+## Backend ProductStoreSetting Universe
+
+Backend data and upgrade files define 35 supported `PROD_STR_STNG` enum IDs after removing deprecated product-store settings:
+
+| Setting ID | Suggested UX home |
+| --- | --- |
+| `AFFECT_QOH_ON_REJ` | Rejection and exception handling |
+| `APPR_WO_PMNT_CHK` | Approval and payment checks |
+| `AUTO_REJ_IDLE_ORD` | Rejection and exception handling |
+| `BARCODE_IDEN_PREF` | Product identity and scanning |
+| `BOPIS_PART_ODR_REJ` | Store pickup / BOPIS |
+| `CAPTURE_PAYMENT_TAG` | Approval and payment checks |
+| `CUST_ALLOW_CNCL` | Customer self-service |
+| `CUST_DLVRADR_UPDATE` | Customer self-service |
+| `CUST_DLVRMTHD_UPDATE` | Customer self-service |
+| `CUST_PCKUP_UPDATE` | Customer self-service |
+| `DEFULT_PKG_BOPIS_ORD` | Store pickup / BOPIS |
+| `ENABLE_TRACKING` | Store pickup / BOPIS |
+| `EX_INV_BY_PRD_TYPE` | Inventory sync |
+| `FF_COLLATERAL_REJ` | Rejection and exception handling |
+| `FULFILL_FORCE_SCAN` | Fulfillment operations |
+| `FULFILL_NOTIF` | Notifications and Shopify behavior |
+| `FULFILL_PART_ODR_REJ` | Fulfillment operations |
+| `HOLD_PRORD_PHYCL_INV` | Inventory and preorder |
+| `ORD_ITM_PICKUP_FAC` | Brokering and routing |
+| `ORD_ITM_SHIP_FAC` | Brokering and routing |
+| `ORD_ITM_SHIP_METH` | Brokering and routing |
+| `PRDT_IDEN_PREF` | Product identity |
+| `PRE_ORDER_GROUP_ID` | Inventory and preorder |
+| `PRE_SLCTD_FAC_TAG` | Brokering and routing |
+| `PRINT_PACKING_SLIPS` | Store pickup / BOPIS |
+| `PRINT_PICKLISTS` | Store pickup / BOPIS |
+| `RATE_SHOPPING` | Shipping and carriers |
+| `RECEIVE_FORCE_SCAN` | Receiving operations |
+| `REJ_ITM_CC_CRT` | Rejection and exception handling |
+| `REL_PREORD_ROUGRP_ID` | Inventory and preorder |
+| `RETURN_DEADLINE_DAYS` | Returns |
+| `RF_SHIPPING_METHOD` | Customer self-service |
+| `RTN_RSTCK_FAC` | Returns |
+| `SAVE_BILL_TO_INF` | Order import |
+| `SHOW_SHIPPING_ORDERS` | Store pickup / BOPIS |
+
+### Removed ProductStoreSetting records
+
+These setting IDs should not be presented as product-store settings in Company:
+
+| Setting ID | Replacement path |
+| --- | --- |
+| `BRK_SHPMNT_THRESHOLD` | Remove; no supported runtime owner found. |
+| `DEFAULT_CARRIER` | Remove after replacing legacy Shopify carrier fallback logic. |
+| `PCKGING_BOX_ALGO` | Remove with legacy packing-box algorithm support. |
+| `PKG_SLIP` | Remove with legacy packing-slip content lookup support. |
+| `FF_USE_NEW_REJ_API` | Remove; no supported runtime owner found. |
+| `DISABLE_UNPACK` | Replace with an action permission that controls who can unpack. |
+| `DISABLE_SHIPNOW` | Replace with an action permission that controls who can ship now. |
+| `INV_CNT_VIEW_QOH` | Remove only as a `ProductStoreSetting`; keep the inventory-count permission. |
+| `DIS_REJ_NOTI_ON_CNCL` | Replace with backend default behavior that suppresses notifications for Shopify cancellation rejections. |
+
+## UX Direction
+
+The product store settings experience should have two layers.
+
+### Guided operating settings
+
+Common and well-understood settings should be shown as guided sections with labels, explanations, typed controls, and validation.
+
+Candidate sections:
+
+- Store identity and defaults
+- Order import and approval
+- Returns and cancellation
+- Inventory reservation and preorder
+- Brokering and routing
+- Fulfillment operations
+- Store pickup / BOPIS
+- Customer self-service / reroute fulfillment
+- Shipping and carriers
+- Packing, labels, and documents
+- Notifications and Shopify behavior
+- Rejection and exception handling
+
+### All settings registry
+
+Every backend product store setting should also appear in a searchable registry. This prevents settings from having no home while allowing risky or obscure settings to be marked advanced.
+
+Minimum registry fields:
+
+- Setting ID
+- Backend enum name
+- Backend description when available
+- Category
+- Current value
+- Value type
+- Default value when known
+- Guided vs advanced status
+- Last updated metadata when available
+
+## Metadata Needed Before Implementation
+
+Create a typed metadata map before changing the UI:
+
+```ts
+{
+  id: "SAVE_BILL_TO_INF",
+  source: "ProductStoreSetting",
+  category: "order-import",
+  label: "Save billing information",
+  valueType: "boolean-y-n",
+  defaultValue: "N",
+  control: "toggle",
+  guided: true,
+  description: "Save Shopify billing information on imported orders."
+}
+```
+
+This metadata should cover all 44 `PROD_STR_STNG` settings plus the direct `ProductStore` fields Company manages.
+
+## Open Questions
+
+- Should direct `ProductStore` fields and `ProductStoreSetting` records be shown together by business area, or should advanced users be able to switch to a source-oriented view?
+- Which backend-only settings are safe enough for guided controls in the first Company app pass?
+- Should the all-settings registry allow raw string editing for unknown settings, or require metadata before a setting becomes editable?
+- Can we expose per-setting audit history from OMS so operators can see who changed critical behavior?

--- a/docs/retailer-onboarding-discovery-to-oms-config.md
+++ b/docs/retailer-onboarding-discovery-to-oms-config.md
@@ -1,0 +1,190 @@
+# Retailer Onboarding Discovery to OMS Configuration Map
+
+## Scope
+
+This document turns first-time retailer discovery calls into an onboarding model for Product Store setup. The wizard should ask questions the way retailers naturally describe their business, then translate those answers into HotWax OMS configuration.
+
+The scan used:
+
+- Read AI sales/discovery calls where a retailer or partner was describing a first implementation, evaluation, or major new operating model.
+- Current Company app surfaces.
+- Current Moqui components and PWA apps under the local GitHub workspace.
+- Exclusions: legacy-only `hotwax-oms` surfaces and config with no current Moqui/PWA owner.
+
+## Read AI Call Evidence
+
+| Read AI meeting | Retailer language observed | Configuration signal |
+| --- | --- | --- |
+| `01KSHQPEGG3YWY16GCQ46NH9AC` Capital Hair and Beauty / HotWax | Wants to unlock store inventory for online sales, has about 60 stores, large DC inventory online but more stock trapped in stores, high online order volume, asks whether routing can consolidate or transfer. | Ask store count, order volume, online SKU coverage, store/DC inventory split, hub-store strategy, split tolerance, transfer vs route-to-store behavior. Map to brokering, split, facility groups, routing rules, fulfillment permissions, labels/carrier setup, and job cadence. |
+| `01KREFVE0KKXH6D25QF7VQPTK9` Julien x HotWax | Wants preorder before the full ERP/WMS setup, asks whether manual stock or PO imports can work, needs per-location preorder and paid shipping overrides. | Ask PO source, promise-date source, preorder pool scope, product/store/location eligibility, paid shipping priority. Map to preorder product-store settings, routing groups, Shopify product metadata sync, and product-store-scoped jobs. |
+| `01KRK722V2NFJ35YCEB3XC5WEC` Subdued first call | Pain is return accounting and inventory valuation by store, especially Shopify POS booking returns to the original store. | Ask whether the pain is configurable OMS behavior or native platform accounting. Map only the supported pieces: return receiving, restock facility, return feed sync, inventory reports, cycle count permissions, and explicit limitations. |
+| `01KRH32X3QYZ07CSDM1257G8E5` Tui first call | Partner asks whether HotWax is modular, where it sits in the stack, how ship-to-store appears in NetSuite, and whether inventory management can start small. | Ask implementation package, source of truth, multiple Shopify instances, store/warehouse scope, ship-from-store vs ship-to-store, and phase plan. Map to Shopify shop/ProductStore links, facility groups, inventory sync, transfer jobs, and app permission packages. |
+| `01KTBXHCR7F2DCBMT85AJ48NXG` Contax / HotWax | ERP partner frames systems by responsibility: ERP as finance/procurement/receiving, OMS as order lifecycle/fulfillment, files vs APIs, sync cadence. | Ask authoritative system per object: products, inventory, customers, orders, payments, POs, transfers, returns. Map to service job families, SystemMessage remotes, NetSuite/Acumatica mappings, and product-store job parameters. |
+| `01KSFVK2QEWK5GC3YE7C2E2GK2` AdCirrus / HotWax | Partner-led Canadian retailer evaluating ERP and HotWax for preorder/allocation across six warehouses. | Ask warehouses, allocation source, container/PO arrival dates, preorder product eligibility, and budget/timeline. Map to preorder settings, routing groups, product sync, and inventory jobs. |
+| `01KTRSHGQK4XBTK4SMP6K7XQK9` RFP Discussion | Multi-store, multi-Shopify, cross-entity/cross-border, WMS/TMS, NetSuite, preorders and kits. | Ask entity/shop/store boundaries first. Map to multiple ProductStores, multiple ShopifyShops, shop-to-store links, shipment methods, and integration jobs. |
+| `01KRXTXW4QSYZ52C9SZVRRX7RJ` HotWax x Tui deployment practices | Discusses custom Shopify fields, customer/address updates until fulfillment, inventory sync cadence, transfer receipts, commitments, returns/exchanges. | Ask which Shopify custom fields carry operational intent, when customers can edit order details, and which events should sync in near real time. Map to preselected facility settings, customer self-service settings, transfer/return jobs, and permissions. |
+| `01JWVBC3WM7SMA8TM6YMCD9DFC` Third Love discovery call | Retailer found HotWax while looking for Shopify POS + NetSuite inventory management. They describe two problems: inventory counts and transfer-order receiving without Excel/NetSuite logins, starting with two stores and growing. | Ask current store count, planned store count, manual workarounds, whether stores need NetSuite access, cycle count flow, transfer receiving flow, and integration replacement scope. Map to receiving/transfers apps, `RECEIVE_FORCE_SCAN`, inventory count permissions, transfer jobs, Shopify/NetSuite jobs, and user/security groups. |
+| `01JWV2RFQSK81V6X5G7Q9HN1BR` Scanlan Theodore inventory call | Retailer wants AP21 as back office, but stores need cloud/iPad/Mac-friendly receiving. They ask about initial inventory receiving, COGS, discrepancy history, damages, dry cleaning, consignments, ship-from-store, store transfers, and budget. | Ask back-office system, device/workflow expectations, PO/invoice source, COGS ownership, damage/hold locations, transfer scenarios, ship-from-store status, force scan vs manual quantity, and budget/timeline. Map to receiving settings, facility/location setup, inventory status/location modeling, carrier setup, transfer/fulfillment permissions, and ERP jobs. |
+| `01JX2Z4AVXP597K053WHAFR596` ThirdLove inventory management demo | Store associates, scanners, inventory adjustments, transfer discrepancies, cycle counts, Shopify catalog import, and role permissions are the decision points. | Ask scanner requirement, discrepancy policy, count types, product identifier source, who can adjust/count/receive, and product import scope. Map to barcode/product identifier settings, inventory count permissions, receiving permissions, and product sync jobs. |
+| `01JVSZNS0BWHYRZD3A4ZHMEY98` BOPIS UI review | Checkout shipping options, pickup-only carts, 3PL interaction, fulfillment location logic, and customer-facing pickup experience dominate the conversation. | Ask whether BOPIS should appear with shipping methods, what shipping methods qualify, whether pickup-only carts suppress shipping rates, and what customer pickup changes are allowed. Map to BOPIS settings, shipping method mappings, delivery-rate config, and BOPIS permissions. |
+
+## Discovery Shape
+
+Retailers rarely begin with configuration names. They describe:
+
+- Business footprint: stores, warehouses, countries, channels, order volume, SKUs, growth plans.
+- Current manual work: Excel sheets, NetSuite logins, store calls, manual labels, manual returns, manual inventory uploads.
+- System ownership: Shopify, Shopify POS, NetSuite, AP21, Acumatica, WMS, 3PL, TMS, carrier, returns platform, Klaviyo.
+- Operational tolerance: whether to split, reroute, reject, hold, transfer, cancel, reserve, force scan, or manually review.
+- Store role expectations: associate, manager, inventory team, customer service, routing admin, system admin.
+
+The onboarding wizard should therefore start with business questions, not tables. The last screen can show the generated configuration package.
+
+## Discovery Question Backbone
+
+| Wizard area | Retailer-facing question | Why it matters | Configuration direction |
+| --- | --- | --- | --- |
+| Fit and scope | What are you trying to improve first: routing, ship from store, BOPIS, store inventory, preorder, returns, or integrations? | Controls which sections are relevant. | Enables only the relevant setting, permission, mapping, and job groups. |
+| Business scale | How many stores, warehouses, Shopify shops, countries, and monthly online orders are in scope now and later? | Determines rollout size and whether one ProductStore is enough. | ProductStore records, ShopifyShop records, facility groups, security groups, service-job scope. |
+| Source of truth | Which system owns products, prices, inventory, customers, orders, payments, POs, transfers, returns, and labels? | Prevents bad config caused by duplicate ownership. | Shopify/ERP/OMS mappings, SystemMessage remotes, service job families, data feed direction. |
+| Inventory exposure | Which inventory should be sellable online: DC only, stores only, selected stores, hubs, all stores, safety-stocked stores, or preorder inventory? | Drives brokering and inventory logic. | `checkInventory`, `reserveInventory`, `enableBrokering`, `allowSplit`, facility groups, routing groups, ATP/rule jobs. |
+| Fulfillment flow | Can stores ship online orders, receive transfers, initiate transfers, print labels, and reject partial orders? | Defines store app package and exception handling. | Fulfillment, BOPIS, receiving, transfer permissions; scan settings; label/carrier config. |
+| Pickup flow | Is pickup store-local only, website-visible inventory, ship-to-store, BOPIS with shipping methods, or pickup-only checkout? | Separates Shopify checkout behavior from OMS pickup operations. | BOPIS settings, shipping method mappings, delivery-rate config, pickup permissions, facility mappings. |
+| Preorder flow | Are preorders based on product tags, POs, locations, warehouses, arrival dates, paid shipping, or manual inventory? | Preorder is usually a workflow before it is a setting. | Preorder settings, preorder routing group, release routing group, product sync, PO/inventory jobs. |
+| Returns and cancellation | Where should returns restock, who receives them, can customers cancel or change pickup/address/method, and should return feeds sync to ERP? | Avoids mapping unsupported platform-accounting asks to settings. | Return settings, customer self-service settings, receiving permissions, return lifecycle jobs. |
+| Product identity | What do stores scan and what does Shopify/ERP use: SKU, UPC, barcode, Shopify product ID, variant ID, style/color/size? | Controls matching and app scanning. | `productIdentifierEnumId`, `PRDT_IDEN_PREF`, `BARCODE_IDEN_PREF`, Shopify product type/product sync mappings. |
+| Jobs and cadence | Which syncs must be real time, scheduled, manually run, per shop, or per product store? | Most integrations become job parameters and schedules. | ServiceJob active flags, cron, `productStoreIds`, shop IDs, remotes, data documents. |
+| Roles | Which roles exist and which apps/actions should each role see? | Permissions are onboarding output, not a separate admin afterthought. | Security groups and app/action permissions. |
+
+## Question to Configuration Matrix
+
+| Retailer answer pattern | ProductStore fields | ProductStoreSetting IDs | Permissions | Shopify and adjacent config | Service-job families |
+| --- | --- | --- | --- | --- | --- |
+| One brand/storefront with normal Shopify import | `productStoreId`, `storeName`, `defaultCurrencyUomId`, `defaultSalesChannelEnumId`, `orderNumberPrefix`, `productIdentifierEnumId` | `SAVE_BILL_TO_INF`, `APPR_WO_PMNT_CHK`, `CAPTURE_PAYMENT_TAG`, `AUTO_ACPT_RISK_REC` | `COMPANY_APP_VIEW`, `APP_UPDT_PRODUCT_STORE_CONFG`, `COMMERCEUSER_VIEW` | `ShopifyShop.productStoreId`, `SHOPIFY_ORDER_SOURCE`, `SHOPIFY_PAYMENT_TYPE`, `SHOPIFY_PRODUCT_TYPE` | Shopify order import/history, customer/payment/order feeds |
+| Stores should fulfill online orders | `enableBrokering`, `allowSplit`, `reserveInventory`, `checkInventory`, `requireInventory`, `inventoryFacilityId` | `PRE_SLCTD_FAC_TAG`, `ORD_ITM_SHIP_FAC`, `ORD_ITM_SHIP_METH`, `FULFILL_NOTIF`, `FULFILL_FORCE_SCAN`, `FULFILL_PART_ODR_REJ`, `AFFECT_QOH_ON_REJ`, `REJ_ITM_CC_CRT`, `FF_COLLATERAL_REJ` | `STOREFULFILLMENT_ADMIN`, `FULFILLMENT_APP_VIEW`, `FF_ORDER_LOOKUP_VIEW`, `FF_SHIP_NOW`, `SF_UNLOCK_ORDER`, `FULFILLMENT_VIEW_ALL_PICKERS`, `ORDER_SHIPMENT_METHOD_UPDATE` | Carrier mappings, `ShipmentGatewayConfig`, ShipHawk/FedEx/UPS/Unigate config, Shopify locations | Routing jobs, fulfillment feeds, carrier/label jobs, Shopify fulfillment ack jobs |
+| Pickup/BOPIS is important | `enableBrokering`, `reserveInventory`, `checkInventory` | `BOPIS_PART_ODR_REJ`, `DEFULT_PKG_BOPIS_ORD`, `SHOW_SHIPPING_ORDERS`, `PRINT_PACKING_SLIPS`, `PRINT_PICKLISTS`, `ENABLE_TRACKING`, `HANDOVER_PROOF`, `BOPIS_SHIP_MTHDS`, `ORD_ITM_PICKUP_FAC` | `BOPIS_APP_VIEW`, `BOPIS_POD_UPDATE`, `BOPIS_REQUEST_TRANSFER_UPDATE`, `ORD_SALES_ORDER_CNCL`, `STOREFULFILLMENT_ADMIN` | Shopify location mapping, shipping-rate/delivery-rate config, pickup shipping methods | Fulfillment order imports, BOPIS/fulfillment sync, delivery-rate jobs if configured |
+| Store inventory management without NetSuite/ERP logins | `productIdentifierEnumId`, `inventoryFacilityId`, `oneInventoryFacility`, `reserveInventory` | `RECEIVE_FORCE_SCAN`, `BARCODE_IDEN_PREF`, `PRDT_IDEN_PREF`, `RECEIVE_BY_FULFILL`, `EX_INV_BY_PRD_TYPE` | `RECEIVING_APP_VIEW`, `RECEIVING_ADMIN`, `TRANSFERS_APP_VIEW`, `ORD_TRANSFER_ORDER_VIEW`, `ORD_TRANSFER_ORDER_ADMIN`, `APP_BULK_UPLOAD`, `APP_DISCREPANCY_REPORT`, `INVCOUNT_APP_VIEW`, `INV_COUNT_ADMIN`, `INV_COUNT_SUBMIT`, `INV_COUNT_VAR_LOG`, `INV_CNT_VIEW_QOH` | Facility mappings, facility IDs, facility locations, Shopify POS embedding, product image/catalog import | Transfer-order jobs, item receipt jobs, inventory variance jobs, cycle count import/export jobs |
+| Preorder/backorder | `reserveInventory`, `allowSplit`, `productIdentifierEnumId`, `requireInventory`, `requirementMethodEnumId` | `HOLD_PRORD_PHYCL_INV`, `PRE_ORDER_GROUP_ID`, `REL_PREORD_ROUGRP_ID`, `EX_INV_BY_PRD_TYPE`, `PROD_CAT_ATTR`, `UPDATE_PRODUCT_TYPE` | `PREORDER_APP_VIEW`, `APP_PRODUCTS_VIEW`, `APP_PRDT_DTLS_VIEW`, `APP_INV_CNFG_UPDT`, `APP_PRODUCT_IDENTIFIER_UPDATE`, `MERCHANDISING_ADMIN` | Shopify product tags, product type mappings, product identifiers, PO/arrival-date import | Shopify product sync, preorder routing jobs, product metafield/tag jobs, PO/inventory jobs |
+| Customer can change or cancel before fulfillment | `headerCancelStatus`, `itemCancelStatus`, `daysToCancelNonPay` | `CUST_ALLOW_CNCL`, `CUST_DLVRADR_UPDATE`, `CUST_DLVRMTHD_UPDATE`, `CUST_PCKUP_UPDATE`, `RF_SHIPPING_METHOD` | `APP_SHPGRP_CNCL`, `APP_SHPGRP_DLVRADR_UPDATE`, `APP_SHPGRP_DLVRMTHD_UPDATE`, `APP_SHPGRP_PCKUP_UPDATE` | Reroute fulfillment app config, shipping method mapping | Order update jobs, fulfillment-order refresh, customer service workflows |
+| Returns and return accounting | `reqReturnInventoryReceive`, `daysToCancelNonPay`, status fields | `RETURN_DEADLINE_DAYS`, `RTN_RSTCK_FAC`, `NS_RTN_FEED_SYNC`, `AUTO_REJ_IDLE_ORD` | `RECEIVING_ADMIN`, `ORD_SALES_ORDER_CNCL`, inventory count permissions as needed | Returns platform mappings, Shopify return IDs/reasons, ERP return feeds | Return transaction/item receipt jobs, return/appeasement feed jobs |
+| Multi-shop or multi-entity | `productStoreId`, `primaryStoreGroupId`, `defaultCurrencyUomId`, `defaultLocaleString`, `defaultTimeZoneString`, `payToPartyId` | Depends on selected operating flows | App package per role/entity | Multiple `ShopifyShop` rows, `ShopifyShopLocation`, `ShopifyShopTypeMapping`, ProductStore email settings, Klaviyo, carrier, Unigate/FedEx | Product-store-scoped service jobs via `productStoreIds`, shop-scoped jobs via `shopId` |
+
+## ProductStore Field Inventory
+
+Current Company detail code exposes these direct fields. The wizard should not ask every field directly; many should be derived, defaulted, or kept in an advanced review step.
+
+| Area | Fields |
+| --- | --- |
+| Store identity and defaults | `productStoreId`, `primaryStoreGroupId`, `storeName`, `companyName`, `title`, `subtitle`, `payToPartyId`, `visualThemeId`, `defaultLocaleString`, `defaultTimeZoneString` |
+| Order import and checkout | `orderNumberPrefix`, `defaultCurrencyUomId`, `defaultSalesChannelEnumId`, `viewCartOnAdd`, `autoSaveCart`, `allowPassword`, `defaultPassword`, `usePrimaryEmailUsername`, `requireCustomerRole`, `retryFailedAuths`, `allowComment`, `orderDecimalQuantity` |
+| Approval, payment, accounting | `manualAuthIsCapture`, `autoApproveOrder`, `autoApproveInvoice`, `shipIfCaptureFails`, `checkGcBalance`, `selectPaymentTypePerItem`, `splitPayPrefPerShpGrp`, `storeCreditAccountEnumId`, `storeCreditValidDays` |
+| Inventory and products | `inventoryFacilityId`, `oneInventoryFacility`, `checkInventory`, `reserveInventory`, `reserveOrderEnumId`, `requireInventory`, `balanceResOnOrderCreation`, `requirementMethodEnumId`, `isImmediatelyFulfilled`, `explodeOrderItems`, `prodSearchExcludeVariants`, `showOutOfStockProducts`, `managedByLot`, `setOwnerUponIssuance`, `productIdentifierEnumId` |
+| Digital, tax, returns | `autoInvoiceDigitalItems`, `reqShipAddrForDigItems`, `showCheckoutGiftOptions`, `showPricesWithVatTax`, `showTaxIsExempt`, `vatTaxAuthGeoId`, `vatTaxAuthPartyId`, `reqReturnInventoryReceive`, `daysToCancelNonPay` |
+| Customer suggestion and uploads | `enableAutoSuggestionList`, `enableDigProdUpload`, `digProdUploadCategoryId` |
+| Status and authorization messaging | `headerApprovedStatus`, `itemApprovedStatus`, `digitalItemApprovedStatus`, `headerDeclinedStatus`, `itemDeclinedStatus`, `headerCancelStatus`, `itemCancelStatus`, `authDeclinedMessage`, `authFraudMessage`, `authErrorMessage` |
+| Auto-order retries | `autoOrderCcTryExp`, `autoOrderCcTryOtherCards`, `autoOrderCcTryLaterNsf`, `autoOrderCcTryLaterMax` |
+| Legacy storefront fields | `oldStyleSheet`, `oldHeaderLogo`, `oldHeaderMiddleBackground`, `oldHeaderRightBackground` |
+
+## ProductStoreSetting Inventory
+
+These IDs were found outside `hotwax-oms` in current Moqui/PWA/component roots. The wizard should split them into guided, advanced, and excluded/replacement buckets.
+
+### Guided and Current
+
+| Area | Setting IDs |
+| --- | --- |
+| Order import and approval | `SAVE_BILL_TO_INF`, `APPR_WO_PMNT_CHK`, `CAPTURE_PAYMENT_TAG`, `AUTO_ACPT_RISK_REC` |
+| Returns and cancellation | `RETURN_DEADLINE_DAYS`, `RTN_RSTCK_FAC`, `AUTO_REJ_IDLE_ORD`, `NS_RTN_FEED_SYNC` |
+| Inventory and preorder | `HOLD_PRORD_PHYCL_INV`, `PRE_ORDER_GROUP_ID`, `REL_PREORD_ROUGRP_ID`, `EX_INV_BY_PRD_TYPE`, `PROD_CAT_ATTR`, `UPDATE_PRODUCT_TYPE` |
+| Brokering and preselected routing | `PRE_SLCTD_FAC_TAG`, `ORD_ITM_PICKUP_FAC`, `ORD_ITM_SHIP_FAC`, `ORD_ITM_SHIP_METH` |
+| Fulfillment operations | `FULFILL_NOTIF`, `FULFILL_FORCE_SCAN`, `FULFILL_PART_ODR_REJ`, `AFFECT_QOH_ON_REJ`, `REJ_ITM_CC_CRT`, `FF_COLLATERAL_REJ` |
+| Store pickup and BOPIS | `BOPIS_PART_ODR_REJ`, `DEFULT_PKG_BOPIS_ORD`, `SHOW_SHIPPING_ORDERS`, `PRINT_PACKING_SLIPS`, `PRINT_PICKLISTS`, `ENABLE_TRACKING`, `HANDOVER_PROOF`, `BOPIS_SHIP_MTHDS` |
+| Receiving and scanning | `RECEIVE_FORCE_SCAN`, `RECEIVE_BY_FULFILL`, `PRDT_IDEN_PREF`, `BARCODE_IDEN_PREF` |
+| Customer self-service / reroute fulfillment | `CUST_ALLOW_CNCL`, `CUST_DLVRADR_UPDATE`, `CUST_DLVRMTHD_UPDATE`, `CUST_PCKUP_UPDATE`, `RF_SHIPPING_METHOD` |
+| Shipping and carriers | `RATE_SHOPPING` |
+
+### Keep Out of Guided Wizard Unless a Current Runtime Owner Is Confirmed
+
+| Setting ID | Reason |
+| --- | --- |
+| `BRK_SHPMNT_THRESHOLD` | Found in non-`hotwax-oms` seed data, but previous Company notes found no supported runtime owner. Treat as excluded until code ownership is proven. |
+| `DEFAULT_CARRIER` | Legacy carrier fallback path; prefer explicit carrier/shipment mappings. |
+| `PCKGING_BOX_ALGO` | Legacy packing-box algorithm path. |
+| `FF_USE_NEW_REJ_API` | Replacement/cleanup candidate. |
+| `DISABLE_UNPACK` | Should become an action permission if still needed. |
+| `DISABLE_SHIPNOW` | Should become an action permission; current fulfillment still references it, so migration must be deliberate. |
+| `DIS_REJ_NOTI_ON_CNCL` | Should be backend behavior, not a retailer-facing onboarding question. |
+| `INV_CNT_VIEW_QOH` | Keep as an inventory-count permission; do not present as a ProductStoreSetting. |
+
+## Ionic Permission Inventory
+
+The wizard should emit security-group recommendations based on selected workflows. These are the permission IDs found in current Ionic/PWA surfaces and adjacent current Moqui screens.
+
+| Permission group | Permission IDs |
+| --- | --- |
+| Base and admin | `COMMERCEUSER_VIEW`, `COMMON_ADMIN`, `APP_PWA_STANDALONE_ACCESS`, `APP_SUPER_USER`, `WEBTOOLS_VIEW` |
+| App access | `COMPANY_APP_VIEW`, `APP_COMMERCE_VIEW`, `ORDERMGR_VIEW`, `ORDER_ROUTING_APP_VIEW`, `JOB_MANAGER_APP_VIEW`, `SERVICE_JOB_VIEW`, `BOPIS_APP_VIEW`, `FULFILLMENT_APP_VIEW`, `FULFILLMENT_LEGACY_APP_VIEW`, `APP_FULFILLMENT_VIEW`, `APP_LEGACY_FULFILLMENT_VIEW`, `RECEIVING_APP_VIEW`, `APP_SHIPMENTS_VIEW`, `INVCOUNT_APP_VIEW`, `PREORDER_APP_VIEW`, `FACILITIES_APP_VIEW`, `TRANSFERS_APP_VIEW`, `USERS_APP_VIEW`, `USERS_LIST_VIEW`, `APP_USERS_LIST_VIEW`, `ATP_APP_VIEW`, `APP_ORDERS_VIEW`, `APP_PRODUCTS_VIEW`, `APP_PRDT_DTLS_VIEW`, `APP_AUDIT_VIEW`, `APP_AUDIT_PRDT_DTLS_VIEW` |
+| Product store and product setup | `APP_UPDT_PRODUCT_STORE_CONFG`, `APP_INV_CNFG_UPDT`, `APP_PRODUCT_IDENTIFIER_UPDATE`, `APP_UPDT_FULFILLMENT_FACILITY`, `APP_PRODUCTS_VIEW`, `APP_PRDT_DTLS_VIEW`, `MERCHANDISING_ADMIN` |
+| Fulfillment | `STOREFULFILLMENT_ADMIN`, `FF_ORDER_LOOKUP_VIEW`, `FF_SHIP_NOW`, `SF_UNLOCK_ORDER`, `FULFILLMENT_VIEW_ALL_PICKERS`, `ORDER_SHIPMENT_METHOD_UPDATE`, `FF_INVOICING_STATUS_VIEW`, `CARRIER_SETUP_VIEW` |
+| BOPIS and pickup | `BOPIS_POD_UPDATE`, `BOPIS_REQUEST_TRANSFER_UPDATE`, `ORD_SALES_ORDER_CNCL`, `BOPIS_APP_VIEW` |
+| Receiving, transfers, and inventory counts | `RECEIVING_ADMIN`, `ORD_TRANSFER_ORDER_VIEW`, `ORD_TRANSFER_ORDER_ADMIN`, `ORD_TRANSFER_ORDER_CANCEL`, `APP_BULK_UPLOAD`, `APP_TFNR_BULK_UPLOAD`, `APP_DISCREPANCY_REPORT`, `APP_TFNR_DISCREPANCY_REPORT`, `INV_COUNT_ADMIN`, `INV_COUNT_LOCK_RLS`, `INV_COUNT_PRE_START`, `INV_COUNT_SUBMIT`, `INV_COUNT_VAR_LOG`, `INV_CNT_VIEW_QOH`, `PREVIEW_COUNT_ITEM` |
+| Customer self-service / reroute fulfillment | `APP_SHPGRP_CNCL`, `APP_SHPGRP_DLVRADR_UPDATE`, `APP_SHPGRP_DLVRMTHD_UPDATE`, `APP_SHPGRP_PCKUP_UPDATE`, `CUST_ALLOW_CNCL`, `CUST_DLVRADR_UPDATE`, `CUST_DLVRMTHD_UPDATE`, `CUST_PCKUP_UPDATE` |
+| Routing administration | `ROUTING_TEST_DRIVE_VIEW`, `DELETE_ORDER_ROUTE` |
+| User and security administration | `APP_USER_CREATE`, `APP_USER_PROFILE_UPDATE`, `APP_USER_STATUS_UPDATE`, `APP_USER_CONTACT_CREATE`, `APP_USER_CONTACT_UPDATE`, `APP_USER_CONTACT_DELETE`, `APP_SECURITY_GROUP_CREATE`, `APP_SECURITY_GROUP_ASSIGNMENT`, `APP_PERMISSION_CREATE`, `APP_PERMISSION_UPDATE`, `APP_PERMISSION_VIEW`, `APP_UPDT_BLOCK_LOGIN`, `APP_UPDT_PASSWORD`, `APP_UPDT_PICKER_CONFG` |
+
+## Shopify and Adjacent Configuration
+
+Retailers talk about Shopify in business terms: locations, payment names, product types, channels, shipping labels, pickup rates, and POS staff access. The onboarding wizard should ask those terms and map them to these current surfaces:
+
+| Retailer-facing topic | Current config surface |
+| --- | --- |
+| Which Shopify shop belongs to this ProductStore? | `ShopifyShop.productStoreId`, `shopId`, `shopifyShopId`, `myshopifyDomain`, SystemMessageRemote credentials |
+| Which Shopify location maps to which OMS facility? | `ShopifyShopLocation` via `shopId`, `facilityId`, `shopifyLocationId` |
+| Which Shopify product type maps to which OMS product type? | `ShopifyShopTypeMapping` with `mappedTypeId = SHOPIFY_PRODUCT_TYPE` |
+| Which Shopify sales channel/order source maps to OMS sales channel? | `ShopifyShopTypeMapping` with `mappedTypeId = SHOPIFY_ORDER_SOURCE` |
+| Which Shopify payment method maps to OMS payment method? | `ShopifyShopTypeMapping` with `mappedTypeId = SHOPIFY_PAYMENT_TYPE` |
+| Which Shopify shipping method name maps to carrier + shipment method? | Shopify carrier shipment mapping via `shopId`, `carrierPartyId`, `shipmentMethodTypeId`, `shopifyShippingMethod` |
+| Which ERP department/location code maps to a facility? | Facility identification such as `ORDR_ORGN_DPT` |
+| Which product-store email events should go to Klaviyo? | `ProductStoreEmailSetting`, Klaviyo connection settings |
+| Which carrier/label systems are needed? | `ShipmentGatewayConfig`, carrier parties, ShipHawk/FedEx/UPS/Unigate config |
+| Which sync job belongs to which shop/store? | Service job parameters `shopId`, `shopifyShopId`, `productStoreIds`, `shopifyProductIdentifier` |
+
+## Service Job Inventory
+
+The onboarding wizard should not show 100+ jobs as a raw checklist. It should ask sync ownership and cadence, then create or recommend a job bundle. Current bounded scan found these job families outside `hotwax-oms`.
+
+| Job family | Job IDs found |
+| --- | --- |
+| Shopify order ingest and order queries | `consume_ShopifyOrders_SQS`, `queue_NewOrderIdsFeed`, `queue_UpdatedOrderIdsFeed`, `queue_UpdatedAgreementOrderIdsFeed`, `queue_OrderIdsByTagFeed`, `queue_ReturnedOrderIdsFeed`, `queue_AppeasementIdsFeed`, `queue_ShopifyOrderSync`, `sync_ShopifyOrderHistory`, `queue_BulkQuerySystemMessage_BulkOrderHeadersQuery`, `queue_BulkQuerySystemMessage_BulkOrderItemsQuery`, `queue_BulkQuerySystemMessage_BulkOrderCustomAttributesQuery`, `queue_BulkQuerySystemMessage_BulkOrderDiscountCodeApplQuery`, `queue_BulkQuerySystemMessage_BulkOrderMetafieldsQuery`, `queue_BulkQuerySystemMessage_BulkCanceledOrdersAndItemsQuery` |
+| Shopify fulfillment and return feeds | `queue_FulfillmentOrderIdsFeed`, `queue_FulfillmentOrdersFeedFromShopify`, `generate_OMSFulfillmentFeed_Shopify`, `sendShopifyFulfillmentAckFeed`, `poll_SystemMessageFileSftp_OMSFulfillmentFeed`, `poll_SystemMessageSftp_OMSFulfillmentFeed`, `poll_SystemMessageFileSftp_ShopifyFulfillmentAckFeed`, `poll_SystemMessageFileSftp_OMSSyncedRefundsFeed`, `poll_SystemMessageFileSftp_ReturnsAndAppeasementsFeed`, `poll_SystemMessageFileSftp_ReturnsAndExchangeFeed`, `poll_SystemMessageFileSftp_ShopifyOrderCancelUpdatesFeed` |
+| Shopify product and catalog sync | `IMP_SHPY_PRD_IDS`, `queue_CreatedProductIdsFeed`, `queue_UpdatedProductIdsFeed`, `queue_BulkQuerySystemMessage_BulkProductAndVariantsById`, `queue_BulkQuerySystemMessage_BulkProductAndVariantsByIdQuery`, `queue_BulkQuerySystemMessage_BulkProductMetaFieldByTagsQuery`, `queue_BulkQuerySystemMessage_BulkVariantsMetafieldQuery`, `queue_BulkQuerySystemMessage_BulkVariantsMetafieldQueryt`, `consume_ShopifyProductDelete_SQS`, `sync_ShopifyProductUpdates`, `resetShopifyInventoryQoh`, `poll_SystemMessageFileSftp_NewProductsFeed`, `poll_SystemMessageFileSftp_ProductUpdatesFeed`, `poll_SystemMessageFileSftp_ProductVariantsFeed`, `poll_SystemMessageFileSftp_ProductTagsFeed`, `poll_SystemMessageFileSftp_ProductMetaFieldQueryResult`, `poll_SystemMessageFileSftp_BulkProductMetaFieldQueryResult`, `poll_SystemMessageFileSftp_ShopifyNewProductsFeed`, `poll_SystemMessageFileSftp_ShopifyUpdateProductsFeed`, `poll_SystemMessageFileSftp_ShopifyChildCatalogUpdatesFeed` |
+| Shopify bulk operation transport | `poll_BulkOperationResult_ShopifyBulkImport`, `poll_BulkOperationResult_ShopifyBulkQuery`, `poll_ShopifyBulkOperationResult`, `send_ProducedBulkMutationSystemMessage_ShopifyBulkImport`, `send_ProducedBulkOperationSystemMessage_ShopifyBulkImport`, `send_ProducedBulkOperationSystemMessage_ShopifyBulkQuery`, `send_BulkProductAndVariantsByIdQueryProducedSystemMessages`, `poll_SystemMessageFileSftp_BulkFulfillmentOrderQuery`, `poll_SystemMessageFileSftp_BulkProductMetaFieldQueryResult`, `consume_AllReceivedSystemMessages_frequent`, `consume_AllReceivedSystemMessages_oms`, `purge_OldSystemMessages` |
+| NetSuite order, customer, payment, fulfillment, and return sync | `generate_CreateOrderFeed`, `generate_CreateOrderFeed_pos`, `generate_CustomerFeed`, `generate_CustomerDepositFeed`, `generate_FulfilledOrderItemsFeed_Netsuite`, `generate_BrokeredOrderItemsFeed_Netsuite`, `sync_NetSuiteItemReceipts`, `sync_NetSuiteReturnTransactions`, `poll_fulfilledItemsNetsuiteToHotwax` |
+| NetSuite / HC restlet and CSV jobs | `HC_MR_CreateCustomerDeposit`, `HC_MR_ExportedCashSaleCSV`, `HC_MR_ExportedCustomerCSV`, `HC_MR_ExportedInventoryAdjustmentCSV`, `HC_MR_ExportedInventoryTransferCSV`, `HC_MR_ExportedSalesOrderCSV`, `HC_MR_ExportedSalesOrderFulfillmentCSV`, `HC_MR_ExportedSalesOrderItemCSV`, `HC_MR_ExportedStoreTOFulfillmentJson_v2`, `HC_MR_ExportedStoretoStoreTOJson_v2`, `HC_MR_ExportedStoretoWhTOJson_v2`, `HC_MR_ExportedWHTOFulfillmentJson_v2`, `HC_MR_ExportedWhtoStoreTOJson_v2`, `HC_SC_CreateCustomerDeposit`, `HC_SC_CreateCustomerDepositAndRefund`, `HC_SC_CreateItemFulfillment`, `HC_SC_CreateSalesOrderInvoice`, `HC_SC_GenerateProductCSV`, `HC_SC_ImportCashSale`, `HC_SC_ImportCustomer`, `HC_SC_ImportInventoryAdjustment`, `HC_SC_ImportInventoryTransfer`, `HC_SC_ImportTOFulfillmentReceipts_v2`, `HC_SC_ImportTOItemFulfillment_v2`, `HC_SC_UpdateSalesOrders`, `HC_SC_UpdateTransferOrders`, `HC_SC_UploadProductCSV`, `HC_generateCSV_InventoryItems`, `HC_importSalesOrders`, `HC_uploadCSV_InventoryItems` |
+| Inventory, transfer, receiving, and variance | `import_store_inventory_from_NS`, `Generate_Inventory_Var_Feed`, `Import_Cycle_Count_Ext_NS`, `generate_TransferOrderItemsFeed`, `generate_TransferOrderReconciliationFeed`, `generate_TransferOrderShipmentFeed`, `generate_TransferOrderShipmentReceiptFeed`, `Generate_TO_Item_Closure_Feed`, `Generate_TransferOrder_MisShipped_Rcpt_Feed`, `Generate_Transfer_Order_Sync_Ack_Feed`, `bulkApprove_StoreFulfillTransferOrders`, `bulkApprove_WarehouseTransferOrders`, `reconcile_TransferOrderReceipts`, `poll_SystemMessageFileSftp_TransferOrder`, `poll_SystemMessageFileSftp_Store_TO_Fulfillment`, `poll_SystemMessageFileSftp_Wh_TO_Fulfillment`, `migrate_sales_shipment` |
+| Routing and ATP/rule maintenance | `Order_Routing_MORNING_ORDER_GROUP`, `Order_Routing_Group_MORNING_ORDER_GROUP`, `Order_Routing_Group_PRE_ORDER_GROUP`, `Order_Routing_Group_RE_BROKERING_GROUP`, `clean_Routing_Runs`, `clean_Rule_Group_Runs` |
+| Migration/admin/background | `migrate_legacy_fulfillment_permissions`, `process_ADP_PendingWorkerHistory` |
+
+One scanner hit, `%queue_BulkQuerySystemMessage_BulkProductAndVariantsById%`, is a template placeholder and should not be shown as a job.
+
+## Wizard Output Model
+
+The final onboarding output should be a configuration package with:
+
+- ProductStore field changes.
+- ProductStoreSetting records with values and defaults.
+- Security-group recommendations by role.
+- Shopify shop, location, type, payment, channel, and shipping mappings.
+- Service job bundle with active flag, cron, `shopId`, `productStoreIds`, and identifier parameters.
+- Integration checklist for ERP/WMS/TMS/Klaviyo/Unigate/FedEx/ShipHawk.
+- Explicit non-configurable limitations when the retailer is asking for native Shopify POS accounting/reporting behavior HotWax cannot change.
+
+## Implementation Notes
+
+- Start with multi-select solution interest, then branch. Do not show unrelated settings.
+- Keep retailer language in the questions and reserve IDs for the review screen.
+- Ask for workflow ownership before asking for schedules or mappings.
+- Treat roles as part of setup: store associate, store manager, inventory manager, customer service, routing admin, integration admin, system admin.
+- Support "not sure yet" answers by recording a pending recommendation instead of forcing a setting.
+- Do not expose deprecated/replacement ProductStoreSetting IDs as normal wizard controls.
+- Validate setting-like keys such as `SHOPIFY_OIG_CHECK`, `SHP_RATE_QUERY_DATE`, and `PICK_LST_PROD_IDENT` before showing them as ProductStoreSettings; they were seen as references, not confirmed guided enum settings in this pass.

--- a/docs/superpowers/plans/2026-06-12-company-cold-start-product-store-onboarding.md
+++ b/docs/superpowers/plans/2026-06-12-company-cold-start-product-store-onboarding.md
@@ -1,0 +1,1144 @@
+# Company Cold-Start Product Store Onboarding Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a Company app create product store flow that guides a first-time Shopify retailer from an empty OMS instance to a usable product store with Shopify connection, facilities, mappings, product identity, inventory setup, users, and selected job families.
+
+**Architecture:** Treat onboarding as an orchestration UI over existing bounded APIs wherever they already exist, and as a research-backed readiness checklist where backend gaps remain. ProductStore fields and ProductStoreSetting enum IDs are grouped by setup topic in the UI; do not create per-feature settings endpoints. Non-settings setup actions such as inventory reset, user setup, Shopify job setup, AWS/SQS validation, order routing clone, and ATP rule copy get explicit backend gap contracts before the UI exposes them as executable tasks.
+
+**Tech Stack:** Vue 3, Ionic Vue, Pinia, AccxUI workspace, Moqui/Maarg REST APIs, Shopify Admin APIs, DataManager upload/log flow, service job clone/update APIs.
+
+---
+
+## Current Baseline
+
+### Existing Company App Flow
+
+- `src/views/CreateProductStore.vue`
+  - Creates the ProductStore with `productStoreId`, `storeName`, `defaultCurrencyUomId`, `companyName`, and `payToPartyId`.
+  - Redirects to `/add-configurations/:productStoreId`.
+  - Still contains DBIC/operating-country behavior that should be revalidated before building cold-start onboarding.
+- `src/views/AddConfigurations.vue`
+  - Offers manual setup or clone setup.
+  - Manual mode currently writes `orderNumberPrefix`, `autoApproveOrder`, and `productIdentifierEnumId`.
+  - Clone mode already has topic groups for ProductStore fields and ProductStoreSetting enum IDs.
+- `src/store/productStore.ts`
+  - Owns `admin/productStores`, `admin/productStores/{productStoreId}`, and `admin/productStores/{productStoreId}/settings`.
+- `src/store/shopify.ts`
+  - Owns Shopify shop, remote, type mapping, carrier/shipment mapping, location mapping, and Shopify facility import calls.
+- `src/composables/useDataManagerLog.ts`
+  - Owns DataManager log detail and file download helpers that onboarding should reuse for import task status.
+- `docs/product-store-onboarding-rest-endpoint-gaps.md`
+  - Tracks existing endpoints, candidate endpoints, and backend gaps discovered during research.
+
+### Product Store Topic Groups
+
+Use this grouping shape for setup UI and clone behavior. This is not a backend endpoint map.
+
+| Topic | ProductStore fields | ProductStoreSetting enum IDs |
+| --- | --- | --- |
+| Order configurations | `autoApproveOrder`, `orderNumberPrefix` | `SAVE_BILL_TO_INF`, `RETURN_DEADLINE_DAYS` |
+| Brokering rules | `enableBrokering`, `allowSplit` | `PRE_SLCTD_FAC_TAG`, `ORD_ITM_SHIP_FAC`, `BRK_SHPMNT_THRESHOLD` |
+| Fulfillment settings | `daysToCancelNonPay` | `FULFILL_NOTIF`, `BOPIS_PART_ODR_REJ` |
+| Inventory settings | `reserveInventory` | `INV_CNT_VIEW_QOH`, `HOLD_PRORD_PHYCL_INV`, `PRE_ORDER_GROUP_ID` |
+| Product configurations | `productIdentifierEnumId` | `PRDT_IDEN_PREF` |
+| Order edit permissions | none | `CUST_DLVRMTHD_UPDATE`, `RF_SHIPPING_METHOD`, `CUST_DLVRADR_UPDATE`, `CUST_PCKUP_UPDATE`, `CUST_ALLOW_CNCL` |
+
+### Target Cold-Start Journey
+
+1. Organization and product store basics.
+2. Shopify connection or selection of an existing Shopify shop.
+3. Facility creation/import and product-store facility association.
+4. Shopify location to HotWax facility mapping.
+5. Product identity and product import readiness.
+6. Inventory source decision and initial inventory load.
+7. User creation/import and security group assignment.
+8. Shopify job families: sales order sync, inventory-to-Shopify sync, realtime order import through EventBridge/SQS.
+9. Topic-based ProductStore fields/settings.
+10. Final readiness review with incomplete tasks, backend gaps, and next actions.
+
+## File Structure
+
+### Documentation And Research
+
+- Modify: `docs/product-store-onboarding-rest-endpoint-gaps.md`
+  - Keep endpoint research current.
+  - Mark endpoints as existing, candidate, composite, gap, or defer.
+- Create: `docs/product-store-onboarding-cold-start-research.md`
+  - Record research findings by setup area.
+  - Keep exact repo paths, services, REST resources, payload notes, and decisions.
+- Create: `docs/product-store-onboarding-test-matrix.md`
+  - Record cold-start scenarios, API smoke checks, browser checks, and backend dependency status.
+
+### Company App Config And State
+
+- Create: `src/config/productStoreOnboarding.ts`
+  - Store step definitions, topic group definitions, task IDs, required prerequisites, and backend capability flags.
+- Create: `src/store/productStoreOnboarding.ts`
+  - Own onboarding draft state, step completion, readiness checks, and calls that span existing stores.
+- Modify: `src/store/productStore.ts`
+  - Add only narrow actions that are missing for ProductStore basics or settings writes.
+- Modify: `src/store/shopify.ts`
+  - Add only narrow actions for onboarding status reads or wrappers around existing Shopify connection/mapping calls.
+
+### Company App Views And Components
+
+- Modify: `src/router/index.ts`
+  - Add a route for the multi-step onboarding experience, or replace the `/add-configurations/:productStoreId` target after the new flow is ready.
+- Modify: `src/views/CreateProductStore.vue`
+  - Keep the first ProductStore creation step focused.
+  - Route into the new onboarding flow after creation.
+- Replace or retire: `src/views/AddConfigurations.vue`
+  - Keep useful topic grouping logic by moving it into `src/config/productStoreOnboarding.ts`.
+  - Avoid maintaining two competing setup experiences after the new flow is accepted.
+- Create: `src/views/ProductStoreOnboarding.vue`
+  - Main multi-step onboarding shell.
+  - Use Ionic headers, list items, segments, toggles, selects, modals, progress, and buttons.
+  - Do not use `ion-grid`, `ion-row`, `ion-col`, or Ionic grid utility classes.
+- Create: `src/components/product-store-onboarding/OnboardingStepList.vue`
+  - Mobile-friendly task list and progress state.
+- Create: `src/components/product-store-onboarding/ProductStoreBasicsStep.vue`
+  - Product store basics review and update.
+- Create: `src/components/product-store-onboarding/ShopifyConnectionStep.vue`
+  - Existing shop selection or new Shopify connection.
+- Create: `src/components/product-store-onboarding/FacilitiesStep.vue`
+  - Facility creation/import entry points and product-store association status.
+- Create: `src/components/product-store-onboarding/ShopifyLocationMappingStep.vue`
+  - Shopify location import/audit/mapping entry point using existing mapping patterns.
+- Create: `src/components/product-store-onboarding/ProductIdentityStep.vue`
+  - Product identifier and import readiness.
+- Create: `src/components/product-store-onboarding/InventorySetupStep.vue`
+  - Inventory source decision, Shopify bulk reset path, and DataManager reset status.
+- Create: `src/components/product-store-onboarding/UserSetupStep.vue`
+  - User creation/import readiness and security group/facility association prompts.
+- Create: `src/components/product-store-onboarding/ShopifyJobsStep.vue`
+  - Sales order sync, inventory-to-Shopify sync, and realtime SQS job family setup.
+- Create: `src/components/product-store-onboarding/TopicSettingsStep.vue`
+  - ProductStore field/settings groups.
+- Create: `src/components/product-store-onboarding/ReadinessReviewStep.vue`
+  - Final review showing complete, skipped, blocked, and backend-gap tasks.
+
+### Verification
+
+- Use wrapper root: `/Users/adityapatel/Documents/GitHub/accxui`.
+- Use app path: `/Users/adityapatel/Documents/GitHub/accxui/apps/company`, which currently resolves to `/Users/adityapatel/Documents/GitHub/company`.
+- Build command: `pnpm --filter company build`.
+- Lint command: `pnpm --filter company lint`.
+- Dev command: `pnpm --filter company dev --host 0.0.0.0 --port 8111`.
+
+## Execution Plan
+
+### Task 1: Baseline Current Flow And Remove Ambiguity
+
+**Files:**
+- Read: `src/views/CreateProductStore.vue`
+- Read: `src/views/AddConfigurations.vue`
+- Read: `src/router/index.ts`
+- Read: `src/store/productStore.ts`
+- Read: `src/store/shopify.ts`
+- Modify: `docs/product-store-onboarding-cold-start-research.md`
+
+- [ ] **Step 1: Verify the active app checkout and wrapper path**
+
+Run:
+
+```bash
+pwd
+git status --short --branch
+readlink /Users/adityapatel/Documents/GitHub/accxui/apps/company
+sed -n '1,220p' /Users/adityapatel/Documents/GitHub/accxui/apps/company/package.json
+```
+
+Expected:
+
+```text
+/Users/adityapatel/Documents/GitHub/company
+```
+
+The `readlink` output must point to the same Company checkout before implementation starts.
+
+- [ ] **Step 2: Record current route behavior**
+
+Write this section into `docs/product-store-onboarding-cold-start-research.md`:
+
+```markdown
+## Current Create Flow
+
+- `/create-product-store` renders `CreateProductStore.vue`.
+- Successful ProductStore creation redirects to `/add-configurations/:productStoreId`.
+- `/add-configurations/:productStoreId` is guarded so it only opens from `CreateProductStore`.
+- Manual configuration currently writes `orderNumberPrefix`, `autoApproveOrder`, and `productIdentifierEnumId`.
+- Clone configuration copies selected ProductStore fields and ProductStoreSetting values by category.
+```
+
+- [ ] **Step 3: Record topic grouping source**
+
+Write this section into `docs/product-store-onboarding-cold-start-research.md`:
+
+```markdown
+## Product Store Topic Groups
+
+The current topic grouping lives in `src/views/AddConfigurations.vue` and `src/views/CloneProductStore.vue`.
+
+| Topic | ProductStore fields | ProductStoreSetting enum IDs |
+| --- | --- | --- |
+| Order configurations | `autoApproveOrder`, `orderNumberPrefix` | `SAVE_BILL_TO_INF`, `RETURN_DEADLINE_DAYS` |
+| Brokering rules | `enableBrokering`, `allowSplit` | `PRE_SLCTD_FAC_TAG`, `ORD_ITM_SHIP_FAC`, `BRK_SHPMNT_THRESHOLD` |
+| Fulfillment settings | `daysToCancelNonPay` | `FULFILL_NOTIF`, `BOPIS_PART_ODR_REJ` |
+| Inventory settings | `reserveInventory` | `INV_CNT_VIEW_QOH`, `HOLD_PRORD_PHYCL_INV`, `PRE_ORDER_GROUP_ID` |
+| Product configurations | `productIdentifierEnumId` | `PRDT_IDEN_PREF` |
+| Order edit permissions | none | `CUST_DLVRMTHD_UPDATE`, `RF_SHIPPING_METHOD`, `CUST_DLVRADR_UPDATE`, `CUST_PCKUP_UPDATE`, `CUST_ALLOW_CNCL` |
+```
+
+- [ ] **Step 4: Commit the research baseline**
+
+Run:
+
+```bash
+git add docs/product-store-onboarding-cold-start-research.md
+git commit -m "docs: capture product store onboarding baseline"
+```
+
+### Task 2: Build The Backend Capability Matrix
+
+**Files:**
+- Modify: `docs/product-store-onboarding-rest-endpoint-gaps.md`
+- Modify: `docs/product-store-onboarding-cold-start-research.md`
+
+- [ ] **Step 1: Verify existing endpoint claims from Company code**
+
+Run:
+
+```bash
+rg -n "admin/productStores|productStores/.*/settings|oms/shopifyShops|oms/systemMessageRemotes|admin/serviceJobs|admin/dataManager|uploadDataManagerFile|shopify/webhook-subscription" src docs
+```
+
+Expected records to classify as existing:
+
+```text
+admin/productStores
+admin/productStores/{productStoreId}
+admin/productStores/{productStoreId}/settings
+oms/shopifyShops/shops
+oms/shopifyShops/typeMappings
+oms/shopifyShops/locations
+oms/shopifyShops/carrierShipments
+oms/systemMessageRemotes
+admin/serviceJobs
+admin/dataManager
+admin/uploadDataManagerFile
+admin/dataManager/downloadDataManagerFile
+shopify/webhook-subscription
+```
+
+- [ ] **Step 2: Verify backend service ownership from local Moqui repos**
+
+Run from `/Users/adityapatel/Documents/GitHub`:
+
+```bash
+rg -n "admin/productStores|uploadDataManagerFile|downloadTemplate|create#WebhookSubscription|consume#SQSOrderMessages|resetShopifyInventoryQoh|queue_ShopifyOrderSync|sync_ShopifyOrderHistory|ExternalInventoryReset|create#ExternalInventoryReset|reset#InventoryItem|DataManagerConfig" hotwax-maarg-util hotwax-shopify-oms-bridge mantle-shopify-connector hotwax-poorti mantle-netsuite-connector oms
+```
+
+Record every confirmed owner in `docs/product-store-onboarding-cold-start-research.md` under:
+
+```markdown
+## Backend Capability Matrix
+
+| Setup area | Existing capability | Owner | Endpoint/service | Gap |
+| --- | --- | --- | --- | --- |
+```
+
+- [ ] **Step 3: Reclassify backend gaps**
+
+Ensure `docs/product-store-onboarding-rest-endpoint-gaps.md` classifies these as gaps or composites:
+
+```markdown
+- `POST /rest/s1/admin/jwtTokens`
+- generic inventory reset DataManager config and file-consuming service
+- `POST /rest/s1/shopify/shops/{shopId}/inventory/reset-file-from-shopify`
+- `POST /rest/s1/admin/users/setup`
+- order routing clone wrapper
+- ATP rule copy wrapper
+- Shopify job family status/setup wrappers
+- optional AWS EventBridge/SQS provisioning service
+```
+
+- [ ] **Step 4: Confirm settings are not backend gaps**
+
+Run:
+
+```bash
+rg -n "features/.*/settings|Feature Setup Endpoints|per-feature settings endpoints" docs/product-store-onboarding-rest-endpoint-gaps.md
+```
+
+Expected: no matches.
+
+- [ ] **Step 5: Commit capability matrix updates**
+
+Run:
+
+```bash
+git add docs/product-store-onboarding-rest-endpoint-gaps.md docs/product-store-onboarding-cold-start-research.md
+git commit -m "docs: map onboarding backend capabilities"
+```
+
+### Task 3: Define The User Journey And Step Model
+
+**Files:**
+- Create: `src/config/productStoreOnboarding.ts`
+- Modify: `docs/product-store-onboarding-cold-start-research.md`
+
+- [ ] **Step 1: Create onboarding step config**
+
+Create `src/config/productStoreOnboarding.ts` with this initial content:
+
+```ts
+export type OnboardingStepStatus = "not-started" | "ready" | "complete" | "blocked" | "skipped";
+
+export type OnboardingTaskId =
+  | "product-store-basics"
+  | "shopify-connection"
+  | "facilities"
+  | "shopify-location-mapping"
+  | "product-identity"
+  | "inventory-source"
+  | "users"
+  | "shopify-order-sync"
+  | "shopify-inventory-sync"
+  | "shopify-realtime-orders"
+  | "topic-settings"
+  | "readiness-review";
+
+export interface OnboardingTaskDefinition {
+  id: OnboardingTaskId;
+  label: string;
+  requiredForColdStart: boolean;
+  backendCapability:
+    | "existing"
+    | "existing-wrapper-needed"
+    | "backend-gap"
+    | "manual-validation";
+}
+
+export interface ProductStoreSetupTopic {
+  id: string;
+  label: string;
+  productStoreFields: string[];
+  settingTypeEnumIds: string[];
+}
+
+export const PRODUCT_STORE_SETUP_TOPICS: ProductStoreSetupTopic[] = [
+  {
+    id: "order",
+    label: "Order configurations",
+    productStoreFields: ["autoApproveOrder", "orderNumberPrefix"],
+    settingTypeEnumIds: ["SAVE_BILL_TO_INF", "RETURN_DEADLINE_DAYS"]
+  },
+  {
+    id: "brokering",
+    label: "Brokering rules",
+    productStoreFields: ["enableBrokering", "allowSplit"],
+    settingTypeEnumIds: ["PRE_SLCTD_FAC_TAG", "ORD_ITM_SHIP_FAC", "BRK_SHPMNT_THRESHOLD"]
+  },
+  {
+    id: "fulfillment",
+    label: "Fulfillment settings",
+    productStoreFields: ["daysToCancelNonPay"],
+    settingTypeEnumIds: ["FULFILL_NOTIF", "BOPIS_PART_ODR_REJ"]
+  },
+  {
+    id: "inventory",
+    label: "Inventory settings",
+    productStoreFields: ["reserveInventory"],
+    settingTypeEnumIds: ["INV_CNT_VIEW_QOH", "HOLD_PRORD_PHYCL_INV", "PRE_ORDER_GROUP_ID"]
+  },
+  {
+    id: "product",
+    label: "Product configurations",
+    productStoreFields: ["productIdentifierEnumId"],
+    settingTypeEnumIds: ["PRDT_IDEN_PREF"]
+  },
+  {
+    id: "permissions",
+    label: "Order edit permissions",
+    productStoreFields: [],
+    settingTypeEnumIds: ["CUST_DLVRMTHD_UPDATE", "RF_SHIPPING_METHOD", "CUST_DLVRADR_UPDATE", "CUST_PCKUP_UPDATE", "CUST_ALLOW_CNCL"]
+  }
+];
+
+export const COLD_START_ONBOARDING_TASKS: OnboardingTaskDefinition[] = [
+  { id: "product-store-basics", label: "Product store basics", requiredForColdStart: true, backendCapability: "existing" },
+  { id: "shopify-connection", label: "Shopify connection", requiredForColdStart: true, backendCapability: "existing" },
+  { id: "facilities", label: "Facilities", requiredForColdStart: true, backendCapability: "existing-wrapper-needed" },
+  { id: "shopify-location-mapping", label: "Shopify location mapping", requiredForColdStart: true, backendCapability: "existing" },
+  { id: "product-identity", label: "Product identity", requiredForColdStart: true, backendCapability: "existing" },
+  { id: "inventory-source", label: "Inventory source and initial load", requiredForColdStart: true, backendCapability: "backend-gap" },
+  { id: "users", label: "Users and roles", requiredForColdStart: true, backendCapability: "backend-gap" },
+  { id: "shopify-order-sync", label: "Shopify sales order sync", requiredForColdStart: true, backendCapability: "existing-wrapper-needed" },
+  { id: "shopify-inventory-sync", label: "Inventory sync to Shopify", requiredForColdStart: false, backendCapability: "existing-wrapper-needed" },
+  { id: "shopify-realtime-orders", label: "Realtime order import", requiredForColdStart: false, backendCapability: "manual-validation" },
+  { id: "topic-settings", label: "Setup topics", requiredForColdStart: true, backendCapability: "existing" },
+  { id: "readiness-review", label: "Readiness review", requiredForColdStart: true, backendCapability: "existing" }
+];
+```
+
+- [ ] **Step 2: Document the step model**
+
+Add this section to `docs/product-store-onboarding-cold-start-research.md`:
+
+```markdown
+## Target Onboarding Step Model
+
+The UI should show the user a cold-start checklist instead of a raw settings form. Each step explains the setup task, runs the available validation, and either performs the action or marks the backend gap clearly.
+
+Required cold-start tasks:
+- product store basics
+- Shopify connection
+- facilities
+- Shopify location mapping
+- product identity
+- inventory source and initial load
+- users and roles
+- Shopify sales order sync
+- setup topics
+- readiness review
+
+Optional or conditional tasks:
+- inventory sync to Shopify
+- realtime order import through EventBridge/SQS
+- order routing clone
+- ATP rule copy
+- preorder jobs
+```
+
+- [ ] **Step 3: Build-test the config**
+
+Run from `/Users/adityapatel/Documents/GitHub/accxui`:
+
+```bash
+pnpm --filter company build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit the step model**
+
+Run:
+
+```bash
+git add src/config/productStoreOnboarding.ts docs/product-store-onboarding-cold-start-research.md
+git commit -m "feat: define product store onboarding steps"
+```
+
+### Task 4: Design Backend Contracts Before UI Execution
+
+**Files:**
+- Modify: `docs/product-store-onboarding-rest-endpoint-gaps.md`
+- Modify: `docs/product-store-onboarding-cold-start-research.md`
+
+- [ ] **Step 1: Write contract for onboarding status**
+
+Add this candidate contract to `docs/product-store-onboarding-rest-endpoint-gaps.md`:
+
+````markdown
+### Onboarding Status Contract
+
+Candidate endpoint: `GET /rest/s1/admin/productStores/{productStoreId}/onboarding/status`
+
+Purpose: return setup readiness for the selected product store without performing writes.
+
+Response shape:
+
+```json
+{
+  "productStoreId": "STORE",
+  "shopify": {
+    "shopId": "SHOP",
+    "remoteId": "SHOP_REMOTE",
+    "accessScopeEnumId": "SHOP_RW_ACCESS",
+    "hasReadWriteAccess": true
+  },
+  "facilities": {
+    "associatedCount": 4,
+    "missingShopifyMappings": 0
+  },
+  "dataManager": {
+    "facilityImportConfigId": "FACILITY_IMPORT",
+    "inventoryResetConfigId": null,
+    "userImportConfigId": "USER_IMPORT"
+  },
+  "jobs": {
+    "orderSyncConfigured": false,
+    "inventorySyncConfigured": false,
+    "realtimeOrderImportConfigured": false
+  },
+  "blockedReasons": [
+    {
+      "taskId": "inventory-source",
+      "message": "Generic inventory reset DataManager config is missing."
+    }
+  ]
+}
+```
+````
+
+- [ ] **Step 2: Write contract for non-settings setup actions**
+
+Add this candidate contract list to `docs/product-store-onboarding-rest-endpoint-gaps.md`:
+
+````markdown
+### Non-Settings Setup Action Contracts
+
+These are not ProductStoreSetting endpoints.
+
+| Action | Candidate endpoint | Purpose |
+| --- | --- | --- |
+| Status | `GET /rest/s1/admin/productStores/{productStoreId}/onboarding/status` | Read readiness across product store, shop, facilities, DataManager, users, and jobs. |
+| User setup | `POST /rest/s1/admin/users/setup` | Create one user and associate selected security groups/facilities/product stores. |
+| Inventory reset from Shopify | `POST /rest/s1/shopify/shops/{shopId}/inventory/reset-file-from-shopify` | Run Shopify bulk inventory query, transform `on_hand`, and create a DataManager reset log. |
+| Shopify jobs | `GET /rest/s1/admin/productStores/{productStoreId}/shopifyJobs/status` | Read draft job, cloned job, webhook, SQS, and access-scope readiness. |
+| Shopify order sync jobs | `PUT /rest/s1/admin/productStores/{productStoreId}/shopifyJobs/orderImport` | Configure fallback/history order sync jobs. |
+| Shopify inventory sync jobs | `PUT /rest/s1/admin/productStores/{productStoreId}/shopifyJobs/inventoryToShopify` | Configure outbound inventory sync and `SHOPIFY_INV_SYNC`. |
+| Realtime order import | `PUT /rest/s1/admin/productStores/{productStoreId}/shopifyJobs/realtimeOrders/awsSqs` | Store/validate AWS SQS connection and webhook EventBridge ARN. |
+```
+````
+
+- [ ] **Step 3: Create backend issue list**
+
+In `docs/product-store-onboarding-cold-start-research.md`, add:
+
+```markdown
+## Backend Issue List
+
+1. Add onboarding status endpoint.
+2. Add generic inventory reset DataManager config and QOH-only reset service.
+3. Add Shopify bulk inventory reset orchestration.
+4. Add setup-safe user creation and security group association endpoint.
+5. Add Shopify job status/setup wrappers for order sync, inventory sync, and realtime SQS.
+6. Decide whether realtime SQS uses one instance-wide consumer or per-shop cloned consumers.
+7. Keep AWS EventBridge/SQS resource provisioning out of v1 unless least-privilege IAM and rollback are designed.
+```
+
+- [ ] **Step 4: Commit backend contract docs**
+
+Run:
+
+```bash
+git add docs/product-store-onboarding-rest-endpoint-gaps.md docs/product-store-onboarding-cold-start-research.md
+git commit -m "docs: define onboarding backend contracts"
+```
+
+### Task 5: Build The Company App Onboarding Shell
+
+**Files:**
+- Create: `src/store/productStoreOnboarding.ts`
+- Create: `src/views/ProductStoreOnboarding.vue`
+- Create: `src/components/product-store-onboarding/OnboardingStepList.vue`
+- Modify: `src/router/index.ts`
+- Modify: `src/views/CreateProductStore.vue`
+
+- [ ] **Step 1: Create onboarding store**
+
+Create `src/store/productStoreOnboarding.ts` with state for selected product store, current task, task statuses, and selected setup topics. The store should import `COLD_START_ONBOARDING_TASKS` and `PRODUCT_STORE_SETUP_TOPICS` from `src/config/productStoreOnboarding.ts`.
+
+Minimum behavior:
+
+```ts
+import { defineStore } from "pinia";
+import { COLD_START_ONBOARDING_TASKS, PRODUCT_STORE_SETUP_TOPICS, type OnboardingTaskId, type OnboardingStepStatus } from "@/config/productStoreOnboarding";
+
+type TaskStatusMap = Record<OnboardingTaskId, OnboardingStepStatus>;
+
+function createInitialTaskStatus(): TaskStatusMap {
+  return COLD_START_ONBOARDING_TASKS.reduce((acc, task) => {
+    acc[task.id] = task.backendCapability === "backend-gap" ? "blocked" : "not-started";
+    return acc;
+  }, {} as TaskStatusMap);
+}
+
+export const useProductStoreOnboardingStore = defineStore("productStoreOnboarding", {
+  state: () => ({
+    productStoreId: "",
+    currentTaskId: "product-store-basics" as OnboardingTaskId,
+    taskStatus: createInitialTaskStatus(),
+    selectedTopicIds: PRODUCT_STORE_SETUP_TOPICS.map((topic) => topic.id)
+  }),
+  getters: {
+    tasks: () => COLD_START_ONBOARDING_TASKS,
+    selectedTopics: (state) => PRODUCT_STORE_SETUP_TOPICS.filter((topic) => state.selectedTopicIds.includes(topic.id)),
+    isComplete: (state) => Object.values(state.taskStatus).every((status) => status === "complete" || status === "skipped")
+  },
+  actions: {
+    start(productStoreId: string) {
+      this.productStoreId = productStoreId;
+      this.currentTaskId = "product-store-basics";
+      this.taskStatus = createInitialTaskStatus();
+    },
+    setCurrentTask(taskId: OnboardingTaskId) {
+      this.currentTaskId = taskId;
+    },
+    setTaskStatus(taskId: OnboardingTaskId, status: OnboardingStepStatus) {
+      this.taskStatus[taskId] = status;
+    },
+    setSelectedTopicIds(topicIds: string[]) {
+      this.selectedTopicIds = topicIds;
+    }
+  },
+  persist: true
+});
+```
+
+- [ ] **Step 2: Add onboarding route**
+
+Modify `src/router/index.ts`:
+
+```ts
+const ProductStoreOnboarding = () => import('@/views/ProductStoreOnboarding.vue')
+```
+
+Add route:
+
+```ts
+{
+  path: '/product-store-onboarding/:productStoreId',
+  name: 'ProductStoreOnboarding',
+  component: ProductStoreOnboarding,
+  props: true,
+  beforeEnter: authGuard
+}
+```
+
+- [ ] **Step 3: Route newly created stores into onboarding**
+
+In `src/views/CreateProductStore.vue`, replace:
+
+```ts
+router.replace(`/add-configurations/${productStoreId}`);
+```
+
+with:
+
+```ts
+router.replace(`/product-store-onboarding/${productStoreId}`);
+```
+
+- [ ] **Step 4: Create step list component**
+
+Create `src/components/product-store-onboarding/OnboardingStepList.vue` using `ion-list`, `ion-item`, `ion-label`, `ion-icon`, `ion-badge`, and `ion-button`. Do not add CSS. Each row should show label, status, and whether the task is blocked because a backend gap remains.
+
+- [ ] **Step 5: Create onboarding shell view**
+
+Create `src/views/ProductStoreOnboarding.vue` with:
+
+- `ion-page`
+- `ion-header`
+- `ion-toolbar`
+- `ion-back-button`
+- `ion-title`
+- `ion-progress-bar`
+- `ion-content`
+- `OnboardingStepList`
+- one detail panel for the selected task
+- footer buttons for previous, skip, and continue
+
+Do not use `ion-grid`, custom CSS, or repeated explanatory copy inside every step.
+
+- [ ] **Step 6: Build and lint**
+
+Run from `/Users/adityapatel/Documents/GitHub/accxui`:
+
+```bash
+pnpm --filter company lint
+pnpm --filter company build
+```
+
+Expected: both commands succeed.
+
+- [ ] **Step 7: Commit onboarding shell**
+
+Run:
+
+```bash
+git add src/config/productStoreOnboarding.ts src/store/productStoreOnboarding.ts src/views/ProductStoreOnboarding.vue src/components/product-store-onboarding/OnboardingStepList.vue src/router/index.ts src/views/CreateProductStore.vue
+git commit -m "feat: add product store onboarding shell"
+```
+
+### Task 6: Implement Existing-Endpoint Steps
+
+**Files:**
+- Create: `src/components/product-store-onboarding/ProductStoreBasicsStep.vue`
+- Create: `src/components/product-store-onboarding/ShopifyConnectionStep.vue`
+- Create: `src/components/product-store-onboarding/ShopifyLocationMappingStep.vue`
+- Create: `src/components/product-store-onboarding/ProductIdentityStep.vue`
+- Create: `src/components/product-store-onboarding/TopicSettingsStep.vue`
+- Modify: `src/views/ProductStoreOnboarding.vue`
+- Modify: `src/store/productStoreOnboarding.ts`
+
+- [ ] **Step 1: Product store basics**
+
+Implement `ProductStoreBasicsStep.vue` so it reads and writes:
+
+- `storeName`
+- `defaultCurrencyUomId`
+- `orderNumberPrefix`
+- `autoApproveOrder`
+
+Use:
+
+```ts
+productStoreStore.fetchProductStoreDetails(productStoreId)
+productStoreStore.updateProductStore(payload)
+```
+
+- [ ] **Step 2: Shopify connection**
+
+Implement `ShopifyConnectionStep.vue` so the user can:
+
+- select an existing Shopify shop from `shopifyStore.fetchShopifyShops()`
+- create a new Shopify connection using `shopifyStore.createShopifyConnection(payload)`
+- associate the shop to the product store through `productStoreId`
+
+Show a blocked state only when no Shopify connection can be created because required credentials are unavailable.
+
+- [ ] **Step 3: Shopify location mapping**
+
+Implement `ShopifyLocationMappingStep.vue` as a task entry point that reuses the existing route:
+
+```ts
+router.push(`/shopify-connection-details/${shopId}/locations`)
+```
+
+Also show current mapping count from:
+
+```ts
+shopifyStore.fetchShopifyShopLocations()
+utilStore.fetchFacilities()
+```
+
+- [ ] **Step 4: Product identity**
+
+Implement `ProductIdentityStep.vue` using:
+
+```ts
+utilStore.fetchProductIdentifiers()
+productStoreStore.updateProductStore({
+  ...productStore,
+  productIdentifierEnumId
+})
+```
+
+- [ ] **Step 5: Topic settings**
+
+Implement `TopicSettingsStep.vue` using `PRODUCT_STORE_SETUP_TOPICS`.
+
+Rules:
+
+- Do not create per-feature endpoints.
+- Write ProductStore fields through `productStoreStore.updateProductStore`.
+- Write settings through `productStoreStore.saveCurrentStoreSettings`.
+- Only show topics selected for the user's chosen setup path.
+- Leave untouched settings unchanged.
+
+- [ ] **Step 6: Build and lint**
+
+Run:
+
+```bash
+cd /Users/adityapatel/Documents/GitHub/accxui
+pnpm --filter company lint
+pnpm --filter company build
+```
+
+Expected: both commands succeed.
+
+- [ ] **Step 7: Commit existing-endpoint steps**
+
+Run:
+
+```bash
+git add src/components/product-store-onboarding src/views/ProductStoreOnboarding.vue src/store/productStoreOnboarding.ts
+git commit -m "feat: implement existing onboarding steps"
+```
+
+### Task 7: Implement Import And Backend-Gap Steps As Honest Task Cards
+
+**Files:**
+- Create: `src/components/product-store-onboarding/FacilitiesStep.vue`
+- Create: `src/components/product-store-onboarding/InventorySetupStep.vue`
+- Create: `src/components/product-store-onboarding/UserSetupStep.vue`
+- Create: `src/components/product-store-onboarding/ShopifyJobsStep.vue`
+- Create: `src/components/product-store-onboarding/ReadinessReviewStep.vue`
+- Modify: `src/views/ProductStoreOnboarding.vue`
+- Modify: `docs/product-store-onboarding-test-matrix.md`
+
+- [ ] **Step 1: Facilities step**
+
+The facilities step should show:
+
+- create facility task using existing `POST /rest/s1/admin/facilities`
+- facility CSV import task using `POST /rest/s1/admin/uploadDataManagerFile`
+- template download using `GET /rest/s1/admin/dataManager/{configId}/downloadTemplate`
+- import log status using `GET /rest/s1/admin/dataManager/details`
+
+If the facility import `configId` is not confirmed, show the task as blocked and record it in the readiness review.
+
+- [ ] **Step 2: Inventory setup step**
+
+The inventory setup step should separate three directions:
+
+- Shopify inventory to OMS initial reset.
+- OMS inventory to Shopify ongoing sync.
+- Manual CSV inventory reset.
+
+Show backend-gap state for the generic inventory reset DataManager config until the backend issue is resolved.
+
+- [ ] **Step 3: User setup step**
+
+The user step should separate:
+
+- create one user
+- import users by CSV
+- associate security groups
+- associate store/facility access
+
+Show backend-gap state for `POST /rest/s1/admin/users/setup` until the backend issue is resolved.
+
+- [ ] **Step 4: Shopify jobs step**
+
+The Shopify jobs step should show three job families:
+
+- sales order sync
+- inventory sync to Shopify
+- realtime order import through EventBridge/SQS
+
+Show assisted manual AWS setup for realtime order import. Do not imply that Moqui can create AWS EventBridge/SQS infrastructure until that backend service exists.
+
+- [ ] **Step 5: Readiness review step**
+
+The readiness review should group tasks into:
+
+- complete
+- skipped
+- blocked by backend gap
+- blocked by missing user input
+
+The user should be able to finish setup only if required cold-start tasks are complete or intentionally skipped with a reason.
+
+- [ ] **Step 6: Create test matrix**
+
+Create `docs/product-store-onboarding-test-matrix.md` with:
+
+```markdown
+# Product Store Onboarding Test Matrix
+
+## Personas
+
+| Persona | Shopify connected? | Existing product stores? | Facilities? | Inventory source |
+| --- | --- | --- | --- | --- |
+| Cold-start Shopify retailer | No | No | No | Shopify |
+| Existing Shopify retailer | Yes | No | No | Shopify |
+| Existing HotWax customer adding a brand | Yes | Yes | Yes | HotWax |
+| Non-realtime order sync customer | Yes | Yes | Yes | HotWax |
+
+## Required Browser Checks
+
+| Scenario | Expected result |
+| --- | --- |
+| Create first product store | Product store is created and user lands in onboarding. |
+| Create another product store | User lands in onboarding without first-store-only company prompts blocking progress. |
+| Skip optional realtime order import | Readiness review marks realtime as skipped, not failed. |
+| Backend gap visible | Missing inventory reset/user setup/job wrapper appears as blocked with exact next action. |
+| Mobile viewport | Steps, buttons, selects, and long labels fit without overlap. |
+```
+
+- [ ] **Step 7: Build and lint**
+
+Run:
+
+```bash
+cd /Users/adityapatel/Documents/GitHub/accxui
+pnpm --filter company lint
+pnpm --filter company build
+```
+
+Expected: both commands succeed.
+
+- [ ] **Step 8: Commit task cards**
+
+Run:
+
+```bash
+git add src/components/product-store-onboarding src/views/ProductStoreOnboarding.vue docs/product-store-onboarding-test-matrix.md
+git commit -m "feat: add onboarding task cards and readiness review"
+```
+
+### Task 8: Browser And API Verification
+
+**Files:**
+- Modify: `docs/product-store-onboarding-test-matrix.md`
+
+- [ ] **Step 1: Start Company app from wrapper root**
+
+Run:
+
+```bash
+cd /Users/adityapatel/Documents/GitHub/accxui
+pnpm --filter company dev --host 0.0.0.0 --port 8111
+```
+
+Expected:
+
+```text
+Local: http://localhost:8111/
+```
+
+If port `8111` is already in use, use the next open port and record it in the test matrix.
+
+- [ ] **Step 2: Verify current browser route**
+
+Open:
+
+```text
+http://localhost:8111/create-product-store
+```
+
+Expected:
+
+- user can create a product store
+- success routes to `/product-store-onboarding/{productStoreId}`
+- progress indicator is visible
+- no text overlaps on desktop
+
+- [ ] **Step 3: Verify mobile viewport**
+
+Use the browser testing tool at a mobile width.
+
+Expected:
+
+- all steps remain reachable
+- footer actions do not cover content
+- long task labels wrap cleanly
+- no `ion-grid`, `ion-row`, or `ion-col` layout is introduced
+
+- [ ] **Step 4: Verify backend writes**
+
+Using the app and network panel, verify these calls happen only when the user reaches the relevant step:
+
+```text
+POST /rest/s1/admin/productStores
+PUT /rest/s1/admin/productStores/{productStoreId}
+GET /rest/s1/admin/productStores/{productStoreId}/settings
+POST /rest/s1/admin/productStores/{productStoreId}/settings
+GET /rest/s1/oms/shopifyShops/shops
+POST /rest/s1/oms/shopifyShops/shops
+POST /rest/s1/oms/systemMessageRemotes
+GET /rest/s1/oms/shopifyShops/locations
+POST /rest/s1/oms/shopifyShops/locations
+```
+
+- [ ] **Step 5: Verify blocked backend gaps**
+
+In a cold-start test instance where the backend gaps are not implemented, verify:
+
+- generic inventory reset is blocked
+- user setup is blocked
+- Shopify job setup wrappers are blocked or manual-validation only
+- readiness review names the exact missing backend work
+
+- [ ] **Step 6: Record results**
+
+Append this section to `docs/product-store-onboarding-test-matrix.md`:
+
+```markdown
+## Verification Results
+
+| Date | Environment | Result | Notes |
+| --- | --- | --- | --- |
+| 2026-06-12 | local Company app + local Moqui | Not run | Record exact port, productStoreId, shopId, and failed checks during execution. |
+```
+
+- [ ] **Step 7: Commit verification notes**
+
+Run:
+
+```bash
+git add docs/product-store-onboarding-test-matrix.md
+git commit -m "test: document product store onboarding verification"
+```
+
+### Task 9: Release Readiness And PR Packaging
+
+**Files:**
+- Modify: `docs/product-store-onboarding-cold-start-research.md`
+- Modify: `docs/product-store-onboarding-test-matrix.md`
+
+- [ ] **Step 1: Final static checks**
+
+Run:
+
+```bash
+cd /Users/adityapatel/Documents/GitHub/accxui
+pnpm --filter company lint
+pnpm --filter company build
+```
+
+Expected: both commands succeed.
+
+- [ ] **Step 2: Check for forbidden Ionic layout**
+
+Run:
+
+```bash
+rg -n "ion-grid|ion-row|ion-col" src/views src/components
+```
+
+Expected: no new matches from onboarding files.
+
+- [ ] **Step 3: Check for feature-specific settings endpoints**
+
+Run:
+
+```bash
+rg -n "features/.*/settings|bopis/settings|shipFromStore/settings|storeInventory/settings|preorders/settings" src docs
+```
+
+Expected: no matches.
+
+- [ ] **Step 4: Check for accidental broad CSS changes**
+
+Run:
+
+```bash
+git diff --name-only main...HEAD | rg "\\.css$|\\.scss$|\\.sass$|style"
+```
+
+Expected: no onboarding-related stylesheet churn. Scoped style blocks should be absent unless an explicit implementation review approved them.
+
+- [ ] **Step 5: Prepare PR summary**
+
+Use this PR business summary:
+
+```markdown
+## Business Summary
+
+This PR turns product store creation into a guided cold-start onboarding flow for Shopify retailers. Instead of dropping users into a small configuration form, the Company app now walks them through the OMS setup journey: product store basics, Shopify connection, facilities, Shopify location mapping, product identity, inventory setup, user setup, Shopify job families, topic-based settings, and final readiness review.
+
+The implementation uses existing ProductStore and ProductStoreSetting endpoints for settings and keeps real backend gaps visible as blocked setup tasks rather than hiding them behind incomplete UI.
+
+## Validation
+
+- `pnpm --filter company lint`
+- `pnpm --filter company build`
+- Browser verification on desktop and mobile viewports
+- Cold-start readiness checks recorded in `docs/product-store-onboarding-test-matrix.md`
+```
+
+- [ ] **Step 6: Create final commit**
+
+Run:
+
+```bash
+git status --short
+git add docs src
+git commit -m "feat: guide cold-start product store onboarding"
+```
+
+## Research Checklist
+
+Use this list before implementation starts and again before PR.
+
+- [ ] ProductStore creation payload is confirmed against live Moqui.
+- [ ] First-store company-name behavior is confirmed or removed from the cold-start flow.
+- [ ] DBIC operating-country behavior is confirmed as still needed or removed from onboarding.
+- [ ] ProductStore topic groups are centralized in `src/config/productStoreOnboarding.ts`.
+- [ ] No feature-specific settings endpoints are planned or implemented.
+- [ ] Facility creation/import path is confirmed.
+- [ ] Shopify location import/mapping path is confirmed.
+- [ ] Product identity values are confirmed from `SHOP_PROD_IDENTITY`.
+- [ ] Generic inventory reset backend gap is tracked.
+- [ ] Shopify bulk inventory reset backend gap is tracked.
+- [ ] User setup backend gap is tracked.
+- [ ] Shopify job family setup backend gaps are tracked.
+- [ ] AWS/EventBridge/SQS setup is manual-validation only until provisioning backend exists.
+- [ ] Readiness review shows exact blockers instead of letting the user think setup is complete.
+
+## Test Plan
+
+### Static Tests
+
+Run:
+
+```bash
+cd /Users/adityapatel/Documents/GitHub/accxui
+pnpm --filter company lint
+pnpm --filter company build
+rg -n "ion-grid|ion-row|ion-col" /Users/adityapatel/Documents/GitHub/company/src/views /Users/adityapatel/Documents/GitHub/company/src/components
+rg -n "features/.*/settings|bopis/settings|shipFromStore/settings|storeInventory/settings|preorders/settings" /Users/adityapatel/Documents/GitHub/company/src /Users/adityapatel/Documents/GitHub/company/docs
+```
+
+Expected:
+
+- lint passes
+- build passes
+- no new Ionic grid matches
+- no feature-specific settings endpoint matches
+
+### Browser Tests
+
+Run:
+
+```bash
+cd /Users/adityapatel/Documents/GitHub/accxui
+pnpm --filter company dev --host 0.0.0.0 --port 8111
+```
+
+Check:
+
+- desktop `/create-product-store`
+- desktop `/product-store-onboarding/{productStoreId}`
+- mobile `/create-product-store`
+- mobile `/product-store-onboarding/{productStoreId}`
+- existing-store create flow
+- first-store create flow
+- Shopify connected path
+- Shopify not connected path
+- skipped optional realtime order import path
+- blocked backend-gap path
+
+### API Smoke Tests
+
+Use the authenticated app session and network panel to verify:
+
+```text
+POST /rest/s1/admin/productStores
+PUT /rest/s1/admin/productStores/{productStoreId}
+GET /rest/s1/admin/productStores/{productStoreId}/settings
+POST /rest/s1/admin/productStores/{productStoreId}/settings
+GET /rest/s1/oms/shopifyShops/shops
+POST /rest/s1/oms/systemMessageRemotes
+POST /rest/s1/oms/shopifyShops/shops
+GET /rest/s1/oms/shopifyShops/locations
+POST /rest/s1/oms/shopifyShops/locations
+GET /rest/s1/admin/dataManager/details
+GET /rest/s1/admin/dataManager/downloadDataManagerFile
+```
+
+Expected:
+
+- settings are saved only through ProductStoreSetting endpoint
+- ProductStore fields are saved only through ProductStore endpoint
+- blocked backend gaps do not fire fake API calls
+- skipped optional steps are recorded in readiness state
+
+## Definition Of Done
+
+- A first-time Shopify retailer can create a ProductStore and land in a guided onboarding flow.
+- The flow covers the full cold-start OMS journey, not only ProductStore fields.
+- Existing endpoints are used where they exist.
+- Backend gaps are explicit and actionable.
+- ProductStore fields and ProductStoreSetting enum IDs are grouped by topic in the UI.
+- No per-feature settings endpoints exist.
+- No Ionic grid layout is introduced.
+- The flow is mobile-compatible.
+- The readiness review gives an honest setup state: complete, skipped, blocked, or needs input.
+- Lint, build, browser checks, and API smoke checks are recorded before PR.

--- a/src/components/product-store-onboarding/OnboardingStepList.vue
+++ b/src/components/product-store-onboarding/OnboardingStepList.vue
@@ -1,0 +1,49 @@
+<template>
+  <ion-list lines="full">
+    <template v-for="group in groups" :key="group.id">
+      <ion-list-header>
+        <ion-label>{{ translate(group.label) }}</ion-label>
+      </ion-list-header>
+      <ion-item
+        v-for="step in stepsByGroup(group.id)"
+        :key="step.id"
+        button
+        :detail="false"
+        :color="step.id === currentStepId ? 'light' : undefined"
+        @click="$emit('select-step', step.id)"
+      >
+        <ion-label>{{ translate(step.label) }}</ion-label>
+        <ion-badge v-if="step.capability === 'backend-gap'" slot="end" color="warning">
+          {{ translate("Gap") }}
+        </ion-badge>
+        <ion-icon
+          slot="end"
+          :color="completedStepIds.includes(step.id) ? 'success' : 'medium'"
+          :icon="completedStepIds.includes(step.id) ? checkmarkCircleOutline : radioButtonOffOutline"
+        />
+      </ion-item>
+    </template>
+  </ion-list>
+</template>
+
+<script setup lang="ts">
+import { IonBadge, IonIcon, IonItem, IonLabel, IonList, IonListHeader } from "@ionic/vue"
+import { checkmarkCircleOutline, radioButtonOffOutline } from "ionicons/icons"
+import { translate } from "@common"
+import type { ProductStoreOnboardingGroup, ProductStoreOnboardingStep } from "@/config/productStoreOnboarding"
+
+const props = defineProps<{
+  groups: ProductStoreOnboardingGroup[]
+  steps: ProductStoreOnboardingStep[]
+  currentStepId: string
+  completedStepIds: string[]
+}>()
+
+defineEmits<{
+  (event: "select-step", stepId: string): void
+}>()
+
+function stepsByGroup(groupId: string) {
+  return props.steps.filter((step) => step.group === groupId)
+}
+</script>

--- a/src/config/productStoreOnboarding.ts
+++ b/src/config/productStoreOnboarding.ts
@@ -1,0 +1,183 @@
+export type ProductStoreOnboardingStepGroup = "setup" | "workflows"
+export type ProductStoreOnboardingCapability = "preview" | "existing-api" | "backend-gap"
+
+export interface ProductStoreOnboardingStep {
+  id: string
+  group: ProductStoreOnboardingStepGroup
+  label: string
+  summary: string
+  capability: ProductStoreOnboardingCapability
+  questions: string[]
+  outputs: string[]
+}
+
+export interface ProductStoreOnboardingGroup {
+  id: ProductStoreOnboardingStepGroup
+  label: string
+}
+
+export const PRODUCT_STORE_ONBOARDING_GROUPS: ProductStoreOnboardingGroup[] = [
+  { id: "setup", label: "Setup" },
+  { id: "workflows", label: "Workflows" }
+]
+
+export const PRODUCT_STORE_ONBOARDING_STEPS: ProductStoreOnboardingStep[] = [
+  {
+    id: "name",
+    group: "setup",
+    label: "Name",
+    summary: "Create the ProductStore identity that every later setup area depends on.",
+    capability: "existing-api",
+    questions: [
+      "What is the retail brand or storefront name?",
+      "Which ID should HotWax use for this Product Store?",
+      "Which currency, locale, and timezone should this store use?"
+    ],
+    outputs: ["ProductStore", "Organization link", "Currency and locale defaults"]
+  },
+  {
+    id: "general",
+    group: "setup",
+    label: "General",
+    summary: "Capture the operating defaults that should exist before solution-specific setup starts.",
+    capability: "preview",
+    questions: [
+      "Should imported orders auto-approve?",
+      "What sales order prefix should this store use?",
+      "Should billing information be saved on imported orders?"
+    ],
+    outputs: ["Order defaults", "Approval policy", "Billing preference"]
+  },
+  {
+    id: "shopify",
+    group: "setup",
+    label: "Shopify",
+    summary: "Connect or reserve the Shopify shop that will feed products, orders, inventory, and locations.",
+    capability: "backend-gap",
+    questions: [
+      "Is this Product Store connected to an existing Shopify shop?",
+      "Which myshopify domain should this setup use?",
+      "Should the user install the HotWax Shopify app now or later?"
+    ],
+    outputs: ["ShopifyShop", "SystemMessageRemote", "Shopify app install token"]
+  },
+  {
+    id: "products",
+    group: "setup",
+    label: "Products",
+    summary: "Choose the product identifier and import direction before inventory or order sync is enabled.",
+    capability: "existing-api",
+    questions: [
+      "What identifier matches Shopify and HotWax products most reliably?",
+      "Should products import from Shopify, ERP, or an existing catalog?",
+      "Are variants identified by SKU, UPC, barcode, or Shopify variant ID?"
+    ],
+    outputs: ["Product identifier", "Identifier preference", "Product import readiness"]
+  },
+  {
+    id: "facilities",
+    group: "setup",
+    label: "Facilities",
+    summary: "Create or import the physical places that can hold, ship, receive, or stage inventory.",
+    capability: "backend-gap",
+    questions: [
+      "How many stores, warehouses, hubs, and pickup locations are in scope?",
+      "Should a one-store retailer start with an automatic facility?",
+      "Which facilities should be associated with this Product Store?"
+    ],
+    outputs: ["Facilities", "Facility groups", "ProductStoreFacility associations"]
+  },
+  {
+    id: "inventory",
+    group: "setup",
+    label: "Inventory",
+    summary: "Decide the source of truth and first load path before fulfillment workflows are turned on.",
+    capability: "backend-gap",
+    questions: [
+      "Which system owns available inventory?",
+      "Should HotWax reserve inventory for online orders?",
+      "Should initial QOH load from Shopify, ERP, WMS, or a file?"
+    ],
+    outputs: ["Inventory source", "Reservation policy", "Initial inventory load task"]
+  },
+  {
+    id: "orders",
+    group: "setup",
+    label: "Orders",
+    summary: "Prepare order import, order updates, and realtime Shopify order flow before activation.",
+    capability: "backend-gap",
+    questions: [
+      "Should orders import in realtime, scheduled batches, or both?",
+      "Which tags or order types should be included?",
+      "Should fallback order sync jobs be active?"
+    ],
+    outputs: ["Order import jobs", "Webhook/SQS readiness", "Fallback sync jobs"]
+  },
+  {
+    id: "users",
+    group: "setup",
+    label: "Users",
+    summary: "Map the people who will operate the store into app roles, security groups, and facility scope.",
+    capability: "backend-gap",
+    questions: [
+      "Which teams need access: stores, inventory, fulfillment, routing, or admins?",
+      "Which users should be associated with each facility?",
+      "Which order edit actions should customer service manage?"
+    ],
+    outputs: ["Users", "Security groups", "Facility and ProductStore scope"]
+  },
+  {
+    id: "routing",
+    group: "workflows",
+    label: "Order routing and fulfillment",
+    summary: "Decide whether HotWax should broker, split, reserve, and route online orders.",
+    capability: "preview",
+    questions: [
+      "Which locations can fulfill online orders?",
+      "Can orders split across locations?",
+      "What should happen when a facility rejects an order?"
+    ],
+    outputs: ["Brokering defaults", "Routing setup task", "Fulfillment permissions"]
+  },
+  {
+    id: "pickup",
+    group: "workflows",
+    label: "In store pickup",
+    summary: "Model pickup promises, pickup facility mapping, and customer-facing pickup changes.",
+    capability: "preview",
+    questions: [
+      "Which stores allow pickup?",
+      "How should pickup orders be identified?",
+      "Can customers change pickup location before fulfillment?"
+    ],
+    outputs: ["Pickup setup task", "BOPIS behavior", "Pickup permissions"]
+  },
+  {
+    id: "storeInventory",
+    group: "workflows",
+    label: "Store inventory management",
+    summary: "Prepare counts, receiving, transfer receiving, adjustments, and scanner expectations.",
+    capability: "preview",
+    questions: [
+      "Which store inventory workflows are in scope?",
+      "What do store teams scan?",
+      "Who can approve adjustments and discrepancies?"
+    ],
+    outputs: ["Inventory app role package", "Barcode preference", "Receiving/count setup task"]
+  },
+  {
+    id: "preorders",
+    group: "workflows",
+    label: "Pre-orders",
+    summary: "Capture preorder eligibility, inventory pools, release behavior, and routing groups.",
+    capability: "preview",
+    questions: [
+      "How are preorder products identified?",
+      "Where should preorder inventory live?",
+      "Should preorder orders split from in-stock items?"
+    ],
+    outputs: ["Preorder setup task", "Preorder facility group", "Release routing task"]
+  }
+]
+
+export const PRODUCT_STORE_ONBOARDING_STEP_IDS = PRODUCT_STORE_ONBOARDING_STEPS.map((step) => step.id)

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -4,6 +4,7 @@ import { Login, logger } from '@common/index'
 import { useAuth } from '@common/composables/useAuth'
 
 const CreateProductStore = () => import('@/views/CreateProductStore.vue')
+const ProductStoreOnboarding = () => import('@/views/ProductStoreOnboarding.vue')
 const AddConfigurations = () => import('@/views/AddConfigurations.vue')
 const ProductStoreDetails = () => import('@/views/ProductStoreDetails.vue')
 const ProductStore = () => import('@/views/ProductStore.vue')
@@ -49,6 +50,8 @@ const routes: Array<RouteRecordRaw> = [
   { path: '/netsuite/sales-channel', name: 'SalesChannel', component: SalesChannel, beforeEnter: authGuard },
   { path: '/netsuite/departments', name: 'Departments', component: Departments, beforeEnter: authGuard },
   { path: '/create-product-store', name: 'CreateProductStore', component: CreateProductStore, beforeEnter: authGuard },
+  { path: '/product-store-onboarding', name: 'ProductStoreOnboarding', component: ProductStoreOnboarding, beforeEnter: authGuard },
+  { path: '/product-store-onboarding/:productStoreId', name: 'ProductStoreOnboardingForStore', component: ProductStoreOnboarding, props: true, beforeEnter: authGuard },
   {
     path: '/add-configurations/:productStoreId',
     name: 'AddConfigurations',

--- a/src/store/productStoreOnboarding.ts
+++ b/src/store/productStoreOnboarding.ts
@@ -1,0 +1,102 @@
+import { defineStore } from "pinia"
+import { PRODUCT_STORE_ONBOARDING_STEP_IDS, PRODUCT_STORE_ONBOARDING_STEPS } from "@/config/productStoreOnboarding"
+import { generateInternalId } from "@/utils"
+
+export interface ProductStoreOnboardingDraft {
+  companyName: string
+  storeName: string
+  productStoreId: string
+  defaultCurrencyUomId: string
+  locale: string
+  timezone: string
+  shopifyDomain: string
+  shopifyConnectionMode: string
+  facilityMode: string
+  productIdentifierEnumId: string
+  inventorySource: string
+  orderImportMode: string
+  selectedWorkflows: string[]
+}
+
+type ProductStoreOnboardingStringField = Exclude<keyof ProductStoreOnboardingDraft, "selectedWorkflows">
+
+const DEFAULT_DRAFT: ProductStoreOnboardingDraft = {
+  companyName: "HotWax Retail",
+  storeName: "Demo Product Store",
+  productStoreId: "DEMO_PRODUCT_STORE",
+  defaultCurrencyUomId: "USD",
+  locale: "America / English",
+  timezone: "America / English",
+  shopifyDomain: "demo.myshopify.com",
+  shopifyConnectionMode: "Prepare Shopify connection",
+  facilityMode: "One store",
+  productIdentifierEnumId: "SHOPIFY_PRODUCT_SKU",
+  inventorySource: "Shopify",
+  orderImportMode: "Realtime and fallback batch",
+  selectedWorkflows: ["routing", "pickup", "storeInventory"]
+}
+
+export const useProductStoreOnboardingStore = defineStore("productStoreOnboarding", {
+  state: () => ({
+    currentStepId: "name",
+    completedStepIds: [] as string[],
+    draft: { ...DEFAULT_DRAFT } as ProductStoreOnboardingDraft
+  }),
+
+  getters: {
+    currentStep: (state) => PRODUCT_STORE_ONBOARDING_STEPS.find((step) => step.id === state.currentStepId) || PRODUCT_STORE_ONBOARDING_STEPS[0],
+    currentStepIndex: (state) => PRODUCT_STORE_ONBOARDING_STEP_IDS.indexOf(state.currentStepId),
+    completedCount: (state) => state.completedStepIds.length,
+    totalStepCount: () => PRODUCT_STORE_ONBOARDING_STEPS.length,
+    progressValue(): number {
+      return this.totalStepCount ? this.completedCount / this.totalStepCount : 0
+    }
+  },
+
+  actions: {
+    selectStep(stepId: string) {
+      if (PRODUCT_STORE_ONBOARDING_STEP_IDS.includes(stepId)) {
+        this.currentStepId = stepId
+      }
+    },
+
+    updateDraftField(field: ProductStoreOnboardingStringField, value: string) {
+      this.draft[field] = value
+
+      if (field === "storeName" && value && !this.draft.productStoreId) {
+        this.draft.productStoreId = generateInternalId(value).slice(0, 20)
+      }
+    },
+
+    toggleWorkflow(stepId: string, checked: boolean) {
+      const selected = new Set(this.draft.selectedWorkflows)
+      checked ? selected.add(stepId) : selected.delete(stepId)
+      this.draft.selectedWorkflows = Array.from(selected)
+    },
+
+    markCurrentStepComplete() {
+      if (!this.completedStepIds.includes(this.currentStepId)) {
+        this.completedStepIds.push(this.currentStepId)
+      }
+    },
+
+    goNext() {
+      this.markCurrentStepComplete()
+      const nextStepId = PRODUCT_STORE_ONBOARDING_STEP_IDS[this.currentStepIndex + 1]
+      if (nextStepId) this.currentStepId = nextStepId
+    },
+
+    goPrevious() {
+      const previousStepId = PRODUCT_STORE_ONBOARDING_STEP_IDS[this.currentStepIndex - 1]
+      if (previousStepId) this.currentStepId = previousStepId
+    },
+
+    resetDraft() {
+      this.currentStepId = "name"
+      this.completedStepIds = []
+      this.draft = { ...DEFAULT_DRAFT }
+    }
+  },
+
+  persist: true
+})

--- a/src/views/CreateProductStore.vue
+++ b/src/views/CreateProductStore.vue
@@ -47,6 +47,11 @@
           {{ translate("Manage configurations") }}
           <ion-icon slot="end" :icon="arrowForwardOutline"/>
         </ion-button>
+
+        <ion-button class="ion-margin-top" fill="outline" router-link="/product-store-onboarding">
+          {{ translate("Preview guided setup") }}
+          <ion-icon slot="end" :icon="arrowForwardOutline"/>
+        </ion-button>
       </main>
     </ion-content>
   </ion-page>

--- a/src/views/ProductStoreOnboarding.vue
+++ b/src/views/ProductStoreOnboarding.vue
@@ -1,0 +1,266 @@
+<template>
+  <ion-page>
+    <ion-header>
+      <ion-toolbar>
+        <ion-back-button default-href="/product-store" slot="start" />
+        <ion-title>{{ translate("Create product store") }}</ion-title>
+        <ion-progress-bar :value="onboardingStore.progressValue" />
+      </ion-toolbar>
+    </ion-header>
+
+    <ion-content>
+      <main class="product-store-onboarding">
+        <section class="onboarding-steps">
+          <ion-list lines="none">
+            <ion-list-header>
+              <ion-label>
+                {{ translate("Progress") }}
+                <p>{{ onboardingStore.completedCount }} {{ translate("of") }} {{ onboardingStore.totalStepCount }} {{ translate("steps complete") }}</p>
+              </ion-label>
+            </ion-list-header>
+          </ion-list>
+
+          <onboarding-step-list
+            :groups="PRODUCT_STORE_ONBOARDING_GROUPS"
+            :steps="PRODUCT_STORE_ONBOARDING_STEPS"
+            :current-step-id="onboardingStore.currentStepId"
+            :completed-step-ids="onboardingStore.completedStepIds"
+            @select-step="onboardingStore.selectStep"
+          />
+        </section>
+
+        <section class="onboarding-task">
+          <ion-card>
+            <ion-card-header>
+              <ion-card-title>{{ translate(currentStep.label) }}</ion-card-title>
+              <ion-card-subtitle>{{ translate(currentStep.summary) }}</ion-card-subtitle>
+            </ion-card-header>
+
+            <ion-list v-if="currentStep.id === 'name'" lines="full">
+              <ion-item>
+                <ion-input
+                  :value="onboardingStore.draft.storeName"
+                  label-placement="stacked"
+                  :helper-text="translate('Product store represents a brand in OMS')"
+                  :clear-input="true"
+                  @ionInput="onboardingStore.updateDraftField('storeName', String($event.detail.value || ''))"
+                >
+                  <div slot="label">{{ translate("Name") }} <ion-text color="danger">*</ion-text></div>
+                </ion-input>
+              </ion-item>
+              <ion-item>
+                <ion-input
+                  :value="onboardingStore.draft.productStoreId"
+                  label-placement="stacked"
+                  :label="translate('ID')"
+                  :helper-text="translate('Product store ID represents an unique ID for your product store')"
+                  :clear-input="true"
+                  @ionInput="onboardingStore.updateDraftField('productStoreId', String($event.detail.value || ''))"
+                />
+              </ion-item>
+              <ion-item>
+                <ion-select
+                  interface="popover"
+                  :value="onboardingStore.draft.defaultCurrencyUomId"
+                  @ionChange="onboardingStore.updateDraftField('defaultCurrencyUomId', String($event.detail.value || ''))"
+                >
+                  <div slot="label">{{ translate("Currency") }} <ion-text color="danger">*</ion-text></div>
+                  <ion-select-option value="USD">{{ translate("USD") }}</ion-select-option>
+                  <ion-select-option value="CAD">{{ translate("CAD") }}</ion-select-option>
+                  <ion-select-option value="GBP">{{ translate("GBP") }}</ion-select-option>
+                </ion-select>
+              </ion-item>
+              <ion-item>
+                <ion-label>{{ translate("Locale") }}</ion-label>
+                <ion-note slot="end">{{ onboardingStore.draft.locale }}</ion-note>
+              </ion-item>
+              <ion-item>
+                <ion-label>{{ translate("Timezone") }}</ion-label>
+                <ion-note slot="end">{{ onboardingStore.draft.timezone }}</ion-note>
+              </ion-item>
+            </ion-list>
+
+            <ion-list v-else-if="currentStep.id === 'shopify'" lines="full">
+              <ion-item>
+                <ion-label>
+                  {{ translate("Connect a Shopify store") }}
+                  <p>{{ translate("A Shopify store cannot be linked to more than one product store at a time.") }}</p>
+                </ion-label>
+                <ion-badge color="warning" slot="end">{{ translate("Gap") }}</ion-badge>
+              </ion-item>
+              <ion-radio-group
+                :value="onboardingStore.draft.shopifyConnectionMode"
+                @ionChange="onboardingStore.updateDraftField('shopifyConnectionMode', String($event.detail.value || ''))"
+              >
+                <ion-item>
+                  <ion-radio slot="start" value="Connect now" />
+                  <ion-label>{{ translate("Connect now") }}</ion-label>
+                </ion-item>
+                <ion-item>
+                  <ion-radio slot="start" value="Use existing Shopify shop" />
+                  <ion-label>{{ translate("Use existing Shopify shop") }}</ion-label>
+                </ion-item>
+                <ion-item>
+                  <ion-radio slot="start" value="Prepare Shopify connection" />
+                  <ion-label>{{ translate("Prepare Shopify connection") }}</ion-label>
+                </ion-item>
+              </ion-radio-group>
+              <ion-item>
+                <ion-input
+                  :value="onboardingStore.draft.shopifyDomain"
+                  label-placement="stacked"
+                  :label="translate('Shopify domain')"
+                  :clear-input="true"
+                  @ionInput="onboardingStore.updateDraftField('shopifyDomain', String($event.detail.value || ''))"
+                />
+              </ion-item>
+            </ion-list>
+
+            <ion-list v-else-if="currentStep.group === 'workflows'" lines="full">
+              <ion-item>
+                <ion-toggle
+                  :checked="onboardingStore.draft.selectedWorkflows.includes(currentStep.id)"
+                  @ionChange="onboardingStore.toggleWorkflow(currentStep.id, $event.detail.checked)"
+                >
+                  {{ translate("Enable workflow") }}
+                </ion-toggle>
+              </ion-item>
+              <ion-item v-for="question in currentStep.questions" :key="question">
+                <ion-label>{{ translate(question) }}</ion-label>
+                <ion-icon slot="end" :icon="radioButtonOffOutline" color="medium" />
+              </ion-item>
+            </ion-list>
+
+            <ion-list v-else lines="full">
+              <ion-item v-for="question in currentStep.questions" :key="question">
+                <ion-label>{{ translate(question) }}</ion-label>
+                <ion-icon slot="end" :icon="radioButtonOffOutline" color="medium" />
+              </ion-item>
+            </ion-list>
+
+            <ion-list lines="full">
+              <ion-list-header>
+                <ion-label>{{ translate("Setup package") }}</ion-label>
+              </ion-list-header>
+              <ion-item v-for="output in currentStep.outputs" :key="output">
+                <ion-label>{{ translate(output) }}</ion-label>
+                <ion-badge slot="end" :color="capabilityColor">{{ translate(capabilityLabel) }}</ion-badge>
+              </ion-item>
+            </ion-list>
+
+            <ion-card-content>
+              <ion-button fill="clear" :disabled="onboardingStore.currentStepIndex === 0" @click="onboardingStore.goPrevious()">
+                <ion-icon slot="start" :icon="arrowBackOutline" />
+                {{ translate("Back") }}
+              </ion-button>
+              <ion-button :disabled="isLastStep" @click="onboardingStore.goNext()">
+                {{ nextLabel }}
+                <ion-icon slot="end" :icon="arrowForwardOutline" />
+              </ion-button>
+            </ion-card-content>
+          </ion-card>
+        </section>
+      </main>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script setup lang="ts">
+import {
+  IonBackButton,
+  IonBadge,
+  IonButton,
+  IonCard,
+  IonCardContent,
+  IonCardHeader,
+  IonCardSubtitle,
+  IonCardTitle,
+  IonContent,
+  IonHeader,
+  IonIcon,
+  IonInput,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonListHeader,
+  IonNote,
+  IonPage,
+  IonProgressBar,
+  IonRadio,
+  IonRadioGroup,
+  IonSelect,
+  IonSelectOption,
+  IonText,
+  IonTitle,
+  IonToggle,
+  IonToolbar
+} from "@ionic/vue"
+import { computed } from "vue"
+import { arrowBackOutline, arrowForwardOutline, radioButtonOffOutline } from "ionicons/icons"
+import { translate } from "@common"
+import OnboardingStepList from "@/components/product-store-onboarding/OnboardingStepList.vue"
+import { PRODUCT_STORE_ONBOARDING_GROUPS, PRODUCT_STORE_ONBOARDING_STEPS } from "@/config/productStoreOnboarding"
+import { useProductStoreOnboardingStore } from "@/store/productStoreOnboarding"
+
+const onboardingStore = useProductStoreOnboardingStore()
+
+const currentStep = computed(() => onboardingStore.currentStep)
+const isLastStep = computed(() => onboardingStore.currentStepIndex === PRODUCT_STORE_ONBOARDING_STEPS.length - 1)
+const nextLabel = computed(() => {
+  const nextStep = PRODUCT_STORE_ONBOARDING_STEPS[onboardingStore.currentStepIndex + 1]
+  return nextStep ? translate(nextStep.label) : translate("Review")
+})
+const capabilityLabel = computed(() => {
+  if (currentStep.value.capability === "backend-gap") return "Gap"
+  if (currentStep.value.capability === "existing-api") return "Existing API"
+  return "Preview"
+})
+const capabilityColor = computed(() => {
+  if (currentStep.value.capability === "backend-gap") return "warning"
+  if (currentStep.value.capability === "existing-api") return "success"
+  return "medium"
+})
+</script>
+
+<style scoped>
+.product-store-onboarding {
+  display: flex;
+  align-items: flex-start;
+  gap: 56px;
+  padding: 24px 16px 48px;
+}
+
+.onboarding-steps {
+  flex: 0 0 375px;
+  max-width: 375px;
+  width: 100%;
+}
+
+.onboarding-task {
+  flex: 1 1 420px;
+  max-width: 420px;
+  margin: 20px auto 0;
+}
+
+@media (max-width: 900px) {
+  .product-store-onboarding {
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .onboarding-steps,
+  .onboarding-task {
+    max-width: none;
+    width: 100%;
+    margin: 0;
+  }
+
+  .onboarding-task {
+    order: 1;
+  }
+
+  .onboarding-steps {
+    order: 2;
+  }
+}
+</style>


### PR DESCRIPTION
## Business summary
This adds the first visible slice of the new product store onboarding flow so retailers can start from guided business setup questions instead of raw configuration screens. The goal is to make the setup path feel like a product/store topology conversation while preserving the current create product store path.

Closes #166

## What changed
- Added a `/product-store-onboarding` preview route and product-store scoped route variant.
- Added a guided setup/task surface for product store basics, Shopify, products, facilities, inventory, orders, users, and workflows.
- Added a small Pinia preview store and structured onboarding step config for the later API-binding PRs.
- Added a non-destructive `Preview guided setup` entry point from the existing create product store screen.
- Added the onboarding discovery/configuration docs to carry forward the larger mapping work.

## Validation
- `pnpm build`
- `git diff --check`
- Browser verified against `localhost:8112` with `VITE_OMS_TYPE=MOQUI`, logging in to `localhost:8080` as `hotwax.user`.
- Verified desktop and mobile layouts plus first-step navigation/progress behavior.

## Notes
- This PR is intentionally vaporware/preview-only. Follow-up PRs should bind existing APIs first, then add the missing Moqui/backend services for Shopify connection, facility import/mapping, inventory load, orders, users/security groups, and service-job setup.