### PR TITLE
[codex] Wire onboarding to Shopify inventory job setup

### DIFF
--- a/src/store/productStore.ts
+++ b/src/store/productStore.ts
@@ -147,6 +147,27 @@ export const useProductStore = defineStore('productStore', {
       return shopifyJobStatus
     },
 
+    async setupProductStoreShopifyInventoryReset(payload: {
+      productStoreId: string
+      shopId?: string
+      activateJobs?: boolean
+      inventoryResetAdditionalParameters?: Record<string, any>
+      facilityGroupId?: string
+      facilityTypeId?: string
+      parentTypeId?: string
+      productId?: string
+    }) {
+      const resp = await api({
+        url: `admin/productStores/${payload.productStoreId}/shopifyJobs/inventoryReset`,
+        method: "post",
+        data: payload
+      })
+      if (!commonUtil.hasError(resp)) {
+        this.currentShopifyJobStatus = resp.data?.shopifyJobsStatus || this.currentShopifyJobStatus
+      }
+      return resp
+    },
+
     async fetchCompany() {
       let company = {}
       try {

--- a/src/views/ProductStoreOnboarding.vue
+++ b/src/views/ProductStoreOnboarding.vue
@@ -736,6 +736,7 @@ const isImportingShopifyFacilities = ref(false)
 const isSavingProductIdentity = ref(false)
 const isSavingOrderDefaults = ref(false)
 const isSavingInventorySettings = ref(false)
+const isSettingUpInventoryJobs = ref(false)
 const isSavingRoutingDefaults = ref(false)
 const isSavingPickupSettings = ref(false)
 const isLoadingSetupData = ref(false)
@@ -761,6 +762,7 @@ const isPrimaryActionLoading = computed(() => {
     || isSavingProductIdentity.value
     || isSavingOrderDefaults.value
     || isSavingInventorySettings.value
+    || isSettingUpInventoryJobs.value
     || isSavingRoutingDefaults.value
     || isSavingPickupSettings.value
 })
@@ -829,7 +831,7 @@ const shopifyConnectionBadgeColor = computed(() => {
 const inventoryResetDescription = computed(() => {
   const inventoryRequirement = findShopifyRequirement("job.inventoryReset")
   if (inventoryRequirement?.message) return inventoryRequirement.message
-  return translate("Shopify, ERP, and file reset paths still need a backend wrapper before onboarding can run the first QOH load.")
+  return translate("Configure the Shopify inventory reset job after products and locations are mapped.")
 })
 const orderImportStatusDescription = computed(() => {
   if (!selectedProductStoreId.value) return translate("Create the Product Store before checking order import jobs.")
@@ -883,6 +885,7 @@ const primaryActionLabel = computed(() => {
   if (currentStep.value.id === "general") return translate("Save order defaults")
   if (currentStep.value.id === "shopify" && isExistingShopifyMode.value && !linkedShopifyShop.value) return translate("Link Shopify")
   if (currentStep.value.id === "products") return translate("Save product identity")
+  if (currentStep.value.id === "inventory" && linkedShopifyShopId.value) return translate("Save inventory setup")
   if (currentStep.value.id === "inventory") return translate("Save inventory settings")
   if (currentStep.value.id === "routing") return translate("Save routing defaults")
   if (currentStep.value.id === "pickup") return translate("Save pickup settings")
@@ -1204,6 +1207,11 @@ async function handlePrimaryAction() {
   if (currentStep.value.id === "inventory") {
     const inventorySettingsSaved = await saveInventorySettings()
     if (!inventorySettingsSaved) return
+
+    if (linkedShopifyShopId.value) {
+      const inventoryJobsConfigured = await setupInventoryResetJob()
+      if (!inventoryJobsConfigured) return
+    }
   }
 
   if (currentStep.value.id === "routing") {
@@ -1342,6 +1350,43 @@ function buildInventorySettingPayload(settingTypeEnumId: string, settingValue: s
     productStoreId: selectedProductStoreId.value,
     settingTypeEnumId,
     settingValue
+  }
+}
+
+async function setupInventoryResetJob() {
+  if (!selectedProductStoreId.value || !linkedShopifyShopId.value) {
+    commonUtil.showToast(translate("Link a Shopify shop before configuring inventory jobs."))
+    return false
+  }
+
+  isSettingUpInventoryJobs.value = true
+  emitter.emit("presentLoader")
+
+  try {
+    const resp = await productStoreStore.setupProductStoreShopifyInventoryReset({
+      productStoreId: selectedProductStoreId.value,
+      shopId: linkedShopifyShopId.value,
+      activateJobs: false,
+      inventoryResetAdditionalParameters: {}
+    })
+
+    if (commonUtil.hasError(resp)) throw resp.data
+
+    if (resp.data?.shopifyJobsStatus) {
+      productStoreStore.currentShopifyJobStatus = resp.data.shopifyJobsStatus
+    } else {
+      await refreshShopifyJobStatus()
+    }
+
+    commonUtil.showToast(translate("Inventory reset job configured successfully."))
+    return true
+  } catch (error: any) {
+    logger.error(error)
+    commonUtil.showToast(translate("Failed to configure inventory reset job."))
+    return false
+  } finally {
+    emitter.emit("dismissLoader")
+    isSettingUpInventoryJobs.value = false
   }
 }
 


### PR DESCRIPTION
## Business summary

This PR makes the onboarding Inventory step actionable for Shopify inventory readiness. After saving OMS inventory settings, the wizard can call the backend to configure the per-shop Shopify inventory reset job and immediately refresh the setup status shown to the retailer.

## Changes

- Adds a Product Store store action for `POST /admin/productStores/:productStoreId/shopifyJobs/inventoryReset`.
- Extends the Inventory step primary action to configure the Shopify inventory reset job when a Shopify shop is linked.
- Updates the Inventory step action label and fallback copy so the step now reflects actionable setup rather than a backend gap.

## Validation

- `pnpm build`
- `git diff --check`

I attempted Browser smoke twice against `http://127.0.0.1:8113/product-store-onboarding`; the in-app Browser timed out attaching to the new test tab both times. The temporary Vite server did start successfully and was stopped after validation.

## Stack

Stacked on #184 and expects the backend endpoint from hotwax/hotwax-maarg-util#127.

Related: #171, #181, hotwax/mantle-shopify-connector#371, hotwax/hotwax-maarg-util#127