### PR TITLE
[codex] Wire onboarding to realtime order setup

### DIFF
--- a/src/store/productStore.ts
+++ b/src/store/productStore.ts
@@ -163,6 +163,24 @@ export const useProductStore = defineStore('productStore', {
       return resp
     },
 
+    async setupProductStoreShopifyRealtimeOrderImport(payload: {
+      productStoreId: string
+      queueName: string
+      awsRemoteId?: string
+      expireLockTime?: number
+      activateJobs?: boolean
+    }) {
+      const resp = await api({
+        url: `admin/productStores/${payload.productStoreId}/shopifyJobs/realtimeOrderImport`,
+        method: "post",
+        data: payload
+      })
+      if (!commonUtil.hasError(resp)) {
+        this.currentShopifyJobStatus = resp.data?.shopifyJobsStatus || this.currentShopifyJobStatus
+      }
+      return resp
+    },
+
     async fetchCompany() {
       let company = {}
       try {

--- a/src/store/productStoreOnboarding.ts
+++ b/src/store/productStoreOnboarding.ts
@@ -37,6 +37,9 @@ export interface ProductStoreOnboardingDraft {
   customerPickupUpdate: string
   customerCancelBeforeFulfillment: string
   orderImportMode: string
+  orderSqsQueueName: string
+  orderSqsAwsRemoteId: string
+  orderSqsExpireLockTime: string
   selectedWorkflows: string[]
 }
 
@@ -77,6 +80,9 @@ const DEFAULT_DRAFT: ProductStoreOnboardingDraft = {
   customerPickupUpdate: "false",
   customerCancelBeforeFulfillment: "false",
   orderImportMode: "Realtime and fallback batch",
+  orderSqsQueueName: "",
+  orderSqsAwsRemoteId: "AWS_CONFIG",
+  orderSqsExpireLockTime: "10",
   selectedWorkflows: ["routing", "pickup", "storeInventory"]
 }
 

--- a/src/views/ProductStoreOnboarding.vue
+++ b/src/views/ProductStoreOnboarding.vue
@@ -489,6 +489,42 @@
                 </ion-label>
                 <ion-badge :color="orderImportBadgeColor" slot="end">{{ orderImportStatusLabel }}</ion-badge>
               </ion-item>
+              <ion-item>
+                <ion-select
+                  interface="popover"
+                  :value="onboardingStore.draft.orderImportMode"
+                  @ionChange="onboardingStore.updateDraftField('orderImportMode', String($event.detail.value || ''))"
+                >
+                  <div slot="label">{{ translate("Order import mode") }}</div>
+                  <ion-select-option value="Realtime and fallback batch">{{ translate("Realtime and fallback batch") }}</ion-select-option>
+                  <ion-select-option value="Fallback batch only">{{ translate("Fallback batch only") }}</ion-select-option>
+                </ion-select>
+              </ion-item>
+              <ion-item v-if="shouldConfigureRealtimeOrderImport">
+                <ion-input
+                  :value="onboardingStore.draft.orderSqsQueueName"
+                  @ionInput="onboardingStore.updateDraftField('orderSqsQueueName', String($event.detail.value || ''))"
+                >
+                  <div slot="label">{{ translate("Realtime SQS queue") }}</div>
+                </ion-input>
+              </ion-item>
+              <ion-item v-if="shouldConfigureRealtimeOrderImport">
+                <ion-input
+                  :value="onboardingStore.draft.orderSqsAwsRemoteId"
+                  @ionInput="onboardingStore.updateDraftField('orderSqsAwsRemoteId', String($event.detail.value || ''))"
+                >
+                  <div slot="label">{{ translate("AWS remote ID") }}</div>
+                </ion-input>
+              </ion-item>
+              <ion-item v-if="shouldConfigureRealtimeOrderImport">
+                <ion-input
+                  type="number"
+                  :value="onboardingStore.draft.orderSqsExpireLockTime"
+                  @ionInput="onboardingStore.updateDraftField('orderSqsExpireLockTime', String($event.detail.value || ''))"
+                >
+                  <div slot="label">{{ translate("Lock timeout minutes") }}</div>
+                </ion-input>
+              </ion-item>
               <ion-item v-for="requirement in orderJobRequirements" :key="requirement.id">
                 <ion-label>
                   {{ translate(requirement.label) }}
@@ -737,6 +773,7 @@ const isSavingProductIdentity = ref(false)
 const isSavingOrderDefaults = ref(false)
 const isSavingInventorySettings = ref(false)
 const isSettingUpOrderJobs = ref(false)
+const isSettingUpRealtimeOrderJobs = ref(false)
 const isSavingRoutingDefaults = ref(false)
 const isSavingPickupSettings = ref(false)
 const isLoadingSetupData = ref(false)
@@ -763,6 +800,7 @@ const isPrimaryActionLoading = computed(() => {
     || isSavingOrderDefaults.value
     || isSavingInventorySettings.value
     || isSettingUpOrderJobs.value
+    || isSettingUpRealtimeOrderJobs.value
     || isSavingRoutingDefaults.value
     || isSavingPickupSettings.value
 })
@@ -796,6 +834,7 @@ const orderJobRequirements = computed(() => {
     return ["job.orderImport", "job.orderHistory", "job.realtimeOrderImport", "dataManager.orderConfigs"].includes(requirement.id)
   })
 })
+const shouldConfigureRealtimeOrderImport = computed(() => onboardingStore.draft.orderImportMode === "Realtime and fallback batch")
 const facilityCount = computed(() => utilStore.facilities.length)
 const facilityGroups = computed(() => utilStore.facilityGroups)
 const shipmentMethodTypes = computed(() => utilStore.shipmentMethodTypes)
@@ -917,7 +956,9 @@ const isPrimaryActionDisabled = computed(() => {
   }
 
   if (currentStep.value.id === "orders") {
-    return !selectedProductStoreId.value || !linkedShopifyShopId.value
+    return !selectedProductStoreId.value
+      || !linkedShopifyShopId.value
+      || (shouldConfigureRealtimeOrderImport.value && !onboardingStore.draft.orderSqsQueueName.trim())
   }
 
   if (currentStep.value.id === "routing") {
@@ -1216,6 +1257,9 @@ async function handlePrimaryAction() {
   if (currentStep.value.id === "orders") {
     const orderJobsConfigured = await setupOrderImportJobs()
     if (!orderJobsConfigured) return
+
+    const realtimeOrderJobsConfigured = await setupRealtimeOrderImportJobs()
+    if (!realtimeOrderJobsConfigured) return
   }
 
   if (currentStep.value.id === "routing") {
@@ -1390,6 +1434,46 @@ async function setupOrderImportJobs() {
   } finally {
     emitter.emit("dismissLoader")
     isSettingUpOrderJobs.value = false
+  }
+}
+
+async function setupRealtimeOrderImportJobs() {
+  if (!shouldConfigureRealtimeOrderImport.value) return true
+
+  if (!selectedProductStoreId.value || !onboardingStore.draft.orderSqsQueueName.trim()) {
+    commonUtil.showToast(translate("Enter the SQS queue before configuring realtime order import."))
+    return false
+  }
+
+  isSettingUpRealtimeOrderJobs.value = true
+  emitter.emit("presentLoader")
+
+  try {
+    const resp = await productStoreStore.setupProductStoreShopifyRealtimeOrderImport({
+      productStoreId: selectedProductStoreId.value,
+      queueName: onboardingStore.draft.orderSqsQueueName.trim(),
+      awsRemoteId: onboardingStore.draft.orderSqsAwsRemoteId.trim() || "AWS_CONFIG",
+      expireLockTime: Number(onboardingStore.draft.orderSqsExpireLockTime || 10),
+      activateJobs: false
+    })
+
+    if (commonUtil.hasError(resp)) throw resp.data
+
+    if (resp.data?.shopifyJobsStatus) {
+      productStoreStore.currentShopifyJobStatus = resp.data.shopifyJobsStatus
+    } else {
+      await refreshShopifyJobStatus()
+    }
+
+    commonUtil.showToast(translate("Realtime order import configured successfully."))
+    return true
+  } catch (error: any) {
+    logger.error(error)
+    commonUtil.showToast(translate("Failed to configure realtime order import."))
+    return false
+  } finally {
+    emitter.emit("dismissLoader")
+    isSettingUpRealtimeOrderJobs.value = false
   }
 }
 


### PR DESCRIPTION
## Business summary

This PR lets the Product Store onboarding Orders step configure realtime Shopify order import when the retailer has SQS queue details. It keeps fallback and historical order job setup in the same step, while making realtime SQS setup explicit and optional through the selected import mode.

## Changes

- Adds onboarding draft fields for order import mode, SQS queue name, AWS remote ID, and lock timeout.
- Adds a Product Store store action for `POST /admin/productStores/:productStoreId/shopifyJobs/realtimeOrderImport`.
- Adds Ionic-native Orders step controls for realtime SQS setup.
- Runs realtime setup after fallback/historical order job setup when realtime mode is selected.

## Validation

- `pnpm build`
- `git diff --check`
- Local serve check: `curl -I http://127.0.0.1:8114/product-store-onboarding` returned `200 OK`; temporary server was stopped.

The in-app Browser tab attach failed earlier in this session, so this branch uses build plus local serve validation.

## Stack

Stacked on #185 and expects the backend endpoint from hotwax/hotwax-maarg-util#129.

Related: #171, #182, hotwax/mantle-shopify-connector#372, hotwax/hotwax-maarg-util#129