### PR TITLE
fix(onboarding): stabilize product store onboarding startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "serve": "vite",
     "build": "vite build",
     "preview": "vite preview",
+    "typecheck": "vue-tsc -p tsconfig.json --noEmit",
     "lint": "eslint ."
   },
   "dependencies": {

--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="vite/client" />
+
 declare module '*.vue' {
   import { defineComponent } from 'vue'
   const component: ReturnType<typeof defineComponent>

--- a/src/views/CreateProductStore.vue
+++ b/src/views/CreateProductStore.vue
@@ -150,7 +150,7 @@ async function manageConfigurations() {
 
       commonUtil.showToast(translate("Product store created successfully."))
       emitter.emit("dismissLoader");
-      router.replace(`/add-configurations/${productStoreId}`);
+      router.replace(`/product-store-onboarding/${productStoreId}`);
     } else {
       throw resp.data;
     }

--- a/src/views/ProductStoreOnboarding.vue
+++ b/src/views/ProductStoreOnboarding.vue
@@ -2086,8 +2086,7 @@ async function loadSelectedProductStoreSetup() {
     productStoreStore.fetchCurrentStoreSettings(selectedProductStoreId.value),
     productStoreStore.fetchProductStoreFacilities(selectedProductStoreId.value),
     netSuiteStore.fetchProductStoreShipmentMethods({ productStoreId: selectedProductStoreId.value }),
-    refreshShopifyJobStatus(),
-    refreshAccessPackageStatus()
+    refreshShopifyJobStatus()
   ])
 
   if (productStoreStore.current?.productIdentifierEnumId) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,10 +10,9 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,
-    "baseUrl": ".",
     "resolveJsonModule": true,
     "paths": {
-      "@/*": ["src/*"],
+      "@/*": ["./src/*"],
       "@common/*": ["../../common/*"],
       "@common": ["../../common/index.ts"]
     },


### PR DESCRIPTION
## Summary

This PR isolates the startup and typecheck fixes needed before the broader product-store onboarding work can be reviewed safely.

## Business context

The product-store onboarding path needs to be reliable enough for reviewers to load and evaluate the next setup-flow changes without first hitting routing or TypeScript failures.

## Changes

- Fixes the onboarding route handoff from create product store into onboarding
- Adds the Vue shim dependency needed by the current typecheck path
- Tightens TypeScript config/package setup for the onboarding flow

## Review notes

This is the base PR for the follow-up onboarding flow branch.