### PR TITLE
docs: specify Shopify onboarding import and history fixes

### DIFF
--- a/docs/product-store-onboarding-inventory-import-fix.md
+++ b/docs/product-store-onboarding-inventory-import-fix.md
@@ -1,0 +1,96 @@
+# Shopify Inventory (and Order) Bulk-Import Fix — companion to mantle-shopify-connector#356
+
+**Status:** proposal · adversarially verified against source (workflow, 2026-06-17) · no new endpoints
+**Repos:** `mantle-shopify-connector` (primary), `hotwax-shopify-oms-bridge` (context)
+**Relationship to PRs:** complementary to **#356** (`fix/bulk-import-memory-limit`). Neither alone is sufficient.
+
+## TL;DR
+
+The Shopify→OMS inventory-reset bulk import strands silently. The OMS→Shopify half works (a real Shopify bulk op completes with ~13.7k inventory objects); the inbound import never lands. Root cause is **not** a missing result URL or a null `receivePath` (those were first-pass red herrings) — it is that a **download failure is swallowed as a soft error**, which trips Moqui's pre-service error gate and **skips the status transition + consume**, leaving the message stuck and **never retried**.
+
+The fix is two small, generic changes in `mantle-shopify-connector` plus landing #356; it fixes both inventory reset and (separately) the product-update bulk flow, and leaves order history untouched.
+
+## Validation (live, 2026-06-17)
+
+Confirmed end-to-end on an isolated JUNE-15 instance (cloned `notnaked` DB, hc-sandbox shop) **with #356 applied and driving the correct new-path poller** (`poll_ShopifyBulkOperationResult`, **not** the legacy `poll_BulkOperationResult_ShopifyBulkQuery`):
+
+- Shopify bulk inventory query → COMPLETED, **13,726 objects / 3.5 MB JSONL**
+- `process#ShopifyBulkOperationResult` downloaded to `receiveMovePath/{id}.jsonl` → message `SmsgReceived → SmsgConsumed`
+- DataManagerLog `RESET_SHOPIFY_INVENTORY` → **DmlsFinished, 2,572 records (129 failed)**
+- **`external_inventory_reset`: 9,560 → 19,239 (+9,679)** and **`inventory_item_detail`: 12,659 → 22,338 (+9,679)** — real per-facility/per-product reset rows (YONKERS, WEST_VALLEY_CITY, TIMES_SQUARE, …) with Shopify on-hand values
+- Outbound echo correctly self-suppressed (resets skipped while `SHOPIFY_INV_SYNC ≠ Y`)
+
+**Takeaway:** the *happy path* works once #356 makes the large-file download succeed **and** the correct (new-path) poller is used. The PRIMARY code change below is therefore **robustness hardening** — it ensures a *failed* download (e.g., expired URL) becomes a bounded, retryable `SmsgError` instead of a silently-stranded message — rather than being strictly required for the success path. Both should land for a reliable cold start.
+
+## Pipeline (new path — what inventory reset uses)
+
+`sync#ShopifyInventoryReset` → produces a `BulkQueryShopifyInventoryReset` SystemMessage (parent `ShopifyBulkQuery`) → `send#…` sends the bulk query to Shopify → **`poll_ShopifyBulkOperationResult` → `process#ShopifyBulkOperationResult`** fetches the fresh result URL (`statusResponse.response.url`) and downloads the JSONL to `receiveMovePath/{systemMessageId}.jsonl` → transitions the message to `SmsgReceived` → `consume#ReceivedSystemMessage` → bridge `consume#ShopifyInventoryResetDataFile` reads that file → `upload#DataManagerFile` (RESET_SHOPIFY_INVENTORY) → `import#ShopifyInventoryReset` → poorti `reset#ProductFacilityInventory` → `ExternalInventoryReset` rows.
+
+This type intentionally has `receiveMovePath` set and **no** `receivePath`; the new poller does not use `receivePath` or `messageText`.
+
+## Root cause (RC#3, adversarially verified)
+
+In `service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml`, `process#ShopifyBulkOperationResult` (~lines 436–464) does the result-file **download before** the `SmsgReceived` transition. The download service `store#BulkOperationResultFile` (`service/co/hotwax/shopify/graphQL/ShopifyBulkImportServices.xml:172–175`) reports failure as a **soft error**:
+
+```groovy
+} catch (Exception e) {
+    ec.message.addError("Failed to download bulk operation result file ... ${downloadUrl}, Error: ${e.getMessage()}")
+    return
+}
+```
+
+Once an error is pending in the message facade, Moqui's `ServiceCallSyncImpl.callSingle` (ServiceCallSyncImpl.java:135–136) **skips every subsequent service-call** — so the `update#SystemMessage → SmsgReceived` and the `consume#ReceivedSystemMessage` are **both skipped**. The message is stranded (at `SmsgSent`/`SmsgConfirmed`), **no `SystemMessageError` is written**, `failCount` is never incremented, and the normal retry job (`consume_AllReceivedSystemMessages_frequent`, which only acts on `SmsgReceived`) never sees it. Re-running the poll just re-downloads and fails the same way.
+
+- **Why Jun-13 worked / now fails:** the download used to succeed; once the full-catalog (13,726-object) result file started failing to download (the OOM/streaming problem **#356** fixes), the swallowed error path began stranding the message.
+- **Regression boundary:** connector commit `79c4ec3` (May 5) moved the unchecked download to just before the `SmsgReceived` transition.
+- **Symptom correction:** the “consume NPE on `InputStreamReader`” seen when poking the *legacy* poller is a side-symptom; `ShopifyHelper.transformShopifyJsonl` guards null refs, and on the **new** path the consume reader is never reached — the real user-visible symptom is a stranded message.
+
+## The fix (no new endpoints)
+
+### PRIMARY — make a failed download retryable instead of silently skipped
+`mantle-shopify-connector/service/co/hotwax/shopify/system/ShopifySystemMessageServices.xml`, in `process#ShopifyBulkOperationResult` (~436–464), reorder + guard:
+
+1. On `completed`, **first** `update#SystemMessage` → `statusId: SmsgReceived`, `isOutgoing: 'N'`, `transaction: force-new` (so the status commits before consume).
+2. **Then** download to `receiveMovePath/{systemMessageId}.jsonl`.
+3. **Then** check `ec.message.hasError()`:
+   - if **true**: capture errors, `ec.message.clearErrors()`, `create#SystemMessageError` (`attemptedStatusId: SmsgConsumed`, errorText), and `return` — leaving the message at `SmsgReceived` so `consume_AllReceivedSystemMessages_frequent` retries it and escalates to `SmsgError` after `retryLimit`.
+   - if **false**: call `consume#ReceivedSystemMessage` (unchanged happy path).
+4. Keep the no-`downloadUrl` branch (warn + `SmsgConsumed`).
+
+Net: the `SmsgReceived` transition can no longer be skipped by the poisoned facade, and a transient download failure becomes **bounded, visible, retryable** (`SmsgReceived → SmsgError` after N tries) instead of an infinite silent loop. This is the inverse of the regressing commit `79c4ec3`.
+
+### DEFENSE-IN-DEPTH (gated on PRIMARY + coordinated with #356)
+`mantle-shopify-connector/service/co/hotwax/shopify/graphQL/ShopifyBulkImportServices.xml:172–175` — make `store#BulkOperationResultFile` **throw** instead of `addError`+return:
+
+```groovy
+} catch (Exception e) {
+    throw new org.moqui.BaseException("Failed to download bulk operation result file from Shopify at URL: ${downloadUrl}", e)
+}
+```
+All callers run under a `consume`/try wrapper, so a throw becomes a clean retryable failure. **#356 rewrites this exact service to streaming `copyURLToFile`** — coordinate so the merged version still **surfaces** failure (throw/addError) and never writes a truncated/empty file.
+
+### OPERATIONAL precondition (deployment, not code)
+Ensure the **new** poller `poll_ShopifyBulkOperationResult` is the active one for the `ShopifyBulkQuery` inventory-reset/product-update family, and the **legacy** `poll_BulkOperationResult_ShopifyBulkQuery` stays the poller for order-history/metafield/product-tag legacy types. Both jobs select `limit=1` `SmsgSent` under `parentTypeId=ShopifyBulkQuery`, so **only one may be un-paused per family** (otherwise it's a race). Seed pause-state does not auto-correct live `ServiceJob` rows — confirm on the running instance.
+
+## Rejected alternatives (verified harmful / no-op)
+
+- **Repoint `poll_BulkOperationResult_ShopifyBulkQuery` → `poll#ShopifyBulkOperationResult`** — *harmful.* That legacy job is the sole poller for `BulkOrderHistoryQuery` and all legacy `ShopifyBulkQuery` children (metafields, product/order bulk), which use `receivePath` + `messageText` semantics and have no `receiveMovePath`. Repointing breaks order-history and product/metafield import.
+- **Add `receivePath` to the `BulkQueryShopifyInventoryReset` seed** — *no-op.* `receivePath` is only read by the legacy `consume#BulkOperationResult`, which is not this type's consume service; under the new poller it's ignored.
+
+## Regression analysis
+
+- **Happy path / Jun-13:** safe — a successful download still flows `SmsgReceived → consume → SmsgConsumed`.
+- **Product-update bulk (`BulkQueryShopifyProductUpdates`):** safe and improved — same new path, benefits identically.
+- **Order-history (`BulkOrderHistoryQuery`):** safe — on the untouched legacy path. (It carries the *same class* of latent defect in `process#BulkOperationResult` — terminal `SmsgConfirmed` before download — worth a **follow-up**, out of scope here.)
+- **Echo-suppression / `SHOPIFY_INV_SYNC` ordering:** safe — orthogonal (outbound SECA path), untouched.
+
+## Residual risk
+
+1. **Necessary, not sufficient alone** — this + #356 are complementary: #356 makes the large-file download *succeed*; this makes failures *retryable/visible* instead of silently stranding. Land both.
+2. **Shopify result URLs are time-limited** — bounded retries may escalate to `SmsgError` if a URL expires mid-retry (acceptable + visible; `failCount` now lives on the consume side).
+3. **Dual-poller race** — enforce exactly one active `ShopifyBulkQuery` poller per family.
+4. **Order-history latent defect** — recommended follow-up.
+
+## Recommendation
+
+File this as a companion PR to **#356** against `mantle-shopify-connector` (PRIMARY + the coordinated `store#BulkOperationResultFile` change), with the operational note about which poller to un-pause. No bridge code or new endpoints required.

--- a/docs/product-store-onboarding-order-history-newpath-migration.md
+++ b/docs/product-store-onboarding-order-history-newpath-migration.md
@@ -1,0 +1,88 @@
+# Migrate Shopify order-history to the new-path bulk processors + deprecate the legacy poller
+
+**Status:** spec · adversarially verified against source (workflow, 2026-06-17) · no new endpoints, no connector code change
+**Repos:** `hotwax-shopify-oms-bridge` (new reader + seed), `mantle-shopify-connector` (deprecation marking only)
+**Confidence:** the target processors (`poll_ShopifyBulkOperationResult` → `process#ShopifyBulkOperationResult` → `consume#ReceivedSystemMessage` → the type's reader) are **already proven end-to-end** for inventory reset (live: 13,726 Shopify objects → +9,679 OMS reset rows) and product updates. Order history is the same shape; the only new code is a near-verbatim port of the proven reader.
+
+## Goal & two corrections
+
+**Goal:** order-history sync should run on the *same* bulk processors as product/inventory sync, not the legacy two-hop consumption jobs.
+
+**Correction 1 — the "fallback order job" is out of scope.** `queue_ShopifyOrderSync → ShopifyOrderSync` (`SOBServiceJobData.xml:130-138`) is **not** a Shopify bulk-operation query: it has no `parentTypeId`, does synchronous live GraphQL orders-connection pagination + SQS staging entirely inside `OrderFeedServices.send#ShopifyOrderSync`, produces no bulk-operation id, and is never polled. It is an ongoing **delta** sync, architecturally distinct from the bulk pipeline; it cannot "ride the bulk poller" without being rewritten as a bulk query. **Leave it unchanged.** Putting order *data* on the new bulk processor = the `BulkOrderHistoryQuery` migration below.
+
+**Correction 2 — don't fully delete the legacy poller.** Besides order history, ~10 other `ShopifyBulkQuery` child types still use the legacy poller + `consume#BulkOperationResult` (BulkVariantsMetafieldQuery, BulkOrderMetafieldsQuery, BulkOrderHeadersQuery, BulkOrderItemsQuery, BulkOrderCustomAttributesQuery, BulkOrderDiscountCodeApplQuery, BulkCanceledOrderItemsQuery, BulkFulfillmentOrderQuery, BulkProductMetaFieldByTagsQuery, + hybrid BulkProductAndVariantsByIdQuery). They define `receivePath` (not `receiveMovePath`) and the new processor requires `receiveMovePath` — so **deprecate by pausing the job, not deleting/renaming services.** Paused legacy types simply wait at `SmsgSent` until migrated or resumed (safe).
+
+## The migration — 4 changes (ordered)
+
+### 1. Deprecate the legacy poller (kills the dual-poller race) — *connector*
+Both `poll_ShopifyBulkOperationResult` and `poll_BulkOperationResult_ShopifyBulkQuery` select `SystemMessageAndType WHERE statusId=SmsgSent AND parentTypeId=ShopifyBulkQuery LIMIT 1` over the same pool — whichever fires first wins. Keep the legacy job **paused** (`data/ShopifyServiceJobData.xml:114`, already `paused="Y"` in seed; verify the live `ServiceJob` row isn't resumed) and mark its description `DEPRECATED…` (exact edit below). Do **not** delete/rename `process#BulkOperationResult` or the shared `store#BulkOperationResultFile` (also used by the new path + modified by PR #356).
+
+```xml
+<!-- DEPRECATED legacy ShopifyBulkQuery poller; superseded by poll_ShopifyBulkOperationResult; keep paused to avoid
+     the dual-poller race; do NOT delete (~10 legacy ShopifyBulkQuery child types still use it until migrated). -->
+<moqui.service.job.ServiceJob jobName="poll_BulkOperationResult_ShopifyBulkQuery" ... paused="Y"
+        description="DEPRECATED legacy ShopifyBulkQuery poller; superseded by poll_ShopifyBulkOperationResult; paused to avoid dual-poller race">
+```
+
+### 2. Unpause the new poller — *connector / live row*
+Set `poll_ShopifyBulkOperationResult` (`data/ShopifyServiceJobData.xml:369`) `paused="N"`. With the legacy poller paused it becomes the sole consumer of the `ShopifyBulkQuery` pool. (Seed change + correct the live `ServiceJob` row, since seed doesn't auto-update provisioned rows.)
+
+### 3. Add a new-path reader `consume#BulkOrderHistoryDataFile` — *bridge*
+`shopify-oms-bridge/service/co/hotwax/sob/order/ShopifyOrderSyncHistoryServices.xml` — single-hop reader that sources the file from `receiveMovePath/{systemMessageId}.jsonl` (the new processor already downloaded it there) and reuses the existing JSONL Order/LineItem streaming + `BULK_ORDER_HISTORY` MDM upload body **verbatim**. Replaces the two-hop `store#BulkOrderHistoryResult` + `consume#BulkOrderHistoryResult`:
+
+```xml
+<service verb="consume" noun="BulkOrderHistoryDataFile" authenticate="anonymous-all" transaction-timeout="3600">
+    <description>New-path reader for BulkOrderHistoryQuery. The bulk processor (process#ShopifyBulkOperationResult)
+        has already downloaded the JSONL to receiveMovePath/{systemMessageId}.jsonl; stream it, accumulate orders,
+        and upload to the BULK_ORDER_HISTORY DataManager config. Mirrors consume#ShopifyInventoryResetDataFile.</description>
+    <implements service="org.moqui.impl.SystemMessageServices.consume#SystemMessage"/>
+    <actions>
+        <entity-find-one entity-name="moqui.service.message.SystemMessage" value-field="systemMessage"/>
+        <entity-find-related-one value-field="systemMessage" relationship-name="type" to-value-field="systemMessageType"/>
+        <entity-find-one entity-name="moqui.service.message.SystemMessageRemote" value-field="systemMessageRemote">
+            <field-map field-name="systemMessageRemoteId" from="systemMessage.systemMessageRemoteId"/>
+        </entity-find-one>
+        <set field="shopId" from="systemMessageRemote?.internalId"/>
+        <if condition="!shopId"><return error="true" message="shopId (internalId) not configured on SystemMessageRemote [${systemMessage.systemMessageRemoteId}]"/></if>
+        <entity-find-one entity-name="co.hotwax.shopify.ShopifyShop" value-field="shopifyShop" cache="true">
+            <field-map field-name="shopId" from="shopId"/>
+        </entity-find-one>
+        <set field="productStoreId" from="shopifyShop?.productStoreId"/>
+        <entity-find-one entity-name="org.apache.ofbiz.common.property.SystemProperty" value-field="launchDateProperty" cache="false">
+            <field-map field-name="systemResourceId" from="shopId"/>
+            <field-map field-name="systemPropertyId" value="newOrderSync.launchDate"/>
+        </entity-find-one>
+        <set field="newOrderSyncLaunchDate" from="launchDateProperty?.systemPropertyValue"/>
+        <!-- NEW PATH: file already downloaded by process#ShopifyBulkOperationResult -->
+        <set field="receiveMovePath" from="ec.resource.expand(systemMessageType.receiveMovePath, null)"/>
+        <if condition="!receiveMovePath.endsWith('/')"><set field="receiveMovePath" from="receiveMovePath + '/'"/></if>
+        <set field="fileLocation" from="receiveMovePath + systemMessage.systemMessageId + '.jsonl'"/>
+        <!-- BODY: identical to the current consume#BulkOrderHistoryResult lines 191-269 (JSONL stream -> Order/LineItem
+             accumulation by GID objectType -> jGenerator JSON array -> upload#DataManagerFile configId=BULK_ORDER_HISTORY). -->
+        <script><![CDATA[ /* port verbatim from consume#BulkOrderHistoryResult */ ]]></script>
+        <if condition="orderCount > 0">
+            <service-call name="co.hotwax.util.UtilityServices.upload#DataManagerFile"
+                          in-map="[configId:'BULK_ORDER_HISTORY', contentFile:fileItem, parameters:[shopId:shopId, productStoreId:productStoreId, newOrderSyncLaunchDate:newOrderSyncLaunchDate].entrySet().toList()]"/>
+        </if>
+    </actions>
+</service>
+```
+Keep the legacy `store#`/`consume#BulkOrderHistoryResult` services in place (other tooling may reference them) but they're no longer wired for order history.
+
+### 4. Repoint the `BulkOrderHistoryQuery` seed — *bridge*
+`shopify-oms-bridge/data/SOBOrderSyncData.xml:16-22`:
+- **ADD** `receiveMovePath="runtime://datamanager/shopify/BulkOrderHistory"`
+- **DROP** `receivePath="…"`
+- **REPOINT** `consumeServiceName` → `co.hotwax.sob.order.ShopifyOrderSyncHistoryServices.consume#BulkOrderHistoryDataFile`
+- **KEEP** `sendServiceName="…send#BulkQuerySystemMessage"` — ⚠️ do **not** swap to `send#ShopifyBulkQueryMessage`: this type's `messageText` is a `{fromDate, thruDate}` map (not a resolved GraphQL query), so the swap would send the map verbatim to Shopify and the bulk op would fail.
+
+Resulting flow (identical shape to the proven inventory/product flows):
+`sync#ShopifyOrderHistory` → `send#BulkQuerySystemMessage` → Shopify bulk op → `process#ShopifyBulkOperationResult` (download to `receiveMovePath/{id}.jsonl`, `SmsgReceived`) → `consume#ReceivedSystemMessage` → `consume#BulkOrderHistoryDataFile` → `create#ShopifyOrderSyncHistory`.
+
+## Blockers / dependencies (not introduced by this migration)
+
+- **Config gap (must resolve to flow end-to-end):** `sync_ShopifyOrderHistory` (`SOBOrderSyncData.xml:50-57`) ships with an empty but **required** `systemMessageRemoteId`. Order history will not run until the job has `systemMessageRemoteId` set, the `SystemMessageRemote.internalId` (shopId) is valid, and an `orderSyncHistory.lastSyncDate` cursor / `newOrderSync.launchDate` exists.
+- **Retryability** (shared with inventory/product): `process#ShopifyBulkOperationResult` leaves a *failed* consume at `SmsgReceived`, which the `SmsgSent`-only poller won't re-drive — so apply the same hardening proposed in `product-store-onboarding-inventory-import-fix.md` (transition→guard→`SystemMessageError`) and land **PR #356**. Necessary for reliability, complementary to this migration.
+
+## Net
+Order history moves onto the proven bulk processors with **one ported reader + one seed edit**, the legacy poller is safely paused (not deleted), the other 10 legacy types are untouched (defer their migration), and the non-bulk fallback delta-sync is left alone. No new endpoints, no connector code change.


### PR DESCRIPTION
## Summary

This PR isolates the written specs for Shopify onboarding fixes so the implementation work can be reviewed separately.

## Business context

The onboarding work includes product decisions around inventory import behavior and order-history migration paths. Keeping those specs separate gives reviewers a clean place to validate scope before or alongside code review.

## Changes

- Documents the Shopify inventory import fix for product-store onboarding
- Documents the order-history new-path migration plan

## Review notes

No runtime app changes are included in this PR.