### PR TITLE
[codex] Enable IDE Trace Vue plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@typescript-eslint/parser": "~5.26.0",
     "@vitejs/plugin-legacy": "catalog:",
     "@vitejs/plugin-vue": "catalog:",
+    "chrome-ide-trace": "^0.1.0",
     "eslint": "catalog:",
     "eslint-plugin-vue": "^9.0.0",
     "typescript": "catalog:",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { createRequire } from 'module'
 import { defineConfig } from 'vite'
 import { versionInfoUtil } from '../../common/utils/versionInfoUtil'
 import { localApiServerDiscoveryPlugin } from '../../common/vite/localApiServerDiscoveryPlugin'
+import { ideTraceVue } from 'chrome-ide-trace/vite'
 import pkg from './package.json'
 
 const require = createRequire(import.meta.url)
@@ -52,11 +53,12 @@ function resolveCommonDeps() {
 }
 
 // https://vitejs.dev/config/
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   server: {
     port: 8100
   },
   plugins: [
+    ...(command === 'serve' ? [ideTraceVue()] : []),
     resolveCommonDeps(),
     localApiServerDiscoveryPlugin(),
     vue(),
@@ -82,4 +84,4 @@ export default defineConfig({
   build: {
     rollupOptions: {}
   }
-})
+}))


### PR DESCRIPTION
## Business summary
Developers need the Company app to emit IDE Trace metadata during local development so browser inspection can point back to the source Vue files. This provides the intended developer workflow without carrying the stale, conflicting history from PR #221.

Closes #224

## What changed
- Added `chrome-ide-trace` as a dev dependency.
- Registered `ideTraceVue()` in `vite.config.ts`.

## Validation
- `pnpm build` passed.
- Build still reports existing Rollup circular chunk warnings unrelated to this change.

## Notes
- This is the isolated replacement for conflicting PR #221. After this PR is accepted, PR #221 can be closed.