### PR TITLE
Keep App Permissions selection within one route

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -140,7 +140,6 @@ const userPages = [
   {
     title: "App Permissions",
     url: "/app-permissions",
-    childRoutes: ["/app-permissions/"],
     permission: "APP_PERMISSION_VIEW OR APP_PERMISSION_CREATE OR APP_PERMISSION_UPDATE OR SECURITY_ADMIN",
     iosIcon: shieldCheckmarkOutline,
     mdIcon: shieldCheckmarkOutline,

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -52,7 +52,7 @@ const routes: Array<RouteRecordRaw> = [
   { path: "/", redirect: "/product-store" },
   { path: "/product-store", name: "ProductStore", component: ProductStore, beforeEnter: authGuard },
   { path: "/users", name: "Users", component: Users, beforeEnter: requirePermission("USERS_LIST_VIEW OR PARTYMGR_VIEW OR PARTYMGR_ADMIN") },
-  { path: "/app-permissions/:appId?", name: "AppPermissions", component: AppPermissions, beforeEnter: requirePermission("APP_PERMISSION_VIEW OR APP_PERMISSION_CREATE OR APP_PERMISSION_UPDATE OR SECURITY_ADMIN") },
+  { path: "/app-permissions", name: "AppPermissions", component: AppPermissions, beforeEnter: requirePermission("APP_PERMISSION_VIEW OR APP_PERMISSION_CREATE OR APP_PERMISSION_UPDATE OR SECURITY_ADMIN") },
   { path: "/security-groups", name: "SecurityGroups", component: SecurityGroups, beforeEnter: requirePermission("SECURITY_VIEW OR SECURITY_ADMIN") },
   { path: "/security-group-detail/:userGroupId", name: "SecurityGroupDetail", component: SecurityGroupDetail, props: true, beforeEnter: requirePermission("SECURITY_VIEW OR SECURITY_ADMIN") },
   { path: "/user-details/:partyId", name: "UserDetails", component: UserDetails, props: true, beforeEnter: requirePermission("USERS_LIST_VIEW OR PARTYMGR_VIEW OR PARTYMGR_ADMIN") },

--- a/src/views/AppPermissions.vue
+++ b/src/views/AppPermissions.vue
@@ -69,7 +69,7 @@ import { commonUtil, logger, translate } from "@common"
 import { IonButton, IonContent, IonHeader, IonIcon, IonItem, IonLabel, IonList, IonMenuButton, IonNote, IonPage, IonSearchbar, IonSpinner, IonTitle, IonToolbar, modalController } from "@ionic/vue"
 import { shieldCheckmarkOutline } from "ionicons/icons"
 import { computed, ref, watch } from "vue"
-import { useRoute, useRouter } from "vue-router"
+import { useRoute } from "vue-router"
 import AppPermissionCard from "@/components/AppPermissionCard.vue"
 import AppPermissionGroupModal from "@/components/AppPermissionGroupModal.vue"
 import AppPermissionHistoryModal from "@/components/AppPermissionHistoryModal.vue"
@@ -82,7 +82,6 @@ import { useUserStore } from "@/store/user"
 const appPermissionsStore = useAppPermissionsStore()
 const userStore = useUserStore()
 const route = useRoute()
-const router = useRouter()
 const loading = ref(false)
 const loadError = ref(false)
 const query = ref("")
@@ -95,7 +94,7 @@ const getAppId = (appId: unknown) => {
     : appPermissionCatalogs[0]?.appId || ""
 }
 
-const selectedAppId = ref<string>(getAppId(route.params.appId))
+const selectedAppId = ref<string>(getAppId(route.query.appId))
 
 const canCreate = computed(() => userStore.hasPermission("APP_PERMISSION_CREATE OR SECURITY_ADMIN"))
 const canUpdate = computed(() => userStore.hasPermission("APP_PERMISSION_UPDATE OR SECURITY_ADMIN"))
@@ -151,13 +150,19 @@ const loadSelectedApp = async () => {
   }
 }
 
-watch(() => route.params.appId, async (appId) => {
+watch(() => route.query.appId, async (appId) => {
   selectedAppId.value = getAppId(appId)
   await loadSelectedApp()
 }, { immediate: true })
 
 const selectApp = async (appId: string) => {
-  await router.push({ name: "AppPermissions", params: { appId } })
+  selectedAppId.value = getAppId(appId)
+
+  const url = new URL(window.location.href)
+  url.searchParams.set("appId", selectedAppId.value)
+  window.history.replaceState(window.history.state, "", `${url.pathname}${url.search}${url.hash}`)
+
+  await loadSelectedApp()
 }
 
 const openHistory = async (permission: AppPermissionDefinition) => {

--- a/src/views/AppPermissions.vue
+++ b/src/views/AppPermissions.vue
@@ -69,19 +69,18 @@ import { commonUtil, logger, translate } from "@common"
 import { IonButton, IonContent, IonHeader, IonIcon, IonItem, IonLabel, IonList, IonMenuButton, IonNote, IonPage, IonSearchbar, IonSpinner, IonTitle, IonToolbar, modalController } from "@ionic/vue"
 import { shieldCheckmarkOutline } from "ionicons/icons"
 import { computed, ref, watch } from "vue"
-import { useRoute } from "vue-router"
 import AppPermissionCard from "@/components/AppPermissionCard.vue"
 import AppPermissionGroupModal from "@/components/AppPermissionGroupModal.vue"
 import AppPermissionHistoryModal from "@/components/AppPermissionHistoryModal.vue"
 import AppPermissionUsersModal from "@/components/AppPermissionUsersModal.vue"
 import { appPermissionCatalogs } from "@/config/appPermissions"
 import type { AppPermissionCatalog, AppPermissionDefinition } from "@/config/appPermissions"
+import router from "@/router"
 import { useAppPermissionsStore } from "@/store/appPermissions"
 import { useUserStore } from "@/store/user"
 
 const appPermissionsStore = useAppPermissionsStore()
 const userStore = useUserStore()
-const route = useRoute()
 const loading = ref(false)
 const loadError = ref(false)
 const query = ref("")
@@ -94,7 +93,7 @@ const getAppId = (appId: unknown) => {
     : appPermissionCatalogs[0]?.appId || ""
 }
 
-const selectedAppId = ref<string>(getAppId(route.query.appId))
+const selectedAppId = ref<string>(getAppId(router.currentRoute.value.query.appId))
 
 const canCreate = computed(() => userStore.hasPermission("APP_PERMISSION_CREATE OR SECURITY_ADMIN"))
 const canUpdate = computed(() => userStore.hasPermission("APP_PERMISSION_UPDATE OR SECURITY_ADMIN"))
@@ -150,19 +149,19 @@ const loadSelectedApp = async () => {
   }
 }
 
-watch(() => route.query.appId, async (appId) => {
+watch(() => router.currentRoute.value.query.appId, async (appId) => {
   selectedAppId.value = getAppId(appId)
   await loadSelectedApp()
 }, { immediate: true })
 
 const selectApp = async (appId: string) => {
-  selectedAppId.value = getAppId(appId)
-
-  const url = new URL(window.location.href)
-  url.searchParams.set("appId", selectedAppId.value)
-  window.history.replaceState(window.history.state, "", `${url.pathname}${url.search}${url.hash}`)
-
-  await loadSelectedApp()
+  await router.replace({
+    name: "AppPermissions",
+    query: {
+      ...router.currentRoute.value.query,
+      appId: getAppId(appId)
+    }
+  })
 }
 
 const openHistory = async (permission: AppPermissionDefinition) => {


### PR DESCRIPTION
## Summary
- Prevent App Permissions app switching from creating Ionic page transitions and browser-history entries.
- Replace the optional `/:appId` path route with a single `/app-permissions` route.
- Persist the selected app in `?appId=...` through the shared router and `router.replace`, keeping the page mounted while preserving direct-link and reload behavior.

## Business summary
Administrators frequently switch among applications while reviewing permission assignments. Treating every selection as a separate route adds unnecessary page transitions and makes Back/Forward navigation noisy. This update keeps the interaction within one page while retaining shareable selection state.

## Evidence
- Closes #276
- Jam waived: reproduced directly in the authenticated Company app on current `origin/main`, and the intended interaction contract was confirmed during testing.
- Before: selecting Order Manager changed `/app-permissions` to `/app-permissions/order-manager` and Back returned to the prior app selection.
- After: selection changes only to `/app-permissions?appId=order-manager`; Back returns directly to the page visited before App Permissions.

## Why this layer
The route record, selected-app state, and Company navigation ownership all live in the Company frontend. No shared AccxUI or backend contract changes are needed.

## Verification
- `pnpm exec eslint src/views/AppPermissions.vue src/components/Menu.vue` — passed.
- `pnpm run build -- --logLevel error` — passed.
- In-app browser on `localhost:8101`:
  - app selection updates only `?appId=`;
  - Back skips prior app selections and returns to the previous page;
  - Forward and reload restore the selected app;
  - invalid app IDs fall back to Users;
  - App Permissions remains selected in the menu;
  - no browser errors.
- Full `pnpm run typecheck` remains blocked by existing unrelated repository-wide type errors.
- Including `src/router/index.ts` in focused ESLint exposes its two pre-existing import-order errors; unchanged imports were deliberately left out of scope.

## Risk
Low. The change is limited to App Permissions route state. Existing `/app-permissions/<appId>` links will no longer be canonical; the supported deep link is `/app-permissions?appId=<appId>`.