### PR TITLE
[codex] Start onboarding from clean product store draft

### DIFF
--- a/src/views/ProductStore.vue
+++ b/src/views/ProductStore.vue
@@ -71,7 +71,7 @@ async function viewProductStoreDetails(productStoreId: string) {
 }
 
 function createStore() {
-  router.push("/create-product-store")
+  router.push("/product-store-onboarding")
 }
 
 function cloneStoreSettings() {

--- a/src/views/ProductStoreOnboarding.vue
+++ b/src/views/ProductStoreOnboarding.vue
@@ -1794,6 +1794,12 @@ async function refreshAccessPackageStatus() {
 onIonViewWillEnter(async () => {
   if (routeProductStoreId.value) {
     onboardingStore.setCreatedProductStoreId(routeProductStoreId.value)
+  } else {
+    onboardingStore.resetDraft()
+    productStoreStore.current = {}
+    productStoreStore.currentStoreSettings = {}
+    productStoreStore.currentShopifyJobStatus = null
+    productStoreStore.currentAccessPackageStatus = null
   }
 
   await loadSetupData()


### PR DESCRIPTION
## Business summary
This moves the Product Store creation entry point onto the guided onboarding flow and makes a new setup session start from a clean draft. The practical effect is that first-time setup now starts in the same conversational map-style experience we are building, instead of falling back to the legacy create form or inheriting stale setup state.

Fixes #198

## What changed
- Pointed the Product Store list create action at `/product-store-onboarding`.
- Reset draft/current product store state when onboarding opens without a product store id.

## Validation
- `git diff --check`
- `VITE_OMS_TYPE=MOQUI pnpm --filter company build`
- Local smoke against isolated Moqui confirmed the create action opens a blank guided setup.

## Known follow-up
Full Product Store creation is still blocked in the isolated cold-start runtime because `admin/organizations?roleTypeId=INTERNAL_ORGANIZATIO` returns no organization, causing the existing save path to stop before POSTing a ProductStore. I am handling that as the next backend/config slice.