### PR TITLE
[codex] Simplify IDE Trace Vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -53,12 +53,12 @@ function resolveCommonDeps() {
 }
 
 // https://vitejs.dev/config/
-export default defineConfig(({ command }) => ({
+export default defineConfig({
   server: {
     port: 8100
   },
   plugins: [
-    ...(command === 'serve' ? [ideTraceVue()] : []),
+    ideTraceVue(),
     resolveCommonDeps(),
     localApiServerDiscoveryPlugin(),
     vue(),
@@ -84,4 +84,4 @@ export default defineConfig(({ command }) => ({
   build: {
     rollupOptions: {}
   }
-}))
+})


### PR DESCRIPTION
## Business summary
Company should rely on the IDE Trace plugin native Vite lifecycle guard instead of duplicating dev-only checks in the app Vite config. This keeps the app configuration cleaner while preserving the production privacy boundary.

Closes #226

## What changed
- Restored direct ideTraceVue() usage in the Vite plugin list.
- Kept the plugin ordered before vue() so local IDE Trace metadata still works.
- Relies on chrome-ide-trace using apply: serve to stay dev-server only.

## Validation
- pnpm build passed.
- rg "data-ide-trace|chrome-ide-trace|ideTraceVue" dist returned no production bundle markers.

## Notes
- Follow-up to #225 after confirming the dev-only behavior belongs in the plugin contract.