### PR TITLE
Fix: remove secret key check from unigate tenant readiness validation

### DIFF
--- a/src/utils/carrierReadiness.ts
+++ b/src/utils/carrierReadiness.ts
@@ -21,7 +21,6 @@ export function hasCompleteUnigateConfig(config: any): boolean {
   return Boolean(
     String(config?.internalId || "").trim()
       && String(config?.sendUrl || "").trim()
-      && String(config?.publicKey || config?.password || "").trim()
   );
 }
 


### PR DESCRIPTION
### Related Issues
Ref #248 

### Summary
This PR updates the client-side validation logic for the Unigate Tenant configuration to align with backend security constraints.

### Details & Rationale
The `hasCompleteUnigateConfig` validation function previously required the presence of either `publicKey` or `password` in the configuration payload to mark the tenant as ready. 

However, since credentials and API keys are sensitive, write-only values, the Moqui backend REST API intentionally filters them out and does not return them in the GET response for `systemMessageRemotes`. This design mismatch caused the UI status to remain stuck in the **"Action needed"** state, even after credentials had been successfully saved.

This change relaxes the client-side check to validate only the `internalId` (Tenant ID) and `sendUrl`. 

### Impact
* Resolves the Unigate Tenant status UI issue.
* Unigate Tenant status now transitions correctly to **"Ready"** when configured.
