### PR TITLE
Remove app-level chrome-ide-trace dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@typescript-eslint/parser": "~5.26.0",
     "@vitejs/plugin-legacy": "catalog:",
     "@vitejs/plugin-vue": "catalog:",
-    "chrome-ide-trace": "^0.1.1",
     "eslint": "catalog:",
     "eslint-plugin-vue": "^9.0.0",
     "typescript": "catalog:",


### PR DESCRIPTION
Business summary: Removes the app-local IDE Trace dependency so AccxUI can own the installed version centrally through its workspace catalog/root dev dependency.\n\nCloses https://github.com/hotwax/company/issues/234