### PR TITLE
[codex] Create Shopify connection from Product Store onboarding

### DIFF
--- a/src/components/CreateShopifyConnectionModal.vue
+++ b/src/components/CreateShopifyConnectionModal.vue
@@ -100,9 +100,10 @@ import { useShopifyStore } from '@/store/shopify'
 import { computed, reactive } from 'vue'
 
 const shopifyStore = useShopifyStore()
+const props = defineProps<{ productStoreId?: string, initialDomain?: string }>()
 
 const form = reactive({
-  myshopifyDomain: '',
+  myshopifyDomain: props.initialDomain || '',
   shopifyShopId: '',
   shopId: '',
   name: '',
@@ -147,7 +148,8 @@ async function saveConnection() {
       shopAccessToken: form.shopAccessToken.trim(),
       clientId: form.clientId.trim(),
       clientSecret: form.clientSecret.trim(),
-      name: form.name.trim() || undefined
+      name: form.name.trim() || undefined,
+      productStoreId: props.productStoreId
     })
 
     commonUtil.showToast(translate('Shopify connection created'))

--- a/src/views/ProductStoreOnboarding.vue
+++ b/src/views/ProductStoreOnboarding.vue
@@ -1060,6 +1060,7 @@ import {
 import { computed, ref } from "vue"
 import { arrowBackOutline, arrowForwardOutline, cloudDownloadOutline, copyOutline, gitNetworkOutline, keyOutline, openOutline, radioButtonOffOutline, storefrontOutline, syncOutline } from "ionicons/icons"
 import { commonUtil, emitter, logger, translate } from "@common"
+import CreateShopifyConnectionModal from "@/components/CreateShopifyConnectionModal.vue"
 import ImportShopifyLocationsModal from "@/components/ImportShopifyLocationsModal.vue"
 import OnboardingStepList from "@/components/product-store-onboarding/OnboardingStepList.vue"
 import { PRODUCT_STORE_ONBOARDING_GROUPS, PRODUCT_STORE_ONBOARDING_STEPS } from "@/config/productStoreOnboarding"
@@ -1495,6 +1496,7 @@ const nextLabel = computed(() => {
 const primaryActionLabel = computed(() => {
   if (currentStep.value.id === "name" && !selectedProductStoreId.value) return translate("Create product store")
   if (currentStep.value.id === "general") return translate("Save order defaults")
+  if (currentStep.value.id === "shopify" && onboardingStore.draft.shopifyConnectionMode === "Connect now" && !linkedShopifyShop.value) return translate("Create Shopify connection")
   if (currentStep.value.id === "shopify" && isExistingShopifyMode.value && !linkedShopifyShop.value) return translate("Link Shopify")
   if (currentStep.value.id === "products") return translate("Save product identity")
   if (currentStep.value.id === "inventory" && shouldSetupShopifyInventoryReset.value && linkedShopifyShopId.value) return translate("Save inventory setup")
@@ -1519,6 +1521,10 @@ const isPrimaryActionDisabled = computed(() => {
 
   if (currentStep.value.id === "shopify" && isExistingShopifyMode.value && !linkedShopifyShop.value) {
     return !selectedProductStoreId.value || !onboardingStore.draft.selectedShopifyShopId
+  }
+
+  if (currentStep.value.id === "shopify" && onboardingStore.draft.shopifyConnectionMode === "Connect now" && !linkedShopifyShop.value) {
+    return !selectedProductStoreId.value
   }
 
   if (currentStep.value.id === "general") {
@@ -2012,6 +2018,11 @@ async function handlePrimaryAction() {
   if (currentStep.value.id === "shopify" && isExistingShopifyMode.value && !linkedShopifyShop.value) {
     const shopLinked = await linkExistingShopifyShop()
     if (!shopLinked) return
+  }
+
+  if (currentStep.value.id === "shopify" && onboardingStore.draft.shopifyConnectionMode === "Connect now" && !linkedShopifyShop.value) {
+    const shopCreated = await createShopifyConnectionForProductStore()
+    if (!shopCreated) return
   }
 
   if (currentStep.value.id === "general") {
@@ -2593,6 +2604,33 @@ async function linkExistingShopifyShop() {
     emitter.emit("dismissLoader")
     isLinkingShopifyShop.value = false
   }
+}
+
+async function createShopifyConnectionForProductStore() {
+  if (!selectedProductStoreId.value) {
+    commonUtil.showToast(translate("Create the Product Store before connecting Shopify."))
+    return false
+  }
+
+  const modal = await modalController.create({
+    component: CreateShopifyConnectionModal,
+    componentProps: {
+      productStoreId: selectedProductStoreId.value,
+      initialDomain: onboardingStore.draft.shopifyDomain
+    }
+  })
+  await modal.present()
+  const { data } = await modal.onWillDismiss()
+  if (!data?.shopId) return false
+
+  await shopifyStore.fetchShopifyShops()
+  const createdShop = shopifyStore.getShopById(data.shopId)
+  onboardingStore.updateDraftField("linkedShopifyShopId", data.shopId)
+  onboardingStore.updateDraftField("selectedShopifyShopId", data.shopId)
+  onboardingStore.updateDraftField("shopifyDomain", createdShop?.myshopifyDomain || onboardingStore.draft.shopifyDomain)
+  await refreshShopifyJobStatus()
+  await refreshShopifyMappingStatus()
+  return true
 }
 
 async function refreshShopifyLocationMappings() {


### PR DESCRIPTION
## Business Summary

Retailer onboarding needs to create the Shopify connection in the same guided Product Store setup flow. This PR lets the Shopify onboarding step open the existing connection modal, prefill the captured Shopify domain, save the new ShopifyShop against the active ProductStore, and return to onboarding with that shop selected so product, facility, inventory, and order setup can keep moving.

Closes #202

## Changes

- Adds optional `productStoreId` and `initialDomain` props to `CreateShopifyConnectionModal`.
- Uses those props to prefill the Shopify domain and persist the ProductStore linkage when creating the connection.
- Updates the onboarding Shopify step so `Connect now` shows `Create Shopify connection` when no shop is linked.
- Refreshes Shopify setup/job state after modal completion and advances the guided flow only after a shop is created.

## Validation

- `git diff --check`
- `VITE_OMS_TYPE=MOQUI pnpm --filter company build`
- Browser smoke via local Playwright CLI against Company on `127.0.0.1:8122` and isolated Moqui on `localhost:8081`:
  - Logged in with Moqui auth.
  - Opened `/product-store-onboarding/ORG_BOOT_SMK2`.
  - Selected Shopify `Connect now`.
  - Verified primary action changed to `Create Shopify connection`.
  - Created dummy Shopify connection `CODEX_SMOKE_0613A` from the modal.
  - Confirmed onboarding advanced to Products with 0 console errors.
- Backend verification confirmed `ShopifyShop.CODEX_SMOKE_0613A.productStoreId = ORG_BOOT_SMK2` and `SystemMessageRemote.CODEX_SMOKE_0613A_REMOTE` was created.

## Notes

This proves the Company/Moqui setup records are created and linked. It does not prove external Shopify import because the smoke test used dummy Shopify credentials rather than a live Shopify store.
