### PR TITLE
Surface Quick Setup server errors

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -41,8 +41,24 @@ const getResponseErrorMessage = (error: any, defaultMessage: string) => {
     return responseData._ERROR_MESSAGE_;
   }
 
+  if(typeof responseData?.error?.message === "string" && responseData.error.message.trim()) {
+    return responseData.error.message;
+  }
+
+  if(typeof responseData?.errorMessage === "string" && responseData.errorMessage.trim()) {
+    return responseData.errorMessage;
+  }
+
+  if(typeof responseData?.error === "string" && responseData.error.trim()) {
+    return responseData.error;
+  }
+
   if (typeof responseData?.message === "string" && responseData.message.trim()) {
     return responseData.message;
+  }
+
+  if(typeof error?.errorMessage === "string" && error.errorMessage.trim()) {
+    return error.errorMessage;
   }
 
   if (typeof error?.message === "string" && error.message.trim()) {

--- a/src/views/UserQuickSetup.vue
+++ b/src/views/UserQuickSetup.vue
@@ -111,6 +111,7 @@ import { addCircleOutline, arrowForwardOutline, documentTextOutline, eyeOffOutli
 import { commonUtil, translate, logger } from "@common";
 import SelectFacilityModal from "@/components/SelectFacilityModal.vue";
 import SelectProductStoreModal from "@/components/SelectProductStoreModal.vue";
+import { getResponseErrorMessage } from "@/utils";
 
 const props = defineProps({
   partyId: {
@@ -323,7 +324,7 @@ const finishSetup = async () => {
     }
   } catch (err: any) {
     logger.error("error", err);
-    commonUtil.showToast(err.errorMessage ? err.errorMessage : translate("Failed to quick setup user."));
+    commonUtil.showToast(getResponseErrorMessage(err, translate("Failed to quick setup user.")));
   }
 };
 
@@ -403,9 +404,9 @@ const finishAndCreateNewUser = async () => {
     });
     await userStore.clearSelectedUser();
     await router.replace({ path: "/create-user" });
-  } catch (err) {
+  } catch (err: any) {
     logger.error("error", err);
-    commonUtil.showToast(translate("Failed to quick setup user."));
+    commonUtil.showToast(getResponseErrorMessage(err, translate("Failed to quick setup user.")));
   }
 };
 


### PR DESCRIPTION
## Summary
- surface backend error messages when Quick Setup fails instead of always showing the generic fallback
- apply the same behavior to both **Finish setup** and **Finish and create new user**
- extend the shared response-error extractor to support nested `error.message`, `errorMessage`, and string `error` response shapes

## Root cause
The Quick Setup catch handlers did not consistently inspect Axios response bodies. In particular, server messages returned as `response.data.error.message` were discarded, leaving users with `Failed to quick setup user.` and no actionable explanation.

## User impact
Validation errors such as an already-taken username can now be shown in the toast returned to the user. The generic translated fallback remains when the server does not provide a usable message.

## Validation
- `pnpm --filter company build` (passes)
- AccxUI staged UI diff checker (passes)
- `git diff --check` (passes)
- full typecheck remains blocked by existing unrelated Company TypeScript errors
- focused ESLint remains blocked by the existing file-level lint baseline and workspace alias-resolution errors

## Browser validation
The isolated PR worktree was not activated on the shared Company dev port, so candidate behavior was not claimed as live-browser verified.