### PR TITLE
[codex] Remove onboarding router warnings

### DIFF
--- a/src/views/ProductStoreOnboarding.vue
+++ b/src/views/ProductStoreOnboarding.vue
@@ -1058,7 +1058,6 @@ import {
   onIonViewWillEnter
 } from "@ionic/vue"
 import { computed, ref } from "vue"
-import { useRoute, useRouter } from "vue-router"
 import { arrowBackOutline, arrowForwardOutline, cloudDownloadOutline, copyOutline, gitNetworkOutline, keyOutline, openOutline, radioButtonOffOutline, storefrontOutline, syncOutline } from "ionicons/icons"
 import { commonUtil, emitter, logger, translate } from "@common"
 import ImportShopifyLocationsModal from "@/components/ImportShopifyLocationsModal.vue"
@@ -1075,8 +1074,6 @@ const productStoreStore = useProductStore()
 const shopifyStore = useShopifyStore()
 const utilStore = useUtilStore()
 const props = defineProps<{ productStoreId?: string }>()
-const route = useRoute()
-const router = useRouter()
 const isSavingProductStore = ref(false)
 const isLinkingShopifyShop = ref(false)
 const isGeneratingShopifyToken = ref(false)
@@ -1109,13 +1106,7 @@ const shopifyMappingCounts = ref<Record<string, number>>({
 
 const currentStep = computed(() => onboardingStore.currentStep)
 const isLastStep = computed(() => onboardingStore.currentStepIndex === PRODUCT_STORE_ONBOARDING_STEPS.length - 1)
-const routeProductStoreId = computed(() => {
-  if (props.productStoreId) return props.productStoreId
-
-  const productStoreId = (route as any)?.params?.productStoreId
-  if (Array.isArray(productStoreId)) return productStoreId[0] || ""
-  return productStoreId ? String(productStoreId) : ""
-})
+const routeProductStoreId = computed(() => props.productStoreId || "")
 const selectedProductStoreId = computed(() => onboardingStore.createdProductStoreId || routeProductStoreId.value)
 const shouldCollectCompanyName = computed(() => productStoreStore.productStores.length === 0)
 const organizationPartyId = computed(() => utilStore.organizationPartyId)
@@ -2653,11 +2644,6 @@ function openShopifyMappingPath(pathSegment: string) {
   const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`
   const fallbackUrl = `${path}?returnTo=${encodeURIComponent(returnTo)}`
 
-  if ((router as any)?.push) {
-    router.push({ path, query: { returnTo } }).catch((error: any) => logger.error(error))
-    return
-  }
-
   window.location.href = fallbackUrl
 }
 
@@ -2682,11 +2668,6 @@ async function openShopifyProductSync() {
     returnTo
   }
   const fallbackQuery = new URLSearchParams(query).toString()
-
-  if ((router as any)?.push) {
-    router.push({ path, query }).catch((error: any) => logger.error(error))
-    return
-  }
 
   window.location.href = `${path}?${fallbackQuery}`
 }

--- a/src/views/ShopifyLocations.vue
+++ b/src/views/ShopifyLocations.vue
@@ -2,7 +2,11 @@
   <ion-page>
     <ion-header :translucent="true">
       <ion-toolbar>
-        <ion-back-button slot="start" :defaultHref="backHref" />
+        <ion-buttons slot="start">
+          <ion-button aria-label="Back" @click="navigateBack">
+            <ion-icon slot="icon-only" :icon="arrowBackOutline" />
+          </ion-button>
+        </ion-buttons>
         <ion-title>{{ translate("Inventory locations") }}</ion-title>
         <ion-buttons slot="end">
           <ion-button @click="runAudit" :disabled="isAuditing">
@@ -110,14 +114,13 @@
 </template>
 
 <script setup lang="ts">
-import { alertController, IonButton, IonBackButton, IonButtons, IonCard, IonCardContent, IonChip, IonContent, IonHeader, IonIcon, IonInput, IonItem, IonLabel, IonPage, IonSkeletonText, IonSpinner, IonTitle, IonToolbar, modalController, onIonViewWillEnter } from "@ionic/vue";
-import { addOutline, checkmarkCircleOutline, cloudDownloadOutline, refreshOutline, saveOutline, shieldCheckmarkOutline, storefrontOutline } from 'ionicons/icons'
+import { alertController, IonButton, IonButtons, IonCard, IonCardContent, IonChip, IonContent, IonHeader, IonIcon, IonInput, IonItem, IonLabel, IonPage, IonSkeletonText, IonSpinner, IonTitle, IonToolbar, modalController, onIonViewWillEnter } from "@ionic/vue";
+import { addOutline, arrowBackOutline, checkmarkCircleOutline, cloudDownloadOutline, refreshOutline, saveOutline, shieldCheckmarkOutline, storefrontOutline } from 'ionicons/icons'
 import ImportShopifyLocationsModal from '@/components/ImportShopifyLocationsModal.vue'
 import { commonUtil, emitter, hasError, logger, translate } from '@common'
 import { useUtilStore } from '@/store/util';
 import { useShopifyStore } from '@/store/shopify';
 import { computed, defineProps, nextTick, ref, watch } from "vue";
-import { onBeforeRouteLeave } from "vue-router";
 
 const props = defineProps(['id']);
 const utilStore = useUtilStore();
@@ -284,12 +287,12 @@ async function runAudit() {
   }
 }
 
-onBeforeRouteLeave(async () => {
+async function confirmLeaveWithDirtyMappings() {
   if (!isDirty.value) {
     return true;
   }
 
-  return new Promise((resolve) => {
+  return new Promise<boolean>((resolve) => {
     alertController.create({
       header: translate("Unsaved changes"),
       message: translate("You have unsaved changes. Would you like to save them before leaving?"),
@@ -318,7 +321,14 @@ onBeforeRouteLeave(async () => {
       ]
     }).then(alert => alert.present());
   });
-});
+}
+
+async function navigateBack() {
+  const canLeave = await confirmLeaveWithDirtyMappings();
+  if (canLeave) {
+    window.location.href = backHref.value;
+  }
+}
 </script>
 
 <style scoped>

--- a/src/views/ShopifyPaymentMethods.vue
+++ b/src/views/ShopifyPaymentMethods.vue
@@ -2,7 +2,11 @@
   <ion-page>
     <ion-header :translucent="true">
       <ion-toolbar>
-        <ion-back-button slot="start" :default-href="backHref" />
+        <ion-buttons slot="start">
+          <ion-button aria-label="Back" @click="navigateBack">
+            <ion-icon slot="icon-only" :icon="arrowBackOutline" />
+          </ion-button>
+        </ion-buttons>
         <ion-title>{{ translate("Payment methods") }}</ion-title>
       </ion-toolbar>
     </ion-header>
@@ -64,13 +68,12 @@
 </template>
 
 <script setup lang="ts">
-import { alertController, IonButton, IonBackButton, IonChip, IonContent, IonHeader, IonIcon, IonInput, IonItem, IonLabel, IonPage, IonSkeletonText, IonTitle, IonToolbar, onIonViewWillEnter } from "@ionic/vue";
-import { addOutline, saveOutline, shieldCheckmarkOutline } from 'ionicons/icons'
+import { alertController, IonButton, IonButtons, IonChip, IonContent, IonHeader, IonIcon, IonInput, IonItem, IonLabel, IonPage, IonSkeletonText, IonTitle, IonToolbar, onIonViewWillEnter } from "@ionic/vue";
+import { addOutline, arrowBackOutline, saveOutline, shieldCheckmarkOutline } from 'ionicons/icons'
 import { commonUtil, emitter, hasError, logger, translate } from '@common'
 import { useNetSuiteStore } from '@/store/netSuite';
 import { useShopifyStore } from '@/store/shopify';
 import { computed, defineProps, nextTick, ref, watch } from "vue";
-import { onBeforeRouteLeave } from "vue-router";
 
 const props = defineProps(['id']);
 const netSuiteStore = useNetSuiteStore();
@@ -211,12 +214,12 @@ async function saveAllDirtyMappings() {
   emitter.emit("dismissLoader");
 }
 
-onBeforeRouteLeave(async () => {
+async function confirmLeaveWithDirtyMappings() {
   if (!isDirty.value) {
     return true;
   }
 
-  return new Promise((resolve) => {
+  return new Promise<boolean>((resolve) => {
     alertController.create({
       header: translate("Unsaved changes"),
       message: translate("You have unsaved changes. Would you like to save them before leaving?"),
@@ -245,7 +248,14 @@ onBeforeRouteLeave(async () => {
       ]
     }).then(alert => alert.present());
   });
-});
+}
+
+async function navigateBack() {
+  const canLeave = await confirmLeaveWithDirtyMappings();
+  if (canLeave) {
+    window.location.href = backHref.value;
+  }
+}
 </script>
 
 <style scoped>

--- a/src/views/ShopifyProductTypes.vue
+++ b/src/views/ShopifyProductTypes.vue
@@ -2,7 +2,11 @@
   <ion-page>
     <ion-header :translucent="true">
       <ion-toolbar>
-        <ion-back-button slot="start" :default-href="backHref" />
+        <ion-buttons slot="start">
+          <ion-button aria-label="Back" @click="navigateBack">
+            <ion-icon slot="icon-only" :icon="arrowBackOutline" />
+          </ion-button>
+        </ion-buttons>
         <ion-title>{{ translate("Product types") }}</ion-title>
       </ion-toolbar>
     </ion-header>
@@ -64,13 +68,12 @@
 </template>
 
 <script setup lang="ts">
-import { alertController, IonButton, IonBackButton, IonChip, IonContent, IonHeader, IonIcon, IonInput, IonItem, IonLabel, IonPage, IonSkeletonText, IonTitle, IonToolbar, onIonViewWillEnter } from "@ionic/vue";
-import { addOutline, saveOutline, shieldCheckmarkOutline } from 'ionicons/icons'
+import { alertController, IonButton, IonButtons, IonChip, IonContent, IonHeader, IonIcon, IonInput, IonItem, IonLabel, IonPage, IonSkeletonText, IonTitle, IonToolbar, onIonViewWillEnter } from "@ionic/vue";
+import { addOutline, arrowBackOutline, saveOutline, shieldCheckmarkOutline } from 'ionicons/icons'
 import { commonUtil, emitter, hasError, logger, translate } from '@common'
 import { useUtilStore } from '@/store/util';
 import { useShopifyStore } from '@/store/shopify';
 import { computed, defineProps, nextTick, ref, watch } from "vue";
-import { onBeforeRouteLeave } from "vue-router";
 
 const props = defineProps(['id']);
 const utilStore = useUtilStore();
@@ -218,12 +221,12 @@ async function saveAllDirtyMappings() {
   emitter.emit("dismissLoader");
 }
 
-onBeforeRouteLeave(async () => {
+async function confirmLeaveWithDirtyMappings() {
   if (!isDirty.value) {
     return true;
   }
 
-  return new Promise((resolve) => {
+  return new Promise<boolean>((resolve) => {
     alertController.create({
       header: translate("Unsaved changes"),
       message: translate("You have unsaved changes. Would you like to save them before leaving?"),
@@ -252,7 +255,14 @@ onBeforeRouteLeave(async () => {
       ]
     }).then(alert => alert.present());
   });
-});
+}
+
+async function navigateBack() {
+  const canLeave = await confirmLeaveWithDirtyMappings();
+  if (canLeave) {
+    window.location.href = backHref.value;
+  }
+}
 </script>
 
 <style scoped>

--- a/src/views/ShopifySalesChannels.vue
+++ b/src/views/ShopifySalesChannels.vue
@@ -2,7 +2,11 @@
   <ion-page>
     <ion-header :translucent="true">
       <ion-toolbar>
-        <ion-back-button slot="start" :default-href="backHref" />
+        <ion-buttons slot="start">
+          <ion-button aria-label="Back" @click="navigateBack">
+            <ion-icon slot="icon-only" :icon="arrowBackOutline" />
+          </ion-button>
+        </ion-buttons>
         <ion-title>{{ translate("Sales channels") }}</ion-title>
       </ion-toolbar>
     </ion-header>
@@ -64,13 +68,12 @@
 </template>
 
 <script setup lang="ts">
-import { alertController, IonButton, IonBackButton, IonChip, IonContent, IonHeader, IonIcon, IonInput, IonItem, IonLabel, IonPage, IonSkeletonText, IonTitle, IonToolbar, onIonViewWillEnter } from "@ionic/vue";
-import { addOutline, saveOutline, shieldCheckmarkOutline } from 'ionicons/icons'
+import { alertController, IonButton, IonButtons, IonChip, IonContent, IonHeader, IonIcon, IonInput, IonItem, IonLabel, IonPage, IonSkeletonText, IonTitle, IonToolbar, onIonViewWillEnter } from "@ionic/vue";
+import { addOutline, arrowBackOutline, saveOutline, shieldCheckmarkOutline } from 'ionicons/icons'
 import { commonUtil, emitter, hasError, logger, translate } from '@common'
 import { useNetSuiteStore } from '@/store/netSuite';
 import { useShopifyStore } from '@/store/shopify';
 import { computed, defineProps, nextTick, ref, watch } from "vue";
-import { onBeforeRouteLeave } from "vue-router";
 
 const props = defineProps(['id']);
 const netSuiteStore = useNetSuiteStore();
@@ -211,12 +214,12 @@ async function saveAllDirtyMappings() {
   emitter.emit("dismissLoader");
 }
 
-onBeforeRouteLeave(async () => {
+async function confirmLeaveWithDirtyMappings() {
   if (!isDirty.value) {
     return true;
   }
 
-  return new Promise((resolve) => {
+  return new Promise<boolean>((resolve) => {
     alertController.create({
       header: translate("Unsaved changes"),
       message: translate("You have unsaved changes. Would you like to save them before leaving?"),
@@ -245,7 +248,14 @@ onBeforeRouteLeave(async () => {
       ]
     }).then(alert => alert.present());
   });
-});
+}
+
+async function navigateBack() {
+  const canLeave = await confirmLeaveWithDirtyMappings();
+  if (canLeave) {
+    window.location.href = backHref.value;
+  }
+}
 </script>
 
 <style scoped>

--- a/src/views/ShopifyShipmentMethods.vue
+++ b/src/views/ShopifyShipmentMethods.vue
@@ -2,7 +2,11 @@
   <ion-page>
     <ion-header :translucent="true">
       <ion-toolbar>
-        <ion-back-button slot="start" :default-href="backHref" />
+        <ion-buttons slot="start">
+          <ion-button aria-label="Back" @click="navigateBack">
+            <ion-icon slot="icon-only" :icon="arrowBackOutline" />
+          </ion-button>
+        </ion-buttons>
         <ion-title>{{ translate("Shipment methods") }}</ion-title>
         <ion-buttons slot="primary">
           <ion-button :disabled="!isDirty" @click="saveAllDirtyMappings()">
@@ -79,14 +83,13 @@
 </template>
 
 <script setup lang="ts">
-import { alertController, IonButton, IonButtons, IonBackButton, IonChip, IonContent, IonHeader, IonIcon, IonInput, IonItem, IonLabel, IonPage, IonSegment, IonSegmentButton, IonSkeletonText, IonTitle, IonToolbar, onIonViewWillEnter } from "@ionic/vue";
-import { addOutline, airplaneOutline, saveOutline, shieldCheckmarkOutline } from 'ionicons/icons'
+import { alertController, IonButton, IonButtons, IonChip, IonContent, IonHeader, IonIcon, IonInput, IonItem, IonLabel, IonPage, IonSegment, IonSegmentButton, IonSkeletonText, IonTitle, IonToolbar, onIonViewWillEnter } from "@ionic/vue";
+import { addOutline, airplaneOutline, arrowBackOutline, saveOutline, shieldCheckmarkOutline } from 'ionicons/icons'
 import { commonUtil, emitter, hasError, logger, translate } from '@common'
 import { useUtilStore } from '@/store/util';
 import { useNetSuiteStore } from '@/store/netSuite';
 import { useShopifyStore } from '@/store/shopify';
 import { computed, defineProps, nextTick, ref, watch } from "vue";
-import { onBeforeRouteLeave } from "vue-router";
 
 const props = defineProps(['id']);
 const utilStore = useUtilStore();
@@ -267,12 +270,12 @@ async function saveAllDirtyMappings() {
   emitter.emit("dismissLoader");
 }
 
-onBeforeRouteLeave(async () => {
+async function confirmLeaveWithDirtyMappings() {
   if (!isDirty.value) {
     return true;
   }
 
-  return new Promise((resolve) => {
+  return new Promise<boolean>((resolve) => {
     alertController.create({
       header: translate("Unsaved changes"),
       message: translate("You have unsaved changes. Would you like to save them before leaving?"),
@@ -301,7 +304,14 @@ onBeforeRouteLeave(async () => {
       ]
     }).then(alert => alert.present());
   });
-});
+}
+
+async function navigateBack() {
+  const canLeave = await confirmLeaveWithDirtyMappings();
+  if (canLeave) {
+    window.location.href = backHref.value;
+  }
+}
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Business summary
Product Store onboarding is becoming the guided setup surface for retailer launch work. This PR removes noisy Vue Router warnings from the onboarding and Shopify mapping path so setup validation can focus on real OMS configuration gaps.

Closes #196

## What changed
- Removed `useRoute` / `useRouter` from `ProductStoreOnboarding.vue` and kept the existing URL fallback navigation for Shopify handoff links.
- Replaced invalid Vue Router leave guards on Shopify mapping pages with Ionic toolbar back buttons.
- Preserved the unsaved-mapping prompt when users leave through those toolbar back actions.

## Validation
- `pnpm build`
- `git diff --check`
- Chrome smoke on `http://127.0.0.1:8120/product-store-onboarding/STORE`
- Confirmed Shopify mapping deep link opens with `returnTo` and the new back control returns to onboarding.
- Confirmed console no longer shows route/router injection warnings or the invalid active-route leave-guard warning.

Known unrelated console noise remains from missing i18n keys and the local OMS missing `oms/productTypes`.