### PR TITLE
Fix migration artifact check referencing stray PROD_STORE_PRODUCTS_COUNT

### DIFF
--- a/src/store/shopifyProductSyncMigration.ts
+++ b/src/store/shopifyProductSyncMigration.ts
@@ -946,9 +946,9 @@ async function fetchAssistantState(
     { id: PRODUCT_SYNC_MIGRATION_CONFIG.incoming.serviceJobs.poll, type: "job", label: "Poll bulk operation results job", note: "Shared poller for completed Shopify bulk query results." },
     { id: PRODUCT_SYNC_MIGRATION_CONFIG.incoming.systemMessageTypes.productSync, type: "systemMessageType", label: "New product sync message type", note: "Required message type for the bulk-query product sync flow." },
     { id: PRODUCT_SYNC_MIGRATION_CONFIG.incoming.dataManagerConfig, type: "dataManagerConfig", label: "Data manager config", note: "Required config for processing imported Shopify product sync files." },
-    { id: "SERVICE_JOB_PARAMETER", type: "dataDocument", label: "Service job parameters document", note: "Required for verifying per-shop sync job configuration via Data Document." },
-    { id: "DATA_MANAGER_LOG_AND_PARAMETER", type: "dataDocument", label: "Data manager logs document", note: "Required for tracking sync progress and error counts via Data Document." },
-    { id: "PROD_STORE_PRODUCTS_COUNT", type: "dataDocument", label: "Product store counts document", note: "Required for preflight checks and catalog metrics via Data Document." }
+    { id: PRODUCT_SYNC_MIGRATION_CONFIG.incoming.dataDocuments[0], type: "dataDocument", label: "Service job parameters document", note: "Required for verifying per-shop sync job configuration via Data Document." },
+    { id: PRODUCT_SYNC_MIGRATION_CONFIG.incoming.dataDocuments[1], type: "dataDocument", label: "Data manager logs document", note: "Required for tracking sync progress and error counts via Data Document." },
+    { id: PRODUCT_SYNC_MIGRATION_CONFIG.incoming.dataDocuments[2], type: "dataDocument", label: "Product store counts document", note: "Required for preflight checks and catalog metrics via Data Document." }
   ];
 
   state.artifactChecks = artifactCheckDefinitions.map(def => ({ id: def.id, label: def.label, note: def.note, status: "checking" }));


### PR DESCRIPTION
## Summary
- The upgrade-assistant's product-count data document check hardcoded the old `PROD_STORE_PRODUCTS_COUNT` id instead of the shared config's `PRODUCT_STORE_PRODUCT`, left over from a merge conflict resolution.
- All three data-document checks in `fetchAssistantState` now read from `PRODUCT_SYNC_MIGRATION_CONFIG.incoming.dataDocuments`, matching what `fetchReviewStats` actually queries at runtime, so this list can't drift from the config again.

## Test plan
- [ ] `npx vue-tsc --noEmit` passes (verified locally, no errors on this file)
- [ ] Run the upgrade assistant against a tenant on release v5.1.0+ and confirm the "Product store counts document" check reports "verified"