### PR TITLE
[codex] Wire onboarding to Shopify order job setup

### DIFF
--- a/src/store/productStore.ts
+++ b/src/store/productStore.ts
@@ -147,6 +147,22 @@ export const useProductStore = defineStore('productStore', {
       return shopifyJobStatus
     },
 
+    async setupProductStoreShopifyOrderImport(payload: {
+      productStoreId: string
+      shopId?: string
+      activateJobs?: boolean
+    }) {
+      const resp = await api({
+        url: `admin/productStores/${payload.productStoreId}/shopifyJobs/orderImport`,
+        method: "post",
+        data: payload
+      })
+      if (!commonUtil.hasError(resp)) {
+        this.currentShopifyJobStatus = resp.data?.shopifyJobsStatus || this.currentShopifyJobStatus
+      }
+      return resp
+    },
+
     async fetchCompany() {
       let company = {}
       try {

--- a/src/views/ProductStoreOnboarding.vue
+++ b/src/views/ProductStoreOnboarding.vue
@@ -736,6 +736,7 @@ const isImportingShopifyFacilities = ref(false)
 const isSavingProductIdentity = ref(false)
 const isSavingOrderDefaults = ref(false)
 const isSavingInventorySettings = ref(false)
+const isSettingUpOrderJobs = ref(false)
 const isSavingRoutingDefaults = ref(false)
 const isSavingPickupSettings = ref(false)
 const isLoadingSetupData = ref(false)
@@ -761,6 +762,7 @@ const isPrimaryActionLoading = computed(() => {
     || isSavingProductIdentity.value
     || isSavingOrderDefaults.value
     || isSavingInventorySettings.value
+    || isSettingUpOrderJobs.value
     || isSavingRoutingDefaults.value
     || isSavingPickupSettings.value
 })
@@ -884,6 +886,7 @@ const primaryActionLabel = computed(() => {
   if (currentStep.value.id === "shopify" && isExistingShopifyMode.value && !linkedShopifyShop.value) return translate("Link Shopify")
   if (currentStep.value.id === "products") return translate("Save product identity")
   if (currentStep.value.id === "inventory") return translate("Save inventory settings")
+  if (currentStep.value.id === "orders") return translate("Configure order jobs")
   if (currentStep.value.id === "routing") return translate("Save routing defaults")
   if (currentStep.value.id === "pickup") return translate("Save pickup settings")
   return nextLabel.value
@@ -911,6 +914,10 @@ const isPrimaryActionDisabled = computed(() => {
 
   if (currentStep.value.id === "inventory") {
     return !selectedProductStoreId.value
+  }
+
+  if (currentStep.value.id === "orders") {
+    return !selectedProductStoreId.value || !linkedShopifyShopId.value
   }
 
   if (currentStep.value.id === "routing") {
@@ -1206,6 +1213,11 @@ async function handlePrimaryAction() {
     if (!inventorySettingsSaved) return
   }
 
+  if (currentStep.value.id === "orders") {
+    const orderJobsConfigured = await setupOrderImportJobs()
+    if (!orderJobsConfigured) return
+  }
+
   if (currentStep.value.id === "routing") {
     const routingDefaultsSaved = await saveRoutingDefaults()
     if (!routingDefaultsSaved) return
@@ -1342,6 +1354,42 @@ function buildInventorySettingPayload(settingTypeEnumId: string, settingValue: s
     productStoreId: selectedProductStoreId.value,
     settingTypeEnumId,
     settingValue
+  }
+}
+
+async function setupOrderImportJobs() {
+  if (!selectedProductStoreId.value || !linkedShopifyShopId.value) {
+    commonUtil.showToast(translate("Link a Shopify shop before configuring order jobs."))
+    return false
+  }
+
+  isSettingUpOrderJobs.value = true
+  emitter.emit("presentLoader")
+
+  try {
+    const resp = await productStoreStore.setupProductStoreShopifyOrderImport({
+      productStoreId: selectedProductStoreId.value,
+      shopId: linkedShopifyShopId.value,
+      activateJobs: false
+    })
+
+    if (commonUtil.hasError(resp)) throw resp.data
+
+    if (resp.data?.shopifyJobsStatus) {
+      productStoreStore.currentShopifyJobStatus = resp.data.shopifyJobsStatus
+    } else {
+      await refreshShopifyJobStatus()
+    }
+
+    commonUtil.showToast(translate("Order jobs configured successfully."))
+    return true
+  } catch (error: any) {
+    logger.error(error)
+    commonUtil.showToast(translate("Failed to configure order jobs."))
+    return false
+  } finally {
+    emitter.emit("dismissLoader")
+    isSettingUpOrderJobs.value = false
   }
 }
 


### PR DESCRIPTION
## Business summary

This PR makes the onboarding Orders step actionable by letting the setup flow create the Shopify order import service-job configuration after a Product Store is linked to Shopify. Retailers can stay inside the onboarding wizard instead of leaving the flow to manually configure fallback and historical order jobs.

## Changes

- Adds a Product Store store action for `POST /admin/productStores/:productStoreId/shopifyJobs/orderImport`.
- Makes the Orders step primary action configure order jobs when a linked Shopify shop exists.
- Refreshes the Shopify job status map after setup so the readiness view reflects the backend result.

## Validation

- `pnpm build`
- `git diff --check`
- Browser smoke on `http://localhost:8106/product-store-onboarding`: app served from this worktree and redirected to login with no console errors; deeper route validation is still blocked by the existing local auth/bootstrap behavior in the stacked onboarding branch.

## Stack

Stacked on #184 and expects the backend endpoint from hotwax/hotwax-maarg-util#125.

Related: #171, #182, hotwax/mantle-shopify-connector#370, hotwax/hotwax-maarg-util#125