### PR TITLE
[codex] Mark executable onboarding steps as existing APIs

### DIFF
--- a/src/config/productStoreOnboarding.ts
+++ b/src/config/productStoreOnboarding.ts
@@ -54,7 +54,7 @@ export const PRODUCT_STORE_ONBOARDING_STEPS: ProductStoreOnboardingStep[] = [
     group: "setup",
     label: "Shopify",
     summary: "Connect or reserve the Shopify shop that will feed products, orders, inventory, and locations.",
-    capability: "backend-gap",
+    capability: "existing-api",
     questions: [
       "Is this Product Store connected to an existing Shopify shop?",
       "Which myshopify domain should this setup use?",
@@ -119,7 +119,7 @@ export const PRODUCT_STORE_ONBOARDING_STEPS: ProductStoreOnboardingStep[] = [
     group: "setup",
     label: "Orders",
     summary: "Prepare order import, order updates, and realtime Shopify order flow before activation.",
-    capability: "backend-gap",
+    capability: "existing-api",
     questions: [
       "Should orders import in realtime, scheduled batches, or both?",
       "Which tags or order types should be included?",
@@ -132,7 +132,7 @@ export const PRODUCT_STORE_ONBOARDING_STEPS: ProductStoreOnboardingStep[] = [
     group: "setup",
     label: "Users",
     summary: "Map the people who will operate the store into app roles, security groups, and facility scope.",
-    capability: "backend-gap",
+    capability: "existing-api",
     questions: [
       "Which teams need access: stores, inventory, fulfillment, routing, or admins?",
       "Which users should be associated with each facility?",


### PR DESCRIPTION
## Business summary
The onboarding stack now has executable UI and backend bindings for Shopify connection, order job setup, and user access setup. This PR updates the step metadata so retailers see those areas as actionable setup steps rather than generic backend gaps, while live readiness checks still show missing jobs, mappings, or access data.

Closes #208

## Changes
- Marks Shopify as an `existing-api` onboarding step.
- Marks Orders as an `existing-api` onboarding step.
- Marks Users as an `existing-api` onboarding step.
- Leaves status-driven readiness gaps unchanged.

## Validation
- `git diff --check`
- `VITE_OMS_TYPE=MOQUI pnpm --filter company build`
- Playwright smoke on `http://127.0.0.1:8122/product-store-onboarding/ORG_BOOT_SMK`: sidebar no longer showed `Shopify Gap`, `Orders Gap`, or `Users Gap`; Orders setup package listed order outputs as `Existing API` while live job readiness still showed the correct gaps.