### PR TITLE
Show 25 users per page

### DIFF
--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -43,10 +43,7 @@ export const useUserStore = defineStore("user", {
     getRedirectedFromUrl: (state): string => state.redirectedFrom,
     getUsers: (state): any[] => state.users.list,
     isScrollable: (state): boolean => {
-      return (
-        state.users.list?.length > 0 &&
-        (state.users.list?.length % Number(import.meta.env.VITE_VIEW_SIZE) === 0)
-      )
+      return state.users.list?.length > 0 && state.users.list.length < state.users.total
     },
     hasPermission: (state) => (permissionId: string): boolean => {
       const checkPermission = (id: string): boolean => {

--- a/src/views/Users.vue
+++ b/src/views/Users.vue
@@ -148,6 +148,7 @@ import { useUtilStore } from "@/store/util";
 
 const userStore = useUserStore();
 const utilStore = useUtilStore();
+const USERS_PAGE_SIZE = 25;
 
 // The logged-in user's own record, pinned at the top of the list. The profile is already available from
 // login, but it doesn't carry group associations, so those are fetched separately via getUserGroups().
@@ -188,7 +189,7 @@ const updateQuery = async () => {
 };
 
 const fetchUsers = async (pSize?: any, pIndex?: any) => {
-  const pageSize = pSize || import.meta.env.VITE_VIEW_SIZE;
+  const pageSize = pSize || USERS_PAGE_SIZE;
   const pageIndex = pIndex || 0;
 
   if(!userStore.query.queryString) {
@@ -215,7 +216,7 @@ const viewUserDetails = async (user: any) => {
 const loadMoreUsers = (event: any) => {
   fetchUsers(
     undefined,
-    Math.ceil(users.value?.length / (import.meta.env.VITE_VIEW_SIZE as any)).toString()
+    Math.ceil(users.value?.length / USERS_PAGE_SIZE).toString()
   ).then(async () => {
     await event.target.complete();
   });


### PR DESCRIPTION
## Summary

- request 25 users per batch on the Users page
- calculate subsequent page indexes from the same page-specific size
- keep infinite scrolling active while the loaded count is below the Solr total

## Validation

- `pnpm --filter company build` — passed
- AccxUI staged UI-diff checker — passed
- `git diff --check` — passed
- focused ESLint — blocked by pre-existing alias-resolution and unrelated style errors in the touched files; no reported error is on a changed line
- workspace typecheck — blocked by pre-existing unrelated TypeScript errors; no reported error is in the changed code