### PR TITLE
Bind onboarding Name step to ProductStore API

### DIFF
--- a/src/store/productStoreOnboarding.ts
+++ b/src/store/productStoreOnboarding.ts
@@ -21,13 +21,13 @@ export interface ProductStoreOnboardingDraft {
 type ProductStoreOnboardingStringField = Exclude<keyof ProductStoreOnboardingDraft, "selectedWorkflows">
 
 const DEFAULT_DRAFT: ProductStoreOnboardingDraft = {
-  companyName: "HotWax Retail",
-  storeName: "Demo Product Store",
-  productStoreId: "DEMO_PRODUCT_STORE",
+  companyName: "",
+  storeName: "",
+  productStoreId: "",
   defaultCurrencyUomId: "USD",
   locale: "America / English",
   timezone: "America / English",
-  shopifyDomain: "demo.myshopify.com",
+  shopifyDomain: "",
   shopifyConnectionMode: "Prepare Shopify connection",
   facilityMode: "One store",
   productIdentifierEnumId: "SHOPIFY_PRODUCT_SKU",
@@ -39,6 +39,7 @@ const DEFAULT_DRAFT: ProductStoreOnboardingDraft = {
 export const useProductStoreOnboardingStore = defineStore("productStoreOnboarding", {
   state: () => ({
     currentStepId: "name",
+    createdProductStoreId: "",
     completedStepIds: [] as string[],
     draft: { ...DEFAULT_DRAFT } as ProductStoreOnboardingDraft
   }),
@@ -80,6 +81,10 @@ export const useProductStoreOnboardingStore = defineStore("productStoreOnboardin
       }
     },
 
+    setCreatedProductStoreId(productStoreId: string) {
+      this.createdProductStoreId = productStoreId
+    },
+
     goNext() {
       this.markCurrentStepComplete()
       const nextStepId = PRODUCT_STORE_ONBOARDING_STEP_IDS[this.currentStepIndex + 1]
@@ -93,6 +98,7 @@ export const useProductStoreOnboardingStore = defineStore("productStoreOnboardin
 
     resetDraft() {
       this.currentStepId = "name"
+      this.createdProductStoreId = ""
       this.completedStepIds = []
       this.draft = { ...DEFAULT_DRAFT }
     }

--- a/src/views/ProductStoreOnboarding.vue
+++ b/src/views/ProductStoreOnboarding.vue
@@ -37,6 +37,17 @@
             </ion-card-header>
 
             <ion-list v-if="currentStep.id === 'name'" lines="full">
+              <ion-item v-if="shouldCollectCompanyName">
+                <ion-input
+                  :value="onboardingStore.draft.companyName"
+                  label-placement="stacked"
+                  :helper-text="translate('The parent organization that owns this first Product Store')"
+                  :clear-input="true"
+                  @ionInput="onboardingStore.updateDraftField('companyName', String($event.detail.value || ''))"
+                >
+                  <div slot="label">{{ translate("Company name") }} <ion-text color="danger">*</ion-text></div>
+                </ion-input>
+              </ion-item>
               <ion-item>
                 <ion-input
                   :value="onboardingStore.draft.storeName"
@@ -65,9 +76,9 @@
                   @ionChange="onboardingStore.updateDraftField('defaultCurrencyUomId', String($event.detail.value || ''))"
                 >
                   <div slot="label">{{ translate("Currency") }} <ion-text color="danger">*</ion-text></div>
-                  <ion-select-option value="USD">{{ translate("USD") }}</ion-select-option>
-                  <ion-select-option value="CAD">{{ translate("CAD") }}</ion-select-option>
-                  <ion-select-option value="GBP">{{ translate("GBP") }}</ion-select-option>
+                  <ion-select-option v-for="currency in currencyOptions" :key="currency.uomId" :value="currency.uomId">
+                    {{ currency.label }}
+                  </ion-select-option>
                 </ion-select>
               </ion-item>
               <ion-item>
@@ -142,6 +153,13 @@
               <ion-list-header>
                 <ion-label>{{ translate("Setup package") }}</ion-label>
               </ion-list-header>
+              <ion-item v-if="selectedProductStoreId">
+                <ion-label>
+                  {{ translate("Created product store") }}
+                  <p>{{ selectedProductStoreId }}</p>
+                </ion-label>
+                <ion-badge slot="end" color="success">{{ translate("Ready") }}</ion-badge>
+              </ion-item>
               <ion-item v-for="output in currentStep.outputs" :key="output">
                 <ion-label>{{ translate(output) }}</ion-label>
                 <ion-badge slot="end" :color="capabilityColor">{{ translate(capabilityLabel) }}</ion-badge>
@@ -153,9 +171,10 @@
                 <ion-icon slot="start" :icon="arrowBackOutline" />
                 {{ translate("Back") }}
               </ion-button>
-              <ion-button :disabled="isLastStep" @click="onboardingStore.goNext()">
-                {{ nextLabel }}
-                <ion-icon slot="end" :icon="arrowForwardOutline" />
+              <ion-button :disabled="isPrimaryActionDisabled" @click="handlePrimaryAction()">
+                {{ primaryActionLabel }}
+                <ion-spinner v-if="isSavingProductStore" slot="end" name="crescent" />
+                <ion-icon v-else slot="end" :icon="arrowForwardOutline" />
               </ion-button>
             </ion-card-content>
           </ion-card>
@@ -190,25 +209,74 @@ import {
   IonRadioGroup,
   IonSelect,
   IonSelectOption,
+  IonSpinner,
   IonText,
   IonTitle,
   IonToggle,
-  IonToolbar
+  IonToolbar,
+  onIonViewWillEnter
 } from "@ionic/vue"
-import { computed } from "vue"
+import { computed, ref } from "vue"
+import { useRoute, useRouter } from "vue-router"
 import { arrowBackOutline, arrowForwardOutline, radioButtonOffOutline } from "ionicons/icons"
-import { translate } from "@common"
+import { commonUtil, emitter, logger, translate } from "@common"
 import OnboardingStepList from "@/components/product-store-onboarding/OnboardingStepList.vue"
 import { PRODUCT_STORE_ONBOARDING_GROUPS, PRODUCT_STORE_ONBOARDING_STEPS } from "@/config/productStoreOnboarding"
 import { useProductStoreOnboardingStore } from "@/store/productStoreOnboarding"
+import { useProductStore } from "@/store/productStore"
+import { useUtilStore } from "@/store/util"
+import { generateInternalId } from "@/utils"
 
 const onboardingStore = useProductStoreOnboardingStore()
+const productStoreStore = useProductStore()
+const utilStore = useUtilStore()
+const route = useRoute()
+const router = useRouter()
+const isSavingProductStore = ref(false)
+const isLoadingSetupData = ref(false)
 
 const currentStep = computed(() => onboardingStore.currentStep)
 const isLastStep = computed(() => onboardingStore.currentStepIndex === PRODUCT_STORE_ONBOARDING_STEPS.length - 1)
+const routeProductStoreId = computed(() => {
+  const productStoreId = route.params.productStoreId
+  if (Array.isArray(productStoreId)) return productStoreId[0] || ""
+  return productStoreId ? String(productStoreId) : ""
+})
+const selectedProductStoreId = computed(() => onboardingStore.createdProductStoreId || routeProductStoreId.value)
+const shouldCollectCompanyName = computed(() => productStoreStore.productStores.length === 0)
+const organizationPartyId = computed(() => utilStore.organizationPartyId)
+const currencyOptions = computed(() => {
+  if (utilStore.currencies.length) {
+    return utilStore.currencies.map((currency: any) => ({
+      uomId: currency.uomId,
+      label: `${currency.description} (${currency.abbreviation})`
+    }))
+  }
+
+  return [
+    { uomId: "USD", label: translate("USD") },
+    { uomId: "CAD", label: translate("CAD") },
+    { uomId: "GBP", label: translate("GBP") }
+  ]
+})
 const nextLabel = computed(() => {
   const nextStep = PRODUCT_STORE_ONBOARDING_STEPS[onboardingStore.currentStepIndex + 1]
   return nextStep ? translate(nextStep.label) : translate("Review")
+})
+const primaryActionLabel = computed(() => {
+  if (currentStep.value.id === "name" && !selectedProductStoreId.value) return translate("Create product store")
+  return nextLabel.value
+})
+const isPrimaryActionDisabled = computed(() => {
+  if (isLastStep.value || isLoadingSetupData.value || isSavingProductStore.value) return true
+
+  if (currentStep.value.id === "name" && !selectedProductStoreId.value) {
+    return !onboardingStore.draft.storeName.trim()
+      || !onboardingStore.draft.defaultCurrencyUomId
+      || (shouldCollectCompanyName.value && !onboardingStore.draft.companyName.trim())
+  }
+
+  return false
 })
 const capabilityLabel = computed(() => {
   if (currentStep.value.capability === "backend-gap") return "Gap"
@@ -220,6 +288,125 @@ const capabilityColor = computed(() => {
   if (currentStep.value.capability === "existing-api") return "success"
   return "medium"
 })
+
+onIonViewWillEnter(async () => {
+  if (routeProductStoreId.value) {
+    onboardingStore.setCreatedProductStoreId(routeProductStoreId.value)
+  }
+
+  await loadSetupData()
+})
+
+async function loadSetupData() {
+  isLoadingSetupData.value = true
+
+  try {
+    if (!utilStore.organizationPartyId) await utilStore.fetchOrganizationPartyId()
+
+    await Promise.allSettled([
+      utilStore.fetchDBICCountries(),
+      utilStore.fetchCurrencies({ uomTypeEnumId: "UT_CURRENCY_MEASURE", pageSize: 250 }),
+      productStoreStore.fetchProductStores()
+    ])
+
+    if (utilStore.organizationPartyId) await productStoreStore.fetchCompany()
+  } catch (error: any) {
+    logger.error(error)
+  }
+
+  isLoadingSetupData.value = false
+}
+
+async function createProductStoreFromDraft() {
+  const storeName = onboardingStore.draft.storeName.trim()
+  const productStoreId = onboardingStore.draft.productStoreId.trim() || generateInternalId(storeName)
+
+  if (!storeName || !onboardingStore.draft.defaultCurrencyUomId) {
+    commonUtil.showToast(translate("Please fill all the required fields"))
+    return ""
+  }
+
+  if (shouldCollectCompanyName.value && !onboardingStore.draft.companyName.trim()) {
+    commonUtil.showToast(translate("Please fill all the required fields"))
+    return ""
+  }
+
+  if (productStoreId.length > 20) {
+    commonUtil.showToast(translate("Product store ID cannot be more than 20 characters."))
+    return ""
+  }
+
+  if (!organizationPartyId.value) {
+    commonUtil.showToast(translate("Unable to find company organization."))
+    return ""
+  }
+
+  isSavingProductStore.value = true
+  emitter.emit("presentLoader")
+
+  try {
+    const payload = {
+      storeName,
+      productStoreId,
+      companyName: productStoreStore.company.companyName,
+      payToPartyId: organizationPartyId.value,
+      defaultCurrencyUomId: onboardingStore.draft.defaultCurrencyUomId
+    } as any
+
+    if (shouldCollectCompanyName.value) payload.companyName = onboardingStore.draft.companyName.trim()
+
+    const resp = await productStoreStore.createProductStore(payload)
+
+    if (commonUtil.hasError(resp)) throw resp.data
+
+    const createdProductStoreId = resp.data.productStoreId
+    onboardingStore.setCreatedProductStoreId(createdProductStoreId)
+    onboardingStore.updateDraftField("productStoreId", createdProductStoreId)
+
+    if (shouldCollectCompanyName.value && onboardingStore.draft.companyName.trim()) {
+      await productStoreStore.updateCompany({
+        ...productStoreStore.company,
+        groupName: onboardingStore.draft.companyName.trim()
+      })
+    }
+
+    await productStoreStore.fetchProductStores()
+    commonUtil.showToast(translate("Product store created successfully."))
+    return createdProductStoreId
+  } catch (error: any) {
+    commonUtil.showToast(translate(error.response?.data?.errors ? error.response.data.errors : "Failed to create product store."))
+    logger.error(error)
+    return ""
+  } finally {
+    emitter.emit("dismissLoader")
+    isSavingProductStore.value = false
+  }
+}
+
+async function handlePrimaryAction() {
+  let productStoreId = selectedProductStoreId.value
+
+  if (currentStep.value.id === "name" && !selectedProductStoreId.value) {
+    productStoreId = await createProductStoreFromDraft()
+    if (!productStoreId) return
+  }
+
+  onboardingStore.goNext()
+
+  if (productStoreId) {
+    replaceRouteForProductStore(productStoreId)
+  }
+}
+
+function replaceRouteForProductStore(productStoreId: string) {
+  const path = `/product-store-onboarding/${encodeURIComponent(productStoreId)}`
+
+  if (window.location.pathname !== path) {
+    window.history.replaceState(window.history.state, "", path)
+  }
+
+  router.replace(path).catch((error: any) => logger.error(error))
+}
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Business summary
This makes the first step of the guided product store onboarding flow real: the retailer can enter the basic ProductStore identity in the new guided shell and create the ProductStore through the existing Company/Moqui API path.

Refs #168

## What changed
- Changed the onboarding draft defaults from demo values to empty inputs for real setup.
- Loaded existing organization, product store, DBIC, and currency data needed by the Name step.
- Reused the existing `productStore.createProductStore` action for the Name step create path.
- Added first-store company name capture when there are no existing product stores.
- After creation, records the created ProductStore ID, advances to General, and scopes the route URL to `/product-store-onboarding/:productStoreId`.

## Validation
- `pnpm build`
- `git diff --check`
- Runtime verified on `localhost:8113` with `VITE_OMS_TYPE=MOQUI`, `localhost:8080`, `hotwax.user` / `hotwax@786`.
- Created local test ProductStore `CXONBQBCVV4J` from the onboarding UI; verified POST `200` to `/rest/s1/admin/productStores`, URL scoping, General step, progress state, and settled layout.

## Notes
- This is stacked on #167 and intentionally only binds the existing ProductStore create API. Shopify, facilities, inventory, orders, users/security, and jobs stay in later backend/API-gap PRs.