### PR TITLE
[codex] Surface Shopify mapping readiness in onboarding

### DIFF
--- a/src/store/shopify.ts
+++ b/src/store/shopify.ts
@@ -50,6 +50,7 @@ export const useShopifyStore = defineStore('shopify', {
 
     async fetchShopifyShopsCarrierShipments(payload: any = {}) {
       let shopifyShopsCarrierShipments: any = {}, pageIndex = 0, resp: any
+      let shipments: any[] = []
       try {
         do {
           resp = await api({
@@ -58,6 +59,7 @@ export const useShopifyStore = defineStore('shopify', {
             params: { ...payload, pageSize: 100, pageIndex }
           })
           if (!commonUtil.hasError(resp)) {
+            shipments = [...shipments, ...resp.data]
             const newShipments = resp.data.reduce((acc: any, item: any) => {
               acc[`${item.carrierPartyId}_${item.shipmentMethodTypeId}`] = {
                 carrierPartyId: item.carrierPartyId,
@@ -75,13 +77,14 @@ export const useShopifyStore = defineStore('shopify', {
         logger.error(error)
       }
       this.shopifyShopsCarrierShipments = shopifyShopsCarrierShipments
+      return shipments
     },
 
-    async fetchShopifyShopLocations() {
+    async fetchShopifyShopLocations(payload: any = {}) {
       let shopifyShopLocations: any = {}, pageIndex = 0, resp: any
       try {
         do {
-          resp = await api({ url: "oms/shopifyShops/locations", method: "get", params: { pageSize: 100, pageIndex } })
+          resp = await api({ url: "oms/shopifyShops/locations", method: "get", params: { ...payload, pageSize: 100, pageIndex } })
           if (!commonUtil.hasError(resp)) {
             const newLocations = resp.data.reduce((acc: any, item: any) => {
               acc[item.facilityId] = item.shopifyLocationId
@@ -97,13 +100,16 @@ export const useShopifyStore = defineStore('shopify', {
         logger.error(error)
       }
       this.shopifyShopsLocations = shopifyShopLocations
+      return shopifyShopLocations
     },
 
-    async fetchShopifyTypeMappings(mappedTypeId: string) {
-      let shopifyTypeMappings: any = {}, pageIndex = 0, resp: any
+    async fetchShopifyTypeMappings(payload: string | { mappedTypeId: string, shopId?: string }) {
+      const mappedTypeId = typeof payload === "string" ? payload : payload.mappedTypeId
+      const params = typeof payload === "string" ? {} : { shopId: payload.shopId }
+      let shopifyTypeMappings: any = { [mappedTypeId]: [] }, pageIndex = 0, resp: any
       try {
         do {
-          resp = await api({ url: "oms/shopifyShops/typeMappings", method: "get", params: { mappedTypeId, pageSize: 100, pageIndex } })
+          resp = await api({ url: "oms/shopifyShops/typeMappings", method: "get", params: { ...params, mappedTypeId, pageSize: 100, pageIndex } })
           if (!commonUtil.hasError(resp) && resp.data) {
             const newMappings = resp.data.reduce((acc: any, item: any) => {
               const typeId = item.mappedTypeId
@@ -111,7 +117,12 @@ export const useShopifyStore = defineStore('shopify', {
               acc[typeId].push(item)
               return acc
             }, {})
-            shopifyTypeMappings = { ...shopifyTypeMappings, ...newMappings }
+            Object.keys(newMappings).forEach((typeId) => {
+              shopifyTypeMappings[typeId] = [
+                ...(shopifyTypeMappings[typeId] || []),
+                ...newMappings[typeId]
+              ]
+            })
           } else {
             throw resp.data
           }
@@ -121,6 +132,7 @@ export const useShopifyStore = defineStore('shopify', {
         logger.error(error)
       }
       this.shopifyTypeMappings = { ...this.shopifyTypeMappings, ...shopifyTypeMappings }
+      return shopifyTypeMappings[mappedTypeId] || []
     },
 
     async updateShopifyShop(payload: any) {

--- a/src/views/ProductStoreOnboarding.vue
+++ b/src/views/ProductStoreOnboarding.vue
@@ -296,6 +296,47 @@
                   <ion-icon v-else slot="icon-only" :icon="syncOutline" />
                 </ion-button>
               </ion-item>
+              <ion-list-header v-if="linkedShopifyShop">
+                <ion-label>{{ translate("Shopify mappings") }}</ion-label>
+              </ion-list-header>
+              <ion-item v-if="linkedShopifyShop">
+                <ion-label>
+                  {{ translate("Mapping readiness") }}
+                  <p>{{ shopifyMappingReadinessDescription }}</p>
+                </ion-label>
+                <ion-badge :color="shopifyMappingBadgeColor" slot="end">
+                  {{ shopifyMappingStatusLabel }}
+                </ion-badge>
+                <ion-button
+                  slot="end"
+                  fill="clear"
+                  :aria-label="translate('Refresh Shopify mappings')"
+                  :disabled="isLoadingShopifyMappingStatus"
+                  @click="refreshShopifyMappingStatus()"
+                >
+                  <ion-spinner v-if="isLoadingShopifyMappingStatus" name="crescent" />
+                  <ion-icon v-else slot="icon-only" :icon="syncOutline" />
+                </ion-button>
+              </ion-item>
+              <template v-if="linkedShopifyShop">
+                <ion-item
+                  v-for="mapping in shopifyMappingAreas"
+                  :key="mapping.id"
+                  button
+                  detail
+                  @click="openShopifyMappingPath(mapping.path)"
+                >
+                  <ion-icon slot="start" :icon="gitNetworkOutline" />
+                  <ion-label>
+                    {{ mapping.label }}
+                    <p>{{ mapping.description }}</p>
+                  </ion-label>
+                  <ion-note slot="end">{{ mapping.count }}</ion-note>
+                  <ion-badge :color="mapping.count ? 'success' : 'warning'" slot="end">
+                    {{ mapping.count ? translate("Ready") : translate("Gap") }}
+                  </ion-badge>
+                </ion-item>
+              </template>
               <ion-item v-for="requirement in shopifyConnectionRequirements" :key="requirement.id">
                 <ion-label>
                   {{ translate(requirement.label) }}
@@ -1009,12 +1050,20 @@ const isSavingRoutingDefaults = ref(false)
 const isSavingPickupSettings = ref(false)
 const isLoadingSetupData = ref(false)
 const isLoadingShopifyJobStatus = ref(false)
+const isLoadingShopifyMappingStatus = ref(false)
 const isLoadingAccessPackageStatus = ref(false)
 const accessTemporaryPassword = ref("")
 const accessTemporaryPasswordVerify = ref("")
 const shopifyHandoffToken = ref("")
 const shopifyHandoffTokenExpirationTime = ref(0)
 const shopifyLocationMappings = ref<any[]>([])
+const shopifyMappingCounts = ref<Record<string, number>>({
+  productTypes: 0,
+  orderSources: 0,
+  paymentMethods: 0,
+  shippingMethods: 0,
+  locations: 0
+})
 
 const currentStep = computed(() => onboardingStore.currentStep)
 const isLastStep = computed(() => onboardingStore.currentStepIndex === PRODUCT_STORE_ONBOARDING_STEPS.length - 1)
@@ -1079,6 +1128,57 @@ const facilityGroups = computed(() => utilStore.facilityGroups)
 const shipmentMethodTypes = computed(() => utilStore.shipmentMethodTypes)
 const mappedShopifyLocationCount = computed(() => shopifyLocationMappings.value.length)
 const productIdentifierOptions = computed(() => utilStore.productIdentifiers)
+const shopifyMappingAreas = computed(() => [
+  {
+    id: "productTypes",
+    label: translate("Product type mappings"),
+    description: translate("Maps Shopify product types into OMS product types for product import."),
+    path: "product-types",
+    count: shopifyMappingCounts.value.productTypes
+  },
+  {
+    id: "orderSources",
+    label: translate("Sales channel mappings"),
+    description: translate("Maps Shopify order sources into OMS sales channels for imported orders."),
+    path: "sales-channels",
+    count: shopifyMappingCounts.value.orderSources
+  },
+  {
+    id: "paymentMethods",
+    label: translate("Payment method mappings"),
+    description: translate("Maps Shopify payment names into OMS payment method types."),
+    path: "payment-methods",
+    count: shopifyMappingCounts.value.paymentMethods
+  },
+  {
+    id: "shippingMethods",
+    label: translate("Shipping method mappings"),
+    description: translate("Maps Shopify shipping names into OMS shipment methods and carriers."),
+    path: "shipment-methods",
+    count: shopifyMappingCounts.value.shippingMethods
+  },
+  {
+    id: "locations",
+    label: translate("Inventory location mappings"),
+    description: translate("Maps Shopify inventory locations to HotWax facilities."),
+    path: "locations",
+    count: shopifyMappingCounts.value.locations
+  }
+])
+const readyShopifyMappingAreaCount = computed(() => {
+  return shopifyMappingAreas.value.filter((mapping) => mapping.count > 0).length
+})
+const shopifyMappingReadinessDescription = computed(() => {
+  if (isLoadingShopifyMappingStatus.value) return translate("Checking Shopify mapping readiness.")
+  if (!linkedShopifyShopId.value) return translate("Link a Shopify shop before configuring mappings.")
+  return `${readyShopifyMappingAreaCount.value} ${translate("of")} ${shopifyMappingAreas.value.length} ${translate("mapping areas have at least one mapping.")}`
+})
+const shopifyMappingStatusLabel = computed(() => {
+  return readyShopifyMappingAreaCount.value === shopifyMappingAreas.value.length ? translate("Ready") : translate("Gap")
+})
+const shopifyMappingBadgeColor = computed(() => {
+  return readyShopifyMappingAreaCount.value === shopifyMappingAreas.value.length ? "success" : "warning"
+})
 const canOpenShopifyProductSync = computed(() => {
   return !!selectedProductStoreId.value && !!linkedShopifyShopId.value && !!onboardingStore.draft.productIdentifierEnumId
 })
@@ -1429,6 +1529,49 @@ async function refreshShopifyJobStatus() {
   }
 }
 
+async function refreshShopifyMappingStatus() {
+  shopifyMappingCounts.value = {
+    productTypes: 0,
+    orderSources: 0,
+    paymentMethods: 0,
+    shippingMethods: 0,
+    locations: 0
+  }
+
+  if (!linkedShopifyShopId.value) return
+
+  isLoadingShopifyMappingStatus.value = true
+
+  try {
+    const shopId = linkedShopifyShopId.value
+    await refreshShopifyLocationMappings()
+
+    const [
+      productTypeMappings,
+      orderSourceMappings,
+      paymentMethodMappings,
+      shippingMethodMappings
+    ] = await Promise.all([
+      shopifyStore.fetchShopifyTypeMappings({ shopId, mappedTypeId: "SHOPIFY_PRODUCT_TYPE" }),
+      shopifyStore.fetchShopifyTypeMappings({ shopId, mappedTypeId: "SHOPIFY_ORDER_SOURCE" }),
+      shopifyStore.fetchShopifyTypeMappings({ shopId, mappedTypeId: "SHOPIFY_PAYMENT_TYPE" }),
+      shopifyStore.fetchShopifyShopsCarrierShipments({ shopId })
+    ])
+
+    shopifyMappingCounts.value = {
+      productTypes: productTypeMappings.length,
+      orderSources: orderSourceMappings.length,
+      paymentMethods: paymentMethodMappings.length,
+      shippingMethods: shippingMethodMappings.length,
+      locations: shopifyLocationMappings.value.length
+    }
+  } catch (error: any) {
+    logger.warn("Failed to refresh Shopify mapping status", error)
+  } finally {
+    isLoadingShopifyMappingStatus.value = false
+  }
+}
+
 async function refreshAccessPackageStatus() {
   if (!selectedProductStoreId.value) {
     productStoreStore.currentAccessPackageStatus = null
@@ -1475,7 +1618,7 @@ async function loadSetupData() {
 
     if (utilStore.organizationPartyId) await productStoreStore.fetchCompany()
     await loadSelectedProductStoreSetup()
-    await refreshShopifyLocationMappings()
+    await refreshShopifyMappingStatus()
   } catch (error: any) {
     logger.error(error)
   }
@@ -2226,7 +2369,7 @@ async function linkExistingShopifyShop() {
     onboardingStore.updateDraftField("shopifyDomain", selectedShop?.myshopifyDomain || onboardingStore.draft.shopifyDomain)
     await shopifyStore.fetchShopifyShops()
     await refreshShopifyJobStatus()
-    await refreshShopifyLocationMappings()
+    await refreshShopifyMappingStatus()
     commonUtil.showToast(translate("Product store linked successfully"))
     return true
   } catch (error: any) {
@@ -2276,10 +2419,8 @@ async function openShopifyLocationImport() {
     const { data } = await modal.onDidDismiss()
 
     if (data?.imported) {
-      await Promise.all([
-        utilStore.fetchFacilities(),
-        refreshShopifyLocationMappings()
-      ])
+      await utilStore.fetchFacilities()
+      await refreshShopifyMappingStatus()
     }
   } catch (error: any) {
     logger.error(error)
@@ -2290,12 +2431,16 @@ async function openShopifyLocationImport() {
 }
 
 function openShopifyLocationMapping() {
+  openShopifyMappingPath("locations")
+}
+
+function openShopifyMappingPath(pathSegment: string) {
   if (!linkedShopifyShopId.value) {
-    commonUtil.showToast(translate("Link a Shopify shop before mapping locations."))
+    commonUtil.showToast(translate("Link a Shopify shop before configuring mappings."))
     return
   }
 
-  const path = `/shopify-connection-details/${encodeURIComponent(linkedShopifyShopId.value)}/locations`
+  const path = `/shopify-connection-details/${encodeURIComponent(linkedShopifyShopId.value)}/${pathSegment}`
   const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`
   const fallbackUrl = `${path}?returnTo=${encodeURIComponent(returnTo)}`
 

--- a/src/views/ShopifyLocations.vue
+++ b/src/views/ShopifyLocations.vue
@@ -147,7 +147,7 @@ onIonViewWillEnter(async () => {
   isLoading.value = true;
   await Promise.all([
     utilStore.fetchFacilities(),
-    shopifyStore.fetchShopifyShopLocations()
+    shopifyStore.fetchShopifyShopLocations({ shopId: props.id })
   ]);
   initializeLocalMappings();
   isLoading.value = false;
@@ -204,7 +204,7 @@ async function saveMapping(facilityId: string) {
 
     if (!commonUtil.hasError(resp)) {
       commonUtil.showToast(translate("Mapping updated successfully"));
-      await shopifyStore.fetchShopifyShopLocations();
+      await shopifyStore.fetchShopifyShopLocations({ shopId: props.id });
       editingItemId.value = "";
     } else {
       throw resp.data;
@@ -228,7 +228,7 @@ async function saveAllDirtyMappings() {
         shopifyLocationId: localMappings.value[id]
       });
     }
-    await shopifyStore.fetchShopifyShopLocations();
+    await shopifyStore.fetchShopifyShopLocations({ shopId: props.id });
     commonUtil.showToast(translate("All mappings saved successfully"));
   } catch (error) {
     logger.error(error);
@@ -248,7 +248,7 @@ async function openImportModal() {
     isLoading.value = true
     await Promise.all([
       utilStore.fetchFacilities(),
-      shopifyStore.fetchShopifyShopLocations()
+      shopifyStore.fetchShopifyShopLocations({ shopId: props.id })
     ])
     initializeLocalMappings()
     isLoading.value = false

--- a/src/views/ShopifyPaymentMethods.vue
+++ b/src/views/ShopifyPaymentMethods.vue
@@ -2,7 +2,7 @@
   <ion-page>
     <ion-header :translucent="true">
       <ion-toolbar>
-        <ion-back-button slot="start" :default-href="'/shopify-connection-details/' + id" />
+        <ion-back-button slot="start" :default-href="backHref" />
         <ion-title>{{ translate("Payment methods") }}</ion-title>
       </ion-toolbar>
     </ion-header>
@@ -81,6 +81,10 @@ const localMappings = ref<any>({});
 
 const paymentMethods = computed(() => netSuiteStore.paymentMethods)
 const shopifyTypeMappings = computed(() => shopifyStore.getShopifyTypeMappings("SHOPIFY_PAYMENT_TYPE"))
+const backHref = computed(() => {
+  const returnTo = new URLSearchParams(window.location.search).get("returnTo")
+  return returnTo || `/shopify-connection-details/${props.id}`
+})
 
 const isDirty = computed(() => {
   return Object.keys(localMappings.value).some(id => {
@@ -94,7 +98,7 @@ onIonViewWillEnter(async () => {
   isLoading.value = true;
   await Promise.all([
     netSuiteStore.fetchPaymentMethods(),
-    shopifyStore.fetchShopifyTypeMappings("SHOPIFY_PAYMENT_TYPE")
+    shopifyStore.fetchShopifyTypeMappings({ mappedTypeId: "SHOPIFY_PAYMENT_TYPE", shopId: props.id })
   ]);
   initializeLocalMappings();
   isLoading.value = false;
@@ -162,7 +166,7 @@ async function saveMapping(paymentMethodTypeId: string) {
 
     if (!commonUtil.hasError(resp)) {
       commonUtil.showToast(translate("Mapping updated successfully"));
-      await shopifyStore.fetchShopifyTypeMappings("SHOPIFY_PAYMENT_TYPE");
+      await shopifyStore.fetchShopifyTypeMappings({ mappedTypeId: "SHOPIFY_PAYMENT_TYPE", shopId: props.id });
       editingItemId.value = "";
     } else {
       throw resp.data;
@@ -198,7 +202,7 @@ async function saveAllDirtyMappings() {
         mappedValue: id
       });
     }
-    await shopifyStore.fetchShopifyTypeMappings("SHOPIFY_PAYMENT_TYPE");
+    await shopifyStore.fetchShopifyTypeMappings({ mappedTypeId: "SHOPIFY_PAYMENT_TYPE", shopId: props.id });
     commonUtil.showToast(translate("All mappings saved successfully"));
   } catch (error) {
     logger.error(error);

--- a/src/views/ShopifyProductTypes.vue
+++ b/src/views/ShopifyProductTypes.vue
@@ -2,7 +2,7 @@
   <ion-page>
     <ion-header :translucent="true">
       <ion-toolbar>
-        <ion-back-button slot="start" :default-href="'/shopify-connection-details/' + id" />
+        <ion-back-button slot="start" :default-href="backHref" />
         <ion-title>{{ translate("Product types") }}</ion-title>
       </ion-toolbar>
     </ion-header>
@@ -79,8 +79,19 @@ const isLoading = ref(true);
 const editingItemId = ref("");
 const localMappings = ref<any>({});
 
-const productTypes = computed(() => utilStore.productTypes)
 const shopifyTypeMappings = computed(() => shopifyStore.getShopifyTypeMappings("SHOPIFY_PRODUCT_TYPE"))
+const productTypes = computed(() => {
+  if (utilStore.productTypes.length) return utilStore.productTypes
+
+  return shopifyTypeMappings.value.map((mapping: any) => ({
+    productTypeId: mapping.mappedValue,
+    description: mapping.mappedValue
+  }))
+})
+const backHref = computed(() => {
+  const returnTo = new URLSearchParams(window.location.search).get("returnTo")
+  return returnTo || `/shopify-connection-details/${props.id}`
+})
 
 const isDirty = computed(() => {
   return Object.keys(localMappings.value).some(id => {
@@ -94,7 +105,7 @@ onIonViewWillEnter(async () => {
   isLoading.value = true;
   await Promise.all([
     utilStore.fetchProductTypes(),
-    shopifyStore.fetchShopifyTypeMappings("SHOPIFY_PRODUCT_TYPE")
+    shopifyStore.fetchShopifyTypeMappings({ mappedTypeId: "SHOPIFY_PRODUCT_TYPE", shopId: props.id })
   ]);
   initializeLocalMappings();
   isLoading.value = false;
@@ -162,7 +173,7 @@ async function saveMapping(productTypeId: string) {
 
     if (!commonUtil.hasError(resp)) {
       commonUtil.showToast(translate("Mapping updated successfully"));
-      await shopifyStore.fetchShopifyTypeMappings("SHOPIFY_PRODUCT_TYPE");
+      await shopifyStore.fetchShopifyTypeMappings({ mappedTypeId: "SHOPIFY_PRODUCT_TYPE", shopId: props.id });
       editingItemId.value = "";
     } else {
       throw resp.data;
@@ -198,7 +209,7 @@ async function saveAllDirtyMappings() {
         mappedValue: id
       });
     }
-    await shopifyStore.fetchShopifyTypeMappings("SHOPIFY_PRODUCT_TYPE");
+    await shopifyStore.fetchShopifyTypeMappings({ mappedTypeId: "SHOPIFY_PRODUCT_TYPE", shopId: props.id });
     commonUtil.showToast(translate("All mappings saved successfully"));
   } catch (error) {
     logger.error(error);

--- a/src/views/ShopifySalesChannels.vue
+++ b/src/views/ShopifySalesChannels.vue
@@ -2,7 +2,7 @@
   <ion-page>
     <ion-header :translucent="true">
       <ion-toolbar>
-        <ion-back-button slot="start" :default-href="'/shopify-connection-details/' + id" />
+        <ion-back-button slot="start" :default-href="backHref" />
         <ion-title>{{ translate("Sales channels") }}</ion-title>
       </ion-toolbar>
     </ion-header>
@@ -81,6 +81,10 @@ const localMappings = ref<any>({});
 
 const salesChannels = computed(() => netSuiteStore.salesChannel)
 const shopifyTypeMappings = computed(() => shopifyStore.getShopifyTypeMappings("SHOPIFY_ORDER_SOURCE"))
+const backHref = computed(() => {
+  const returnTo = new URLSearchParams(window.location.search).get("returnTo")
+  return returnTo || `/shopify-connection-details/${props.id}`
+})
 
 const isDirty = computed(() => {
   return Object.keys(localMappings.value).some(id => {
@@ -94,7 +98,7 @@ onIonViewWillEnter(async () => {
   isLoading.value = true;
   await Promise.all([
     netSuiteStore.fetchSalesChannel(),
-    shopifyStore.fetchShopifyTypeMappings("SHOPIFY_ORDER_SOURCE")
+    shopifyStore.fetchShopifyTypeMappings({ mappedTypeId: "SHOPIFY_ORDER_SOURCE", shopId: props.id })
   ]);
   initializeLocalMappings();
   isLoading.value = false;
@@ -162,7 +166,7 @@ async function saveMapping(salesChannelEnumId: string) {
 
     if (!commonUtil.hasError(resp)) {
       commonUtil.showToast(translate("Mapping updated successfully"));
-      await shopifyStore.fetchShopifyTypeMappings("SHOPIFY_ORDER_SOURCE");
+      await shopifyStore.fetchShopifyTypeMappings({ mappedTypeId: "SHOPIFY_ORDER_SOURCE", shopId: props.id });
       editingItemId.value = "";
     } else {
       throw resp.data;
@@ -198,7 +202,7 @@ async function saveAllDirtyMappings() {
         mappedValue: id
       });
     }
-    await shopifyStore.fetchShopifyTypeMappings("SHOPIFY_ORDER_SOURCE");
+    await shopifyStore.fetchShopifyTypeMappings({ mappedTypeId: "SHOPIFY_ORDER_SOURCE", shopId: props.id });
     commonUtil.showToast(translate("All mappings saved successfully"));
   } catch (error) {
     logger.error(error);

--- a/src/views/ShopifyShipmentMethods.vue
+++ b/src/views/ShopifyShipmentMethods.vue
@@ -2,7 +2,7 @@
   <ion-page>
     <ion-header :translucent="true">
       <ion-toolbar>
-        <ion-back-button slot="start" :default-href="'/shopify-connection-details/' + id" />
+        <ion-back-button slot="start" :default-href="backHref" />
         <ion-title>{{ translate("Shipment methods") }}</ion-title>
         <ion-buttons slot="primary">
           <ion-button :disabled="!isDirty" @click="saveAllDirtyMappings()">
@@ -101,6 +101,10 @@ const selectedCarrierPartyId = ref("");
 const shipmentMethodTypes = computed(() => utilStore.shipmentMethodTypes)
 const productStoreShipmentMethods = computed(() => netSuiteStore.productStoreShipmentMethods)
 const shopifyShopsCarrierShipments = computed(() => shopifyStore.shopifyShopsCarrierShipments)
+const backHref = computed(() => {
+  const returnTo = new URLSearchParams(window.location.search).get("returnTo")
+  return returnTo || `/shopify-connection-details/${props.id}`
+})
 
 const carriers = computed(() => {
   const carrierMap: any = {};
@@ -222,7 +226,7 @@ async function saveMapping(shipmentMethodTypeId: string) {
 
     if (!commonUtil.hasError(resp)) {
       commonUtil.showToast(translate("Mapping updated successfully"));
-      await shopifyStore.fetchShopifyShopsCarrierShipments({});
+      await shopifyStore.fetchShopifyShopsCarrierShipments({ shopId: props.id });
       editingItemKey.value = "";
     } else {
       throw resp.data;
@@ -254,7 +258,7 @@ async function saveAllDirtyMappings() {
         carrierPartyId: carrierPartyId
       });
     }
-    await shopifyStore.fetchShopifyShopsCarrierShipments({});
+    await shopifyStore.fetchShopifyShopsCarrierShipments({ shopId: props.id });
     commonUtil.showToast(translate("All mappings saved successfully"));
   } catch (error) {
     logger.error(error);


### PR DESCRIPTION
## Business summary

This PR makes the Shopify mapping layer visible from Product Store onboarding. Retailers can see whether the linked Shopify shop already has the mappings needed for product import, order source attribution, payment mapping, shipping mapping, and inventory location mapping, then jump directly to the existing shop-specific setup screen.

## Scope

- Adds shop-scoped mapping counts to the onboarding Shopify step.
- Deep-links mapping rows to product types, sales channels, payment methods, shipment methods, and inventory locations with a return path back to onboarding.
- Keeps existing mapping screens shop-scoped when fetching or refreshing mappings.
- Makes the product-type mapping page resilient when the live OMS runtime does not expose `oms/productTypes` by falling back to mapped OMS product-type IDs from `ShopifyShopTypeMapping`.
- Leaves mapping writes on the existing Company/Moqui endpoints; no backend endpoint is introduced.

## Stack

- Base: company PR #191.
- Tracks issue #192.

## Validation

- `pnpm build`
- `git diff --check`
- Chrome smoke on `http://127.0.0.1:8118/product-store-onboarding/STORE`:
  - Shopify step shows mapping readiness and linked-shop counts.
  - Product type mapping row navigates to `/shopify-connection-details/10000/product-types?returnTo=/product-store-onboarding/STORE`.
  - Product type mapping page renders rows from `ShopifyShopTypeMapping` despite the current runtime returning 404 for `oms/productTypes`.
  - Back navigation returns to onboarding and mapping counts refresh.