### PR TITLE
Rename user filter labels

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1065,6 +1065,7 @@
   "Search users": "Search users",
   "Security group history": "Security group history",
   "Security Groups": "Security Groups",
+  "Security groups": "Security groups",
   "Security groups with access": "Security groups with access",
   "Select security groups": "Select security groups",
   "Some permission assignments were updated, but others failed. The latest state has been reloaded.": "Some permission assignments were updated, but others failed. The latest state has been reloaded.",

--- a/src/views/Users.vue
+++ b/src/views/Users.vue
@@ -14,7 +14,7 @@
           <div class="filter-row">
             <ion-select
               v-model="userStore.query.userGroupId"
-              :label="translate('Clearance')"
+              :label="translate('Security groups')"
               label-placement="stacked"
               fill="outline"
               interface="popover"
@@ -29,7 +29,7 @@
             </ion-select>
             <ion-select
               v-model="userStore.query.status"
-              :label="translate('Login')"
+              :label="translate('Status')"
               label-placement="stacked"
               fill="outline"
               interface="popover"


### PR DESCRIPTION
## Summary
- rename the Users security-group filter from `Clearance` to `Security groups`
- rename the login-status filter from `Login` to `Status`
- preserve the existing filter query behavior

## Validation
- `pnpm --filter company build` (passes)
- AccxUI UI diff checker (passes)
- `git diff --check` (passes)
- focused ESLint reaches only the existing workspace alias-resolution errors for `@common` and `@/`; no change-specific lint error

## Browser validation
- baseline labels were confirmed on the existing localhost Users page
- the isolated PR worktree was not activated on the shared dev port, so the candidate UI was not served over the active checkout