### PR TITLE
Bind onboarding products to Shopify product sync

### DIFF
--- a/src/components/ShopifyProductSyncWizardView.vue
+++ b/src/components/ShopifyProductSyncWizardView.vue
@@ -160,7 +160,7 @@
     <ion-item lines="none" class="circuit" button :disabled="!reviewReady" @click="$emit('open-mistake-modal')" v-if="currentStep === 'review'"
       data-testid="mistake-check">
       <ion-label>
-        <ion-icon slot="start" :icon="chipOutline" />
+        <ion-icon slot="start" :icon="hardwareChipOutline" />
         {{ translate("Am I making a mistake?") }}
       </ion-label>
     </ion-item>
@@ -618,7 +618,8 @@ import {
   checkmarkCircleOutline,
   shirtOutline,
   timeOutline,
-  alertCircleOutline
+  alertCircleOutline,
+  hardwareChipOutline
 } from "ionicons/icons";
 import { translate } from '@common';
 import { computed, defineEmits, defineProps } from "vue";

--- a/src/views/ProductStoreOnboarding.vue
+++ b/src/views/ProductStoreOnboarding.vue
@@ -213,9 +213,36 @@
               <ion-item>
                 <ion-label>
                   {{ translate("Shopify product import") }}
-                  <p>{{ translate("Product import and product sync job setup are handled after identity is saved.") }}</p>
+                  <p>{{ productSyncHandoffDescription }}</p>
                 </ion-label>
-                <ion-badge color="warning" slot="end">{{ translate("Next") }}</ion-badge>
+                <ion-badge :color="canOpenShopifyProductSync ? 'success' : 'warning'" slot="end">
+                  {{ canOpenShopifyProductSync ? translate("Ready") : translate("Gap") }}
+                </ion-badge>
+              </ion-item>
+              <ion-item v-if="linkedShopifyShop">
+                <ion-icon slot="start" :icon="syncOutline" />
+                <ion-label>
+                  {{ translate("Product import workspace") }}
+                  <p>{{ translate("Review live Shopify catalog counts before starting the first import.") }}</p>
+                </ion-label>
+                <ion-button
+                  slot="end"
+                  fill="clear"
+                  data-testid="onboarding-open-product-sync"
+                  :aria-label="translate('Open product import')"
+                  :disabled="!canOpenShopifyProductSync || isSavingProductIdentity"
+                  @click="openShopifyProductSync()"
+                >
+                  <ion-spinner v-if="isSavingProductIdentity" name="crescent" />
+                  <ion-icon v-else slot="icon-only" :icon="openOutline" />
+                </ion-button>
+              </ion-item>
+              <ion-item v-else>
+                <ion-label>
+                  {{ translate("Shopify shop required") }}
+                  <p>{{ translate("Link a Shopify shop before importing products.") }}</p>
+                </ion-label>
+                <ion-badge color="warning" slot="end">{{ translate("Gap") }}</ion-badge>
               </ion-item>
             </ion-list>
 
@@ -415,7 +442,7 @@ import {
 } from "@ionic/vue"
 import { computed, ref } from "vue"
 import { useRoute, useRouter } from "vue-router"
-import { arrowBackOutline, arrowForwardOutline, cloudDownloadOutline, gitNetworkOutline, radioButtonOffOutline, storefrontOutline } from "ionicons/icons"
+import { arrowBackOutline, arrowForwardOutline, cloudDownloadOutline, gitNetworkOutline, openOutline, radioButtonOffOutline, storefrontOutline, syncOutline } from "ionicons/icons"
 import { commonUtil, emitter, logger, translate } from "@common"
 import ImportShopifyLocationsModal from "@/components/ImportShopifyLocationsModal.vue"
 import OnboardingStepList from "@/components/product-store-onboarding/OnboardingStepList.vue"
@@ -430,6 +457,7 @@ const onboardingStore = useProductStoreOnboardingStore()
 const productStoreStore = useProductStore()
 const shopifyStore = useShopifyStore()
 const utilStore = useUtilStore()
+const props = defineProps<{ productStoreId?: string }>()
 const route = useRoute()
 const router = useRouter()
 const isSavingProductStore = ref(false)
@@ -442,6 +470,8 @@ const shopifyLocationMappings = ref<any[]>([])
 const currentStep = computed(() => onboardingStore.currentStep)
 const isLastStep = computed(() => onboardingStore.currentStepIndex === PRODUCT_STORE_ONBOARDING_STEPS.length - 1)
 const routeProductStoreId = computed(() => {
+  if (props.productStoreId) return props.productStoreId
+
   const productStoreId = (route as any)?.params?.productStoreId
   if (Array.isArray(productStoreId)) return productStoreId[0] || ""
   return productStoreId ? String(productStoreId) : ""
@@ -468,6 +498,14 @@ const linkedShopifyShopId = computed(() => linkedShopifyShop.value?.shopId || ""
 const facilityCount = computed(() => utilStore.facilities.length)
 const mappedShopifyLocationCount = computed(() => shopifyLocationMappings.value.length)
 const productIdentifierOptions = computed(() => utilStore.productIdentifiers)
+const canOpenShopifyProductSync = computed(() => {
+  return !!selectedProductStoreId.value && !!linkedShopifyShopId.value && !!onboardingStore.draft.productIdentifierEnumId
+})
+const productSyncHandoffDescription = computed(() => {
+  if (!linkedShopifyShopId.value) return translate("Link a Shopify shop before importing products.")
+  if (!onboardingStore.draft.productIdentifierEnumId) return translate("Choose the product identifier before importing products.")
+  return translate("Open the existing first-time product sync wizard with this Product Store and identifier preselected.")
+})
 const productIdentityPreferences = computed(() => {
   const settingValue = productStoreStore.currentStoreSettings?.PRDT_IDEN_PREF?.settingValue
   if (!settingValue) return {} as any
@@ -847,6 +885,36 @@ function openShopifyLocationMapping() {
   }
 
   window.location.href = fallbackUrl
+}
+
+async function openShopifyProductSync() {
+  if (!canOpenShopifyProductSync.value) {
+    commonUtil.showToast(translate("Link Shopify and choose a product identifier before importing products."))
+    return
+  }
+
+  const saved = await saveProductIdentity()
+  if (!saved) return
+
+  onboardingStore.markCurrentStepComplete()
+
+  const path = `/shopify-connection-details/${encodeURIComponent(linkedShopifyShopId.value)}/product-sync`
+  const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`
+  const query = {
+    mode: "first-time",
+    step: "review",
+    productStoreId: selectedProductStoreId.value,
+    identifierEnumId: onboardingStore.draft.productIdentifierEnumId,
+    returnTo
+  }
+  const fallbackQuery = new URLSearchParams(query).toString()
+
+  if ((router as any)?.push) {
+    router.push({ path, query }).catch((error: any) => logger.error(error))
+    return
+  }
+
+  window.location.href = `${path}?${fallbackQuery}`
 }
 
 function getShopifyShopLabel(shop: any) {

--- a/src/views/ShopifyProductSync.vue
+++ b/src/views/ShopifyProductSync.vue
@@ -3,7 +3,7 @@
     <ion-header>
       <ion-toolbar>
         <ion-buttons slot="start">
-          <ion-back-button :default-href="'/shopify-connection-details/' + id" />
+          <ion-back-button :default-href="productSyncBackHref" />
         </ion-buttons>
         <ion-title>{{ translate("Product sync") }}</ion-title>
         <ion-buttons slot="end">
@@ -765,6 +765,7 @@ import {
   nextProductSyncStep,
   normalizeProductSyncStatus,
   previousProductSyncStep,
+  productSyncWizardSteps,
   ProductSyncExperienceMode,
   ProductSyncWizardStep,
   requiresPreflightConfirmation,
@@ -928,6 +929,9 @@ const shop = computed(() => shopifyStore.getShopById(props.id) || {});
 const userProfile = computed(() => useUserStore().getUserProfile || {});
 const statusItems = computed(() => utilStore.statusItems || {});
 const latestBulkOperationId = computed(() => getSystemMessageBulkOperationId(latestSystemMessage.value));
+const productSyncBackHref = computed(() => {
+  return getSafeProductSyncReturnPath(getQueryValue(router.currentRoute.value.query.returnTo)) || `/shopify-connection-details/${props.id}`;
+});
 
 function getStatusDescription(statusId: string) {
   return statusItems.value[statusId]?.description || statusId;
@@ -1694,6 +1698,7 @@ async function loadWizard() {
       syncStarted: !!setupState.value.syncJobId,
       startConfirmed: false
     });
+    applyProductSyncRouteContext();
 
     syncJobId.value = setupState.value.syncJobId || "";
     if (setupState.value.completed) {
@@ -1715,9 +1720,12 @@ async function loadWizard() {
 
     await loadWebhookSubscriptions();
 
-    // Dev override to land on a specific step
-    if (router.currentRoute.value.query.step) {
-      currentStep.value = router.currentRoute.value.query.step as ProductSyncWizardStep;
+    const requestedStep = getQueryProductSyncWizardStep(router.currentRoute.value.query.step);
+    if (requestedStep) {
+      currentStep.value = requestedStep;
+      if (currentStep.value === "review") {
+        await loadReviewStats();
+      }
       if (currentStep.value === "progress") {
         const loadedProgress = await loadProgress();
         if (loadedProgress) startProgressPolling();
@@ -1736,6 +1744,48 @@ async function loadWizard() {
     stopProgressPolling();
   } finally {
     isLoading.value = false;
+  }
+}
+
+function getQueryValue(value: any) {
+  if (Array.isArray(value)) return String(value[0] || "");
+  return value ? String(value) : "";
+}
+
+function getSafeProductSyncReturnPath(value: string) {
+  const path = value.trim();
+  if (!path || !path.startsWith("/") || path.startsWith("//") || path.includes("://")) return "";
+  return path;
+}
+
+function getQueryProductSyncExperienceMode(value: any): ProductSyncExperienceMode | "" {
+  const mode = getQueryValue(value);
+  if (mode === "first-time" || mode === "returning" || mode === "auto") return mode;
+  return "";
+}
+
+function getQueryProductSyncWizardStep(value: any): ProductSyncWizardStep | "" {
+  const step = getQueryValue(value);
+  return productSyncWizardSteps.includes(step as ProductSyncWizardStep) ? step as ProductSyncWizardStep : "";
+}
+
+function applyProductSyncRouteContext() {
+  const query = router.currentRoute.value.query;
+  const mode = getQueryProductSyncExperienceMode(query.mode);
+  if (mode) experienceMode.value = mode;
+
+  const productStoreId = getQueryValue(query.productStoreId);
+  if (productStoreId && !productStoreLocked.value) {
+    draft.value = selectProductStore(draft.value, productStoreId);
+  }
+
+  if (productStoreId && shop.value.productStoreId === productStoreId) {
+    draft.value.productStoreVerified = true;
+  }
+
+  const identifierEnumId = getQueryValue(query.identifierEnumId);
+  if (identifierEnumId && !identifierLocked.value) {
+    draft.value.selectedIdentifierEnumId = identifierEnumId;
   }
 }
 


### PR DESCRIPTION
## Business summary

This PR turns the onboarding Products step into a real handoff into the existing Shopify product sync workflow. After a retailer chooses the product identifier, onboarding can save that identity and open the first-time product sync review for the linked Shopify shop, so the setup agent is not leaving catalog import as a disconnected task.

Refs #171

## What changed

- Adds an onboarding Product import workspace action that saves product identity and opens Shopify product sync with `mode=first-time`, `step=review`, `productStoreId`, `identifierEnumId`, and `returnTo` query context.
- Lets Shopify product sync honor onboarding query context and use a safe `returnTo` path for the toolbar back destination.
- Reads ProductStore onboarding route params from router props first so direct `/product-store-onboarding/:productStoreId` loads hydrate the current setup store reliably.
- Fixes the product sync review icon reference by using the exported `hardwareChipOutline` icon.

## Validation

- `pnpm build`
- `git diff --check`
- Runtime smoke test on `http://localhost:8117` with seeded local Moqui auth: Products step opened `/shopify-connection-details/CXSHOPQBD79HR/product-sync?mode=first-time&step=review&productStoreId=CXPSQBD89VF&identifierEnumId=SHOPIFY_PRODUCT_SKU&returnTo=%2Fproduct-store-onboarding%2FCXPSQBD89VF` and rendered Review product import / Live Shopify stats / Run product import.

## Notes

- The linked dummy Shopify connection currently has read-only access, so the product sync review correctly blocks the final import start until the remote is upgraded to write access.