### PR TITLE
[codex] Associate Shopify-imported facilities to Product Store onboarding

### DIFF
--- a/src/components/ImportShopifyLocationsModal.vue
+++ b/src/components/ImportShopifyLocationsModal.vue
@@ -90,12 +90,14 @@ import {
   modalController
 } from '@ionic/vue'
 import { close, downloadOutline } from 'ionicons/icons'
-import { commonUtil, translate } from '@common'
+import { commonUtil, logger, translate } from '@common'
 import { useShopifyStore } from '@/store/shopify'
+import { useProductStore } from '@/store/productStore'
 import { computed, ref, onMounted } from 'vue'
 
-const props = defineProps(['shopId'])
+const props = defineProps<{ shopId: string, productStoreId?: string }>()
 const shopifyStore = useShopifyStore()
+const productStoreStore = useProductStore()
 
 const isLoading    = ref(true)
 const isImporting  = ref(false)
@@ -188,14 +190,85 @@ async function importSelected() {
         longitude:   loc.longitude
       }))
     })
+
+    if (commonUtil.hasError(resp)) throw resp.data
+
     const count = Array.isArray(resp.data) ? resp.data.length : selectedForImport.value.length
+    const importedShopifyLocationIds = selectedForImport.value.map(loc => String(loc.shopifyLocationId))
+    const facilityIds = await resolveImportedFacilityIds(resp.data, importedShopifyLocationIds)
+    let associated = 0
+
+    try {
+      associated = await associateImportedFacilities(facilityIds)
+    } catch (error: any) {
+      logger.error(error)
+      commonUtil.showToast(translate('Locations imported, but Product Store association failed'))
+      modalController.dismiss({ imported: count, associated, facilityIds, associationFailed: true })
+      return
+    }
+
     commonUtil.showToast(translate('{count} locations imported', { count }))
-    modalController.dismiss({ imported: count })
+    modalController.dismiss({ imported: count, associated, facilityIds })
   } catch (e: any) {
+    logger.error(e)
     commonUtil.showToast(translate('Import failed'))
   } finally {
     isImporting.value = false
   }
+}
+
+async function resolveImportedFacilityIds(importResponse: any, shopifyLocationIds: string[]) {
+  const importedFacilityIds = collectFacilityIds(importResponse)
+  if (importedFacilityIds.length) return importedFacilityIds
+
+  try {
+    const mappingResp = await shopifyStore.fetchShopifyShopLocationsRaw({
+      shopId: props.shopId,
+      pageSize: 200
+    })
+    if (commonUtil.hasError(mappingResp)) throw mappingResp.data
+
+    const selectedShopifyLocationIds = new Set(shopifyLocationIds)
+    const mappedRows = (mappingResp.data || []).filter((mapping: any) =>
+      selectedShopifyLocationIds.has(String(mapping.shopifyLocationId))
+    )
+    return collectFacilityIds(mappedRows)
+  } catch (error: any) {
+    logger.warn('Failed to resolve imported Shopify facility IDs', error)
+    return []
+  }
+}
+
+function collectFacilityIds(data: any) {
+  const rows = Array.isArray(data)
+    ? data
+    : Array.isArray(data?.facilities)
+      ? data.facilities
+      : Array.isArray(data?.locations)
+        ? data.locations
+        : Array.isArray(data?.facilityIds)
+          ? data.facilityIds
+          : []
+
+  return Array.from(new Set(rows
+    .map((row: any) => typeof row === 'string' ? row : row?.facilityId || row?.facility?.facilityId || row?.Facility?.facilityId)
+    .filter(Boolean)
+    .map(String)))
+}
+
+async function associateImportedFacilities(facilityIds: string[]) {
+  if (!props.productStoreId || !facilityIds.length) return 0
+
+  let associated = 0
+  for (const facilityId of facilityIds) {
+    const resp = await productStoreStore.associateProductStoreFacility({
+      productStoreId: props.productStoreId,
+      facilityId
+    })
+    if (commonUtil.hasError(resp)) throw resp.data
+    associated += 1
+  }
+  return associated
 }
 
 function closeModal() {

--- a/src/store/productStore.ts
+++ b/src/store/productStore.ts
@@ -6,6 +6,7 @@ export const useProductStore = defineStore('productStore', {
   state: () => ({
     current: {} as any,
     currentStoreSettings: {} as any,
+    currentFacilities: [] as any[],
     currentShopifyJobStatus: null as any,
     currentAccessPackageStatus: null as any,
     productStores: [] as any[],
@@ -22,6 +23,7 @@ export const useProductStore = defineStore('productStore', {
   getters: {
     getCurrent: (state) => state.current ? JSON.parse(JSON.stringify(state.current)) : {},
     getCurrentStoreSettings: (state) => state.currentStoreSettings,
+    getCurrentFacilities: (state) => state.currentFacilities,
     getCurrentShopifyJobStatus: (state) => state.currentShopifyJobStatus,
     getCurrentAccessPackageStatus: (state) => state.currentAccessPackageStatus,
     getProductStores: (state) => state.productStores,
@@ -124,6 +126,42 @@ export const useProductStore = defineStore('productStore', {
         logger.error(error)
       }
       this.currentStoreSettings = storeSettings
+    },
+
+    async fetchProductStoreFacilities(productStoreId: string) {
+      let facilities: any[] = []
+      try {
+        const resp = await api({
+          url: `admin/productStores/${productStoreId}/facilities`,
+          method: "get",
+          params: { pageSize: 200 }
+        })
+        if (!commonUtil.hasError(resp)) {
+          facilities = resp.data || []
+        } else {
+          throw resp.data
+        }
+      } catch (error: any) {
+        logger.error(error)
+      }
+      this.currentFacilities = facilities
+      return facilities
+    },
+
+    async associateProductStoreFacility(payload: {
+      productStoreId: string
+      facilityId: string
+      fromDate?: number
+    }) {
+      return api({
+        url: `admin/productStores/${payload.productStoreId}/facilities/${payload.facilityId}/association`,
+        method: "post",
+        data: {
+          productStoreId: payload.productStoreId,
+          facilityId: payload.facilityId,
+          fromDate: payload.fromDate || Date.now()
+        }
+      })
     },
 
     async fetchProductStoreShopifyJobStatus(productStoreId: string) {

--- a/src/views/ProductStoreOnboarding.vue
+++ b/src/views/ProductStoreOnboarding.vue
@@ -1158,7 +1158,7 @@ const orderJobRequirements = computed(() => {
   })
 })
 const shouldConfigureRealtimeOrderImport = computed(() => onboardingStore.draft.orderImportMode === "Realtime and fallback batch")
-const facilityCount = computed(() => utilStore.facilities.length)
+const facilityCount = computed(() => productStoreStore.currentFacilities.length)
 const facilityGroups = computed(() => utilStore.facilityGroups)
 const shipmentMethodTypes = computed(() => utilStore.shipmentMethodTypes)
 const mappedShopifyLocationCount = computed(() => shopifyLocationMappings.value.length)
@@ -1805,6 +1805,7 @@ onIonViewWillEnter(async () => {
     onboardingStore.resetDraft()
     productStoreStore.current = {}
     productStoreStore.currentStoreSettings = {}
+    productStoreStore.currentFacilities = []
     productStoreStore.currentShopifyJobStatus = null
     productStoreStore.currentAccessPackageStatus = null
   }
@@ -1918,6 +1919,7 @@ async function loadSelectedProductStoreSetup() {
   await Promise.allSettled([
     productStoreStore.fetchProductStoreDetails(selectedProductStoreId.value),
     productStoreStore.fetchCurrentStoreSettings(selectedProductStoreId.value),
+    productStoreStore.fetchProductStoreFacilities(selectedProductStoreId.value),
     refreshShopifyJobStatus(),
     refreshAccessPackageStatus()
   ])
@@ -2663,15 +2665,22 @@ async function openShopifyLocationImport() {
   try {
     const modal = await modalController.create({
       component: ImportShopifyLocationsModal,
-      componentProps: { shopId: linkedShopifyShopId.value }
+      componentProps: {
+        shopId: linkedShopifyShopId.value,
+        productStoreId: selectedProductStoreId.value
+      }
     })
 
     await modal.present()
     const { data } = await modal.onDidDismiss()
 
     if (data?.imported) {
-      await utilStore.fetchFacilities()
+      await Promise.allSettled([
+        utilStore.fetchFacilities(),
+        productStoreStore.fetchProductStoreFacilities(selectedProductStoreId.value)
+      ])
       await refreshShopifyMappingStatus()
+      onboardingStore.markCurrentStepComplete()
     }
   } catch (error: any) {
     logger.error(error)


### PR DESCRIPTION
## Business Summary

Product Store onboarding needs the physical business topology to be scoped to the Product Store being configured. This PR makes the Facilities step count ProductStoreFacility associations instead of all global facilities, and lets the Shopify location import modal associate imported facility IDs back to the active Product Store when onboarding launches it.

Closes #204

## Changes

- Adds ProductStore-scoped facility state and fetch support in the Company ProductStore store.
- Adds a narrow wrapper for the existing `admin/productStores/{productStoreId}/facilities/{facilityId}/association` endpoint.
- Passes the active ProductStore into the Shopify location import modal from onboarding.
- Resolves imported facility IDs from the import response, falling back to a refreshed Shopify location mapping read.
- Associates resolved imported facilities to the active ProductStore and refreshes onboarding readiness after import.

## Validation

- `git diff --check`
- `VITE_OMS_TYPE=MOQUI pnpm --filter company build`
- Backend smoke against isolated Moqui on `localhost:8081`:
  - Created smoke facility `CODEX_FAC_0613A`.
  - Associated it to `ORG_BOOT_SMK2` through `admin/productStores/ORG_BOOT_SMK2/facilities/CODEX_FAC_0613A/association`.
  - Verified `admin/productStores/ORG_BOOT_SMK2/facilities` returned that ProductStoreFacility row.
- Browser smoke via local Playwright CLI against Company on `127.0.0.1:8122`:
  - Opened `/product-store-onboarding/ORG_BOOT_SMK2`.
  - Opened the Facilities step.
  - Confirmed readiness shows `1 facilities available for setup` from ProductStore-scoped association data.
  - Opened the Shopify import modal from onboarding and confirmed it mounted with the new props path.

## Notes

The isolated runtime does not mount the Shopify bridge REST resource, so `shopify/shops/{shopId}/shopify-locations` returns 404 with the dummy Shopify connection. This PR validates the Company/Moqui association path; live Shopify location import still requires a mounted Shopify bridge component and real Shopify credentials.
