### PR TITLE
Fix inverted Shopify access-scope enum (SHOP_RW_ACCESS is canonical)

### DIFF
--- a/src/store/productStore.ts
+++ b/src/store/productStore.ts
@@ -13,7 +13,10 @@ const SHOPIFY_JOB_SPECS = [
 ]
 
 const ORDER_DATA_MANAGER_CONFIG_IDS = ["SYNC_SHOPIFY_ORDER", "BULK_ORDER_HISTORY"]
-const SHOPIFY_READ_WRITE_ACCESS_SCOPE_IDS = ["SHOP_READ_WRITE_ACCESS", "SHOP_RW_ACCESS"]
+// SHOP_RW_ACCESS is the official read-write access scope. The full-form SHOP_READ_WRITE_ACCESS
+// is deprecated and not enforced — a remote still on it is treated as needing a fix (force-replace
+// to SHOP_RW_ACCESS via the scope-fix action), not as already having read-write access.
+const SHOPIFY_READ_WRITE_ACCESS_SCOPE_IDS = ["SHOP_RW_ACCESS"]
 
 function valueText(value: any) {
   return value == null ? "" : String(value).trim()

--- a/src/store/shopifyProductSync.ts
+++ b/src/store/shopifyProductSync.ts
@@ -235,8 +235,10 @@ interface SystemMessageRemotesResponse {
 
 const PRODUCT_UPDATE_SYNC_MESSAGE_TYPE_ID = "BulkQueryShopifyProductUpdates";
 const SHOPIFY_NO_ACCESS_SCOPE_ENUM_ID = "SHOP_NO_ACCESS";
-const SHOPIFY_LEGACY_READ_WRITE_ACCESS_SCOPE_ENUM_ID = "SHOP_RW_ACCESS";
-const SHOPIFY_READ_WRITE_ACCESS_SCOPE_ENUM_ID = "SHOP_READ_WRITE_ACCESS";
+// SHOP_RW_ACCESS is the official read-write access scope. SHOP_READ_WRITE_ACCESS is the
+// deprecated full-form enum and requires updating (it is being phased out / force-replaced).
+const SHOPIFY_LEGACY_READ_WRITE_ACCESS_SCOPE_ENUM_ID = "SHOP_READ_WRITE_ACCESS";
+const SHOPIFY_READ_WRITE_ACCESS_SCOPE_ENUM_ID = "SHOP_RW_ACCESS";
 const LIVE_CATALOG_COUNTS_QUERY = `
 query WizardLiveCatalogCounts {
   productsCount {
@@ -532,8 +534,8 @@ function getShopRemoteCandidates(systemMessageRemoteList: any[], payload: any) {
 
 function sortShopRemoteCandidates(candidates: any[]) {
   return [...candidates].sort((first: any, second: any) => {
-    const firstReadWrite = String(first.accessScopeEnumId || "").includes("READ_WRITE") ? 1 : 0;
-    const secondReadWrite = String(second.accessScopeEnumId || "").includes("READ_WRITE") ? 1 : 0;
+    const firstReadWrite = hasShopifyWriteAccess(first.accessScopeEnumId) ? 1 : 0;
+    const secondReadWrite = hasShopifyWriteAccess(second.accessScopeEnumId) ? 1 : 0;
     return secondReadWrite - firstReadWrite;
   });
 }

--- a/src/store/shopifyProductSync.ts
+++ b/src/store/shopifyProductSync.ts
@@ -533,10 +533,17 @@ function getShopRemoteCandidates(systemMessageRemoteList: any[], payload: any) {
 }
 
 function sortShopRemoteCandidates(candidates: any[]) {
+  // Prioritize the best access scope so the selected candidate surfaces the right state:
+  // canonical write > deprecated/legacy write (still surfaces "update required") > read-only > no-access.
+  const accessScopeRank = (scope: string) => {
+    const normalized = String(scope || "").trim().toUpperCase();
+    if (normalized === SHOPIFY_READ_WRITE_ACCESS_SCOPE_ENUM_ID) return 3;
+    if (normalized === SHOPIFY_LEGACY_READ_WRITE_ACCESS_SCOPE_ENUM_ID) return 2;
+    if (normalized === SHOPIFY_NO_ACCESS_SCOPE_ENUM_ID) return 0;
+    return 1;
+  };
   return [...candidates].sort((first: any, second: any) => {
-    const firstReadWrite = hasShopifyWriteAccess(first.accessScopeEnumId) ? 1 : 0;
-    const secondReadWrite = hasShopifyWriteAccess(second.accessScopeEnumId) ? 1 : 0;
-    return secondReadWrite - firstReadWrite;
+    return accessScopeRank(second.accessScopeEnumId) - accessScopeRank(first.accessScopeEnumId);
   });
 }
 

--- a/src/views/ShopifyConnectionDetails.vue
+++ b/src/views/ShopifyConnectionDetails.vue
@@ -364,7 +364,7 @@ const productSyncMigrationNotice = computed(() => {
     return {
       state: "access-scope-update-required",
       label: translate("Update Shopify access scope"),
-      detail: translate("This Shopify connection still uses SHOP_RW_ACCESS. Update the remote configuration to SHOP_READ_WRITE_ACCESS before starting the new product sync."),
+      detail: translate("This Shopify connection still uses the deprecated SHOP_READ_WRITE_ACCESS scope. Update the remote configuration to SHOP_RW_ACCESS before starting the new product sync."),
       badge: translate("Update required"),
       color: "warning",
       action: "setup"

--- a/src/views/ShopifyProductSync.vue
+++ b/src/views/ShopifyProductSync.vue
@@ -1014,7 +1014,7 @@ const shopifyAccessDetail = computed(() => {
   }
 
   if (shopifyAccessState.value.status === "update-required") {
-    return translate("This Shopify connection uses a deprecated access scope enum. Update the remote configuration to SHOP_READ_WRITE_ACCESS before starting product sync.");
+    return translate("This Shopify connection uses a deprecated access scope enum. Update the remote configuration to SHOP_RW_ACCESS before starting product sync.");
   }
 
   if (shopifyAccessState.value.status === "read-only") {
@@ -1031,7 +1031,7 @@ const shopifyAccessBlockingMessage = computed(() => {
   }
 
   if (shopifyAccessState.value.status === "update-required") {
-    return translate("This Shopify connection uses deprecated access scope SHOP_RW_ACCESS. Update it to SHOP_READ_WRITE_ACCESS before starting product sync.");
+    return translate("This Shopify connection uses deprecated access scope SHOP_READ_WRITE_ACCESS. Update it to SHOP_RW_ACCESS before starting product sync.");
   }
 
   if (!hasShopifyWriteAccess.value) {


### PR DESCRIPTION
## What
The official Shopify read-write access scope is **`SHOP_RW_ACCESS`**. The full-form **`SHOP_READ_WRITE_ACCESS`** is deprecated. The company app had this inverted, so connections on the correct `SHOP_RW_ACCESS` were flagged "Update required" and users were told to switch *to* the deprecated enum.

Fixes:
- **`src/store/shopifyProductSync.ts`** — swap the inverted constants so `SHOP_RW_ACCESS` is the required scope and `SHOP_READ_WRITE_ACCESS` is the legacy/deprecated one; fix the remote sort that string-matched `"READ_WRITE"` (which `SHOP_RW_ACCESS` doesn't contain) to use the proper `hasShopifyWriteAccess` check.
- **`src/store/productStore.ts`** — `SHOPIFY_READ_WRITE_ACCESS_SCOPE_IDS` now contains only `SHOP_RW_ACCESS`, so a remote still on the deprecated scope is offered the one-click "Enable read-write" fix (force-replace to `SHOP_RW_ACCESS`) instead of being accepted.
- **`src/views/ShopifyProductSync.vue`** / **`src/views/ShopifyConnectionDetails.vue`** — correct the user-facing messages (they pointed users to the deprecated `SHOP_READ_WRITE_ACCESS`; one even called `SHOP_RW_ACCESS` deprecated).

## Why
Pairs with the backend canonicalization in hotwax/mantle-shopify-connector#362 (force-replace `SHOP_READ_WRITE_ACCESS` → `SHOP_RW_ACCESS` and drop the deprecated enum). Standalone — contains only the access-scope changes, not the in-flight onboarding work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)