### PR TITLE
[codex] Bootstrap organization during Product Store onboarding

### DIFF
--- a/src/store/util.ts
+++ b/src/store/util.ts
@@ -225,6 +225,27 @@ export const useUtilStore = defineStore('util', {
         this.fetchStatus = { ...this.fetchStatus, organizationPartyId: 'error' }
       }
       this.organizationPartyId = partyId
+      return partyId
+    },
+
+    async bootstrapOrganization(payload: { partyId?: string, groupName?: string } = {}) {
+      this.fetchStatus = { ...this.fetchStatus, organizationPartyId: 'pending' }
+
+      try {
+        const resp = await api({ url: "admin/organizations/bootstrap", method: "post", data: payload })
+        if (!commonUtil.hasError(resp)) {
+          this.organizationPartyId = resp.data?.partyId || payload.partyId || this.organizationPartyId
+          this.fetchStatus = { ...this.fetchStatus, organizationPartyId: 'success', lastFetched: Date.now() }
+          return resp.data
+        } else {
+          throw resp.data
+        }
+      } catch (error) {
+        logger.error(error)
+        this.fetchStatus = { ...this.fetchStatus, organizationPartyId: 'error' }
+      }
+
+      return null
     },
 
     async fetchStatusItems() {

--- a/src/views/ProductStoreOnboarding.vue
+++ b/src/views/ProductStoreOnboarding.vue
@@ -1068,6 +1068,7 @@ import { useProductStore } from "@/store/productStore"
 import { useShopifyStore } from "@/store/shopify"
 import { useUtilStore } from "@/store/util"
 import { generateInternalId } from "@/utils"
+import router from "@/router"
 
 const onboardingStore = useProductStoreOnboardingStore()
 const productStoreStore = useProductStore()
@@ -1108,8 +1109,8 @@ const currentStep = computed(() => onboardingStore.currentStep)
 const isLastStep = computed(() => onboardingStore.currentStepIndex === PRODUCT_STORE_ONBOARDING_STEPS.length - 1)
 const routeProductStoreId = computed(() => props.productStoreId || "")
 const selectedProductStoreId = computed(() => onboardingStore.createdProductStoreId || routeProductStoreId.value)
-const shouldCollectCompanyName = computed(() => productStoreStore.productStores.length === 0)
 const organizationPartyId = computed(() => utilStore.organizationPartyId)
+const shouldCollectCompanyName = computed(() => productStoreStore.productStores.length === 0 || !organizationPartyId.value)
 const isPrimaryActionLoading = computed(() => {
   return isSavingProductStore.value
     || isLinkingShopifyShop.value
@@ -1851,19 +1852,25 @@ async function createProductStoreFromDraft() {
     return ""
   }
 
-  if (!organizationPartyId.value) {
-    commonUtil.showToast(translate("Unable to find company organization."))
-    return ""
-  }
-
   isSavingProductStore.value = true
   emitter.emit("presentLoader")
 
   try {
+    if (!organizationPartyId.value) {
+      const bootstrapCompanyName = onboardingStore.draft.companyName.trim() || productStoreStore.company.companyName || storeName
+      await utilStore.bootstrapOrganization({ groupName: bootstrapCompanyName })
+      if (organizationPartyId.value) await productStoreStore.fetchCompany()
+    }
+
+    if (!organizationPartyId.value) {
+      commonUtil.showToast(translate("Unable to find company organization."))
+      return ""
+    }
+
     const payload = {
       storeName,
       productStoreId,
-      companyName: productStoreStore.company.companyName,
+      companyName: productStoreStore.company.companyName || onboardingStore.draft.companyName.trim() || storeName,
       payToPartyId: organizationPartyId.value,
       defaultCurrencyUomId: onboardingStore.draft.defaultCurrencyUomId
     } as any


### PR DESCRIPTION
## Business summary
This lets the guided Product Store setup recover when a cold-start runtime has no internal organization yet. Instead of stopping with `Unable to find company organization`, onboarding can ask for the company name, create the organization link through the backend bootstrap endpoint, and continue creating ProductStore.

Fixes #200

## What changed
- Added `utilStore.bootstrapOrganization()` for `admin/organizations/bootstrap`.
- Treat missing organization as a reason to collect company name in the Name step.
- Bootstrap organization during ProductStore create before posting the ProductStore.
- Imported the router used by the route replacement helper, fixing the `router is not defined` error exposed during smoke testing.

## Validation
- `git diff --check`
- `VITE_OMS_TYPE=MOQUI pnpm --filter company build`
- Playwright smoke against Company 8122 + isolated Moqui 8081 created `ORG_BOOT_SMK2` through guided onboarding, advanced to `/product-store-onboarding/ORG_BOOT_SMK2`, and reported 0 console errors after the router import fix.
- Backend verification confirmed `ORG_BOOT_SMK2` exists with `payToPartyId=COMPANY` and `defaultCurrencyUomId=USD`.

## Backend dependency
Depends on hotwax-maarg-util PR for `POST /rest/s1/admin/organizations/bootstrap`.