### PR TITLE
Persist app permission selection and remove Shopify BOPIS

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -140,6 +140,7 @@ const userPages = [
   {
     title: "App Permissions",
     url: "/app-permissions",
+    childRoutes: ["/app-permissions/"],
     permission: "APP_PERMISSION_VIEW OR APP_PERMISSION_CREATE OR APP_PERMISSION_UPDATE OR SECURITY_ADMIN",
     iosIcon: shieldCheckmarkOutline,
     mdIcon: shieldCheckmarkOutline,

--- a/src/config/appPermissions.ts
+++ b/src/config/appPermissions.ts
@@ -140,7 +140,6 @@ export const appPermissionCatalogs: readonly AppPermissionCatalog[] = [
     permissionIds: ["APP_SHPGRP_CNCL", "APP_SHPGRP_DLVRADR_UPDATE", "APP_SHPGRP_DLVRMTHD_UPDATE", "APP_SHPGRP_PCKUP_UPDATE"]
   },
   { appId: "returns", appName: "Returns", permissionIds: [] },
-  { appId: "shopify-bopis", appName: "Shopify BOPIS", permissionIds: [] },
   {
     appId: "transfers",
     appName: "Transfers",

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -52,7 +52,7 @@ const routes: Array<RouteRecordRaw> = [
   { path: "/", redirect: "/product-store" },
   { path: "/product-store", name: "ProductStore", component: ProductStore, beforeEnter: authGuard },
   { path: "/users", name: "Users", component: Users, beforeEnter: requirePermission("USERS_LIST_VIEW OR PARTYMGR_VIEW OR PARTYMGR_ADMIN") },
-  { path: "/app-permissions", name: "AppPermissions", component: AppPermissions, beforeEnter: requirePermission("APP_PERMISSION_VIEW OR APP_PERMISSION_CREATE OR APP_PERMISSION_UPDATE OR SECURITY_ADMIN") },
+  { path: "/app-permissions/:appId?", name: "AppPermissions", component: AppPermissions, beforeEnter: requirePermission("APP_PERMISSION_VIEW OR APP_PERMISSION_CREATE OR APP_PERMISSION_UPDATE OR SECURITY_ADMIN") },
   { path: "/security-groups", name: "SecurityGroups", component: SecurityGroups, beforeEnter: requirePermission("SECURITY_VIEW OR SECURITY_ADMIN") },
   { path: "/security-group-detail/:userGroupId", name: "SecurityGroupDetail", component: SecurityGroupDetail, props: true, beforeEnter: requirePermission("SECURITY_VIEW OR SECURITY_ADMIN") },
   { path: "/user-details/:partyId", name: "UserDetails", component: UserDetails, props: true, beforeEnter: requirePermission("USERS_LIST_VIEW OR PARTYMGR_VIEW OR PARTYMGR_ADMIN") },

--- a/src/views/AppPermissions.vue
+++ b/src/views/AppPermissions.vue
@@ -68,7 +68,8 @@
 import { commonUtil, logger, translate } from "@common"
 import { IonButton, IonContent, IonHeader, IonIcon, IonItem, IonLabel, IonList, IonMenuButton, IonNote, IonPage, IonSearchbar, IonSpinner, IonTitle, IonToolbar, modalController } from "@ionic/vue"
 import { shieldCheckmarkOutline } from "ionicons/icons"
-import { computed, onMounted, ref } from "vue"
+import { computed, ref, watch } from "vue"
+import { useRoute, useRouter } from "vue-router"
 import AppPermissionCard from "@/components/AppPermissionCard.vue"
 import AppPermissionGroupModal from "@/components/AppPermissionGroupModal.vue"
 import AppPermissionHistoryModal from "@/components/AppPermissionHistoryModal.vue"
@@ -80,10 +81,21 @@ import { useUserStore } from "@/store/user"
 
 const appPermissionsStore = useAppPermissionsStore()
 const userStore = useUserStore()
+const route = useRoute()
+const router = useRouter()
 const loading = ref(false)
 const loadError = ref(false)
 const query = ref("")
-const selectedAppId = ref<string>(appPermissionCatalogs[0]?.appId || "")
+
+const getAppId = (appId: unknown) => {
+  const requestedAppId = Array.isArray(appId) ? appId[0] : appId
+
+  return typeof requestedAppId === "string" && appPermissionCatalogs.some((app) => app.appId === requestedAppId)
+    ? requestedAppId
+    : appPermissionCatalogs[0]?.appId || ""
+}
+
+const selectedAppId = ref<string>(getAppId(route.params.appId))
 
 const canCreate = computed(() => userStore.hasPermission("APP_PERMISSION_CREATE OR SECURITY_ADMIN"))
 const canUpdate = computed(() => userStore.hasPermission("APP_PERMISSION_UPDATE OR SECURITY_ADMIN"))
@@ -139,11 +151,13 @@ const loadSelectedApp = async () => {
   }
 }
 
-onMounted(loadSelectedApp)
+watch(() => route.params.appId, async (appId) => {
+  selectedAppId.value = getAppId(appId)
+  await loadSelectedApp()
+}, { immediate: true })
 
 const selectApp = async (appId: string) => {
-  selectedAppId.value = appId
-  await loadSelectedApp()
+  await router.push({ name: "AppPermissions", params: { appId } })
 }
 
 const openHistory = async (permission: AppPermissionDefinition) => {


### PR DESCRIPTION
## Summary

- add an optional app ID parameter to the App Permissions route
- push the selected app ID into the URL when an app is selected
- restore and load the selected app from the route on initial load, reload, and browser navigation
- fall back to the first configured app when the URL does not contain a valid catalog ID
- remove Shopify BOPIS from the App Permissions catalog

## User impact

App Permission URLs can be bookmarked or reloaded without losing the selected application, and the intentionally unsupported Shopify BOPIS entry no longer appears in the application list.

## Validation

- `pnpm --filter company build` — passed
- AccxUI staged UI-diff checker — passed
- `git diff --check` — passed
- workspace typecheck — blocked by pre-existing unrelated TypeScript errors; no reported error is in the touched route/view code
- focused ESLint — blocked by pre-existing alias-resolution/import-order errors; no reported error is on a changed line
- live browser validation was not run because the isolated candidate worktree was not activated over the user's currently served dirty checkout