### PR TITLE
Create Shopify payment and shipment method types with mapping

### DIFF
--- a/src/components/CreatePaymentMethodModal.vue
+++ b/src/components/CreatePaymentMethodModal.vue
@@ -1,0 +1,116 @@
+<template>
+  <ion-header>
+    <ion-toolbar>
+      <ion-buttons slot="start">
+        <ion-button @click="closeModal()">
+          <ion-icon slot="icon-only" :icon="closeOutline" />
+        </ion-button>
+      </ion-buttons>
+      <ion-title>{{ translate("Create payment method") }}</ion-title>
+    </ion-toolbar>
+  </ion-header>
+
+  <ion-content>
+    <ion-list>
+      <ion-item>
+        <ion-input v-model="description" :label="translate('Payment method name')" label-placement="stacked" :placeholder="translate('e.g. Store Credit')" :maxlength="60" />
+      </ion-item>
+      <ion-item lines="none">
+        <ion-label class="ion-text-wrap">
+          <p>{{ translate("Hotwax ID") }}: <ion-text color="primary">{{ derivedId || "—" }}</ion-text></p>
+        </ion-label>
+      </ion-item>
+
+      <ion-item>
+        <ion-input v-model="shopifyId" :label="translate('Shopify ID')" label-placement="stacked" :placeholder="translate('Shopify payment method')" />
+      </ion-item>
+    </ion-list>
+  </ion-content>
+
+  <ion-fab slot="fixed" vertical="bottom" horizontal="end">
+    <ion-fab-button :disabled="!canSave" @click="createPaymentMethod()">
+      <ion-icon :icon="saveOutline" />
+    </ion-fab-button>
+  </ion-fab>
+</template>
+
+<script setup lang="ts">
+import { computed, PropType, ref } from "vue";
+import { IonButton, IonButtons, IonContent, IonFab, IonFabButton, IonHeader, IonIcon, IonInput, IonItem, IonLabel, IonList, IonText, IonTitle, IonToolbar, modalController } from "@ionic/vue";
+import { closeOutline, saveOutline } from "ionicons/icons";
+import { commonUtil, emitter, logger, translate } from "@common";
+import { useNetSuiteStore } from "@/store/netSuite";
+import { useShopifyStore } from "@/store/shopify";
+
+const props = defineProps({
+  shopId: {
+    type: String,
+    required: true
+  },
+  existingTypes: {
+    type: Array as PropType<any[]>,
+    default: () => []
+  }
+});
+
+const netSuiteStore = useNetSuiteStore();
+const shopifyStore = useShopifyStore();
+
+const description = ref("");
+const shopifyId = ref("");
+
+// Auto-derive the payment method type id from the description (uppercase, non-alphanumeric -> underscore).
+const derivedId = computed(() => description.value
+  .trim()
+  .toUpperCase()
+  .replace(/[^A-Z0-9]+/g, "_")
+  .replace(/^_+|_+$/g, "")
+);
+
+const canSave = computed(() => Boolean(derivedId.value && shopifyId.value.trim()));
+
+const closeModal = () => {
+  modalController.dismiss();
+};
+
+const createPaymentMethod = async () => {
+  if(!canSave.value) {return;}
+
+  const paymentMethodTypeId = derivedId.value;
+  emitter.emit("presentLoader");
+
+  try {
+    // 1. Create the payment method type if it does not already exist.
+    const typeExists = props.existingTypes.some((type: any) => type.paymentMethodTypeId === paymentMethodTypeId);
+    if(!typeExists) {
+      const typeResp = await netSuiteStore.createPaymentMethodType({
+        paymentMethodTypeId,
+        description: description.value.trim()
+      });
+      if(commonUtil.hasError(typeResp)) {
+        throw typeResp.data;
+      }
+    }
+
+    // 2. Create the Shopify type mapping (the identification).
+    const mappingResp = await shopifyStore.createShopifyShopTypeMapping({
+      shopId: props.shopId,
+      mappedTypeId: "SHOPIFY_PAYMENT_TYPE",
+      mappedKey: shopifyId.value.trim(),
+      mappedValue: paymentMethodTypeId
+    });
+    if(commonUtil.hasError(mappingResp)) {
+      throw mappingResp.data;
+    }
+
+    commonUtil.showToast(translate("Payment method created successfully"));
+    modalController.dismiss({ created: true });
+  } catch (error) {
+    logger.error(error);
+    commonUtil.showToast(translate("Failed to create payment method"));
+    // Keep the modal open so the user can correct and retry.
+  } finally {
+    emitter.emit("dismissLoader");
+  }
+};
+</script>

--- a/src/components/CreatePaymentMethodModal.vue
+++ b/src/components/CreatePaymentMethodModal.vue
@@ -39,8 +39,8 @@ import { computed, PropType, ref } from "vue";
 import { IonButton, IonButtons, IonContent, IonFab, IonFabButton, IonHeader, IonIcon, IonInput, IonItem, IonLabel, IonList, IonText, IonTitle, IonToolbar, modalController } from "@ionic/vue";
 import { closeOutline, saveOutline } from "ionicons/icons";
 import { commonUtil, emitter, logger, translate } from "@common";
-import { useNetSuiteStore } from "@/store/netSuite";
 import { useShopifyStore } from "@/store/shopify";
+import { useUtilStore } from "@/store/util";
 
 const props = defineProps({
   shopId: {
@@ -53,8 +53,8 @@ const props = defineProps({
   }
 });
 
-const netSuiteStore = useNetSuiteStore();
 const shopifyStore = useShopifyStore();
+const utilStore = useUtilStore();
 
 const description = ref("");
 const shopifyId = ref("");
@@ -83,7 +83,7 @@ const createPaymentMethod = async () => {
     // 1. Create the payment method type if it does not already exist.
     const typeExists = props.existingTypes.some((type: any) => type.paymentMethodTypeId === paymentMethodTypeId);
     if(!typeExists) {
-      const typeResp = await netSuiteStore.createPaymentMethodType({
+      const typeResp = await utilStore.createPaymentMethodType({
         paymentMethodTypeId,
         description: description.value.trim()
       });

--- a/src/components/CreateShipmentMethodModal.vue
+++ b/src/components/CreateShipmentMethodModal.vue
@@ -48,7 +48,6 @@ import { IonButton, IonButtons, IonContent, IonFab, IonFabButton, IonHeader, Ion
 import { closeOutline, saveOutline } from "ionicons/icons";
 import { commonUtil, emitter, logger, translate } from "@common";
 import { useUtilStore } from "@/store/util";
-import { useNetSuiteStore } from "@/store/netSuite";
 import { useShopifyStore } from "@/store/shopify";
 
 const props = defineProps({
@@ -71,7 +70,6 @@ const props = defineProps({
 });
 
 const utilStore = useUtilStore();
-const netSuiteStore = useNetSuiteStore();
 const shopifyStore = useShopifyStore();
 
 const description = ref("");
@@ -117,7 +115,7 @@ const createShipmentMethod = async () => {
     }
 
     // 2. Associate the shipment method type with the product store + carrier so it appears as a row.
-    const assocResp = await netSuiteStore.createProductStoreShipmentMethod({
+    const assocResp = await utilStore.createProductStoreShipmentMethod({
       productStoreId: props.productStoreId,
       shipmentMethodTypeId,
       partyId: carrierPartyId.value,

--- a/src/components/CreateShipmentMethodModal.vue
+++ b/src/components/CreateShipmentMethodModal.vue
@@ -1,0 +1,151 @@
+<template>
+  <ion-header>
+    <ion-toolbar>
+      <ion-buttons slot="start">
+        <ion-button @click="closeModal()">
+          <ion-icon slot="icon-only" :icon="closeOutline" />
+        </ion-button>
+      </ion-buttons>
+      <ion-title>{{ translate("Create shipment method") }}</ion-title>
+    </ion-toolbar>
+  </ion-header>
+
+  <ion-content>
+    <ion-list>
+      <ion-item v-if="carriers.length > 1">
+        <ion-select :label="translate('Carrier')" :placeholder="translate('Select')" v-model="carrierPartyId" interface="popover">
+          <ion-select-option v-for="carrier in carriers" :key="carrier.partyId" :value="carrier.partyId">
+            {{ carrier.groupName || carrier.partyId }}
+          </ion-select-option>
+        </ion-select>
+      </ion-item>
+
+      <ion-item>
+        <ion-input v-model="description" :label="translate('Shipment method name')" label-placement="stacked" :placeholder="translate('e.g. Standard Shipping')" :maxlength="60" @ionInput="onDescriptionInput" />
+      </ion-item>
+      <ion-item lines="none">
+        <ion-label class="ion-text-wrap">
+          <p>{{ translate("Hotwax ID") }}: <ion-text color="primary">{{ derivedId || "—" }}</ion-text></p>
+        </ion-label>
+      </ion-item>
+
+      <ion-item>
+        <ion-input v-model="shopifyShippingMethod" :label="translate('Shopify name')" label-placement="stacked" :placeholder="translate('Shopify shipping method name')" />
+      </ion-item>
+    </ion-list>
+  </ion-content>
+
+  <ion-fab slot="fixed" vertical="bottom" horizontal="end">
+    <ion-fab-button :disabled="!canSave" @click="createShipmentMethod()">
+      <ion-icon :icon="saveOutline" />
+    </ion-fab-button>
+  </ion-fab>
+</template>
+
+<script setup lang="ts">
+import { computed, PropType, ref } from "vue";
+import { IonButton, IonButtons, IonContent, IonFab, IonFabButton, IonHeader, IonIcon, IonInput, IonItem, IonLabel, IonList, IonSelect, IonSelectOption, IonText, IonTitle, IonToolbar, modalController } from "@ionic/vue";
+import { closeOutline, saveOutline } from "ionicons/icons";
+import { commonUtil, emitter, logger, translate } from "@common";
+import { useUtilStore } from "@/store/util";
+import { useNetSuiteStore } from "@/store/netSuite";
+import { useShopifyStore } from "@/store/shopify";
+
+const props = defineProps({
+  shopId: {
+    type: String,
+    required: true
+  },
+  productStoreId: {
+    type: String,
+    required: true
+  },
+  carrierPartyId: {
+    type: String,
+    default: ""
+  },
+  carriers: {
+    type: Array as PropType<any[]>,
+    default: () => []
+  }
+});
+
+const utilStore = useUtilStore();
+const netSuiteStore = useNetSuiteStore();
+const shopifyStore = useShopifyStore();
+
+const description = ref("");
+const shopifyShippingMethod = ref("");
+const carrierPartyId = ref(props.carrierPartyId || (props.carriers[0]?.partyId ?? ""));
+
+// Auto-derive the shipment method type id from the description (uppercase, non-alphanumeric -> underscore).
+const derivedId = computed(() => description.value
+  .trim()
+  .toUpperCase()
+  .replace(/[^A-Z0-9]+/g, "_")
+  .replace(/^_+|_+$/g, "")
+);
+
+const canSave = computed(() => Boolean(derivedId.value && shopifyShippingMethod.value.trim() && carrierPartyId.value));
+
+function onDescriptionInput() {
+  // keep description as typed; derivedId recomputes reactively
+}
+
+const closeModal = () => {
+  modalController.dismiss();
+};
+
+const createShipmentMethod = async () => {
+  if(!canSave.value) {return;}
+
+  const shipmentMethodTypeId = derivedId.value;
+  emitter.emit("presentLoader");
+
+  try {
+    // 1. Create the shipment method type if it does not already exist.
+    const typeExists = utilStore.shipmentMethodTypes.some((type: any) => type.shipmentMethodTypeId === shipmentMethodTypeId);
+    if(!typeExists) {
+      const typeResp = await utilStore.createShipmentMethodType({
+        shipmentMethodTypeId,
+        description: description.value.trim()
+      });
+      if(commonUtil.hasError(typeResp)) {
+        throw typeResp.data;
+      }
+      await utilStore.fetchShipmentMethodTypes(true);
+    }
+
+    // 2. Associate the shipment method type with the product store + carrier so it appears as a row.
+    const assocResp = await netSuiteStore.createProductStoreShipmentMethod({
+      productStoreId: props.productStoreId,
+      shipmentMethodTypeId,
+      partyId: carrierPartyId.value,
+      roleTypeId: "CARRIER"
+    });
+    if(commonUtil.hasError(assocResp)) {
+      throw assocResp.data;
+    }
+
+    // 3. Create the Shopify carrier-shipment mapping (the identification).
+    const mappingResp = await shopifyStore.createShopifyShopCarrierShipment({
+      shopId: props.shopId,
+      shipmentMethodTypeId,
+      shopifyShippingMethod: shopifyShippingMethod.value.trim(),
+      carrierPartyId: carrierPartyId.value
+    });
+    if(commonUtil.hasError(mappingResp)) {
+      throw mappingResp.data;
+    }
+
+    commonUtil.showToast(translate("Shipment method created successfully"));
+    modalController.dismiss({ created: true, carrierPartyId: carrierPartyId.value });
+  } catch (error) {
+    logger.error(error);
+    commonUtil.showToast(translate("Failed to create shipment method"));
+    // Keep the modal open so the user can correct and retry.
+  } finally {
+    emitter.emit("dismissLoader");
+  }
+};
+</script>

--- a/src/store/netSuite.ts
+++ b/src/store/netSuite.ts
@@ -162,14 +162,6 @@ export const useNetSuiteStore = defineStore('netSuite', {
       this.productStoreShipmentMethods = productStoreShipmentMethods
     },
 
-    async createPaymentMethodType(payload: { paymentMethodTypeId: string; description: string }): Promise<any> {
-      return api({
-        url: "admin/paymentMethodTypes",
-        method: "post",
-        data: payload
-      })
-    },
-
     async createProductStoreShipmentMethod(payload: {
       productStoreId: string
       shipmentMethodTypeId: string

--- a/src/store/netSuite.ts
+++ b/src/store/netSuite.ts
@@ -162,19 +162,6 @@ export const useNetSuiteStore = defineStore('netSuite', {
       this.productStoreShipmentMethods = productStoreShipmentMethods
     },
 
-    async createProductStoreShipmentMethod(payload: {
-      productStoreId: string
-      shipmentMethodTypeId: string
-      partyId: string
-      roleTypeId?: string
-    }): Promise<any> {
-      return api({
-        url: `admin/productStores/${payload.productStoreId}/shippingMethods`,
-        method: "post",
-        data: { roleTypeId: "CARRIER", ...payload }
-      })
-    },
-
     async fetchIntegrationTypeMappings(params: any) {
       let integrationTypeMappings: any = {}, pageIndex = 0, resp: any
       try {

--- a/src/store/netSuite.ts
+++ b/src/store/netSuite.ts
@@ -162,6 +162,27 @@ export const useNetSuiteStore = defineStore('netSuite', {
       this.productStoreShipmentMethods = productStoreShipmentMethods
     },
 
+    async createPaymentMethodType(payload: { paymentMethodTypeId: string; description: string }): Promise<any> {
+      return api({
+        url: "admin/paymentMethodTypes",
+        method: "post",
+        data: payload
+      })
+    },
+
+    async createProductStoreShipmentMethod(payload: {
+      productStoreId: string
+      shipmentMethodTypeId: string
+      partyId: string
+      roleTypeId?: string
+    }): Promise<any> {
+      return api({
+        url: `admin/productStores/${payload.productStoreId}/shippingMethods`,
+        method: "post",
+        data: { roleTypeId: "CARRIER", ...payload }
+      })
+    },
+
     async fetchIntegrationTypeMappings(params: any) {
       let integrationTypeMappings: any = {}, pageIndex = 0, resp: any
       try {

--- a/src/store/util.ts
+++ b/src/store/util.ts
@@ -260,6 +260,19 @@ export const useUtilStore = defineStore("util", {
       })
     },
 
+    async createProductStoreShipmentMethod(payload: {
+      productStoreId: string
+      shipmentMethodTypeId: string
+      partyId: string
+      roleTypeId?: string
+    }): Promise<any> {
+      return api({
+        url: `admin/productStores/${payload.productStoreId}/shippingMethods`,
+        method: "post",
+        data: { roleTypeId: "CARRIER", ...payload }
+      })
+    },
+
     async fetchOrganizationPartyId() {
       this.fetchStatus = { ...this.fetchStatus, organizationPartyId: "pending" }
       let partyId = ""

--- a/src/store/util.ts
+++ b/src/store/util.ts
@@ -221,8 +221,8 @@ export const useUtilStore = defineStore("util", {
       this.emailTypes = emailTypes
     },
 
-    async fetchShipmentMethodTypes() {
-      if(this.shipmentMethodTypes.length) {return}
+    async fetchShipmentMethodTypes(force = false) {
+      if(this.shipmentMethodTypes.length && !force) {return}
       this.fetchStatus = { ...this.fetchStatus, shipmentMethodTypes: "pending" }
       let shipmentMethodTypes: any[] = [], pageIndex = 0, resp: any
 
@@ -242,6 +242,14 @@ export const useUtilStore = defineStore("util", {
         this.fetchStatus = { ...this.fetchStatus, shipmentMethodTypes: "error" }
       }
       this.shipmentMethodTypes = shipmentMethodTypes
+    },
+
+    async createShipmentMethodType(payload: { shipmentMethodTypeId: string; description: string }) {
+      return api({
+        url: "oms/shippingGateways/shipmentMethodTypes",
+        method: "post",
+        data: payload
+      })
     },
 
     async fetchOrganizationPartyId() {

--- a/src/store/util.ts
+++ b/src/store/util.ts
@@ -252,6 +252,14 @@ export const useUtilStore = defineStore("util", {
       })
     },
 
+    async createPaymentMethodType(payload: { paymentMethodTypeId: string; description: string }): Promise<any> {
+      return api({
+        url: "admin/paymentMethodTypes",
+        method: "post",
+        data: payload
+      })
+    },
+
     async fetchOrganizationPartyId() {
       this.fetchStatus = { ...this.fetchStatus, organizationPartyId: "pending" }
       let partyId = ""

--- a/src/store/util.ts
+++ b/src/store/util.ts
@@ -254,7 +254,7 @@ export const useUtilStore = defineStore("util", {
 
     async createPaymentMethodType(payload: { paymentMethodTypeId: string; description: string }): Promise<any> {
       return api({
-        url: "admin/paymentMethodTypes",
+        url: "oms/paymentMethodTypes",
         method: "post",
         data: payload
       })

--- a/src/views/ShopifyPaymentMethods.vue
+++ b/src/views/ShopifyPaymentMethods.vue
@@ -8,6 +8,11 @@
           </ion-button>
         </ion-buttons>
         <ion-title>{{ translate("Payment methods") }}</ion-title>
+        <ion-buttons slot="end">
+          <ion-button aria-label="Create payment method" @click="openCreateModal()">
+            <ion-icon slot="icon-only" :icon="addOutline" />
+          </ion-button>
+        </ion-buttons>
       </ion-toolbar>
     </ion-header>
 
@@ -68,11 +73,12 @@
 </template>
 
 <script setup lang="ts">
-import { alertController, IonButton, IonButtons, IonChip, IonContent, IonHeader, IonIcon, IonInput, IonItem, IonLabel, IonPage, IonSkeletonText, IonTitle, IonToolbar, onIonViewWillEnter } from "@ionic/vue";
+import { alertController, IonButton, IonButtons, IonChip, IonContent, IonHeader, IonIcon, IonInput, IonItem, IonLabel, IonPage, IonSkeletonText, IonTitle, IonToolbar, modalController, onIonViewWillEnter } from "@ionic/vue";
 import { addOutline, arrowBackOutline, saveOutline, shieldCheckmarkOutline } from 'ionicons/icons'
 import { commonUtil, emitter, hasError, logger, translate } from '@common'
 import { useNetSuiteStore } from '@/store/netSuite';
 import { useShopifyStore } from '@/store/shopify';
+import CreatePaymentMethodModal from '@/components/CreatePaymentMethodModal.vue';
 import { computed, defineProps, nextTick, ref, watch } from "vue";
 import { onBeforeRouteLeave, useRouter } from "vue-router";
 
@@ -257,6 +263,27 @@ onBeforeRouteLeave(() => confirmLeaveWithDirtyMappings());
 
 function navigateBack() {
   router.push(backHref.value);
+}
+
+async function openCreateModal() {
+  const modal = await modalController.create({
+    component: CreatePaymentMethodModal,
+    componentProps: {
+      shopId: props.id,
+      existingTypes: paymentMethods.value
+    }
+  });
+
+  modal.onDidDismiss().then(async ({ data }) => {
+    if (!data?.created) return;
+    await Promise.all([
+      netSuiteStore.fetchPaymentMethods(),
+      shopifyStore.fetchShopifyTypeMappings({ mappedTypeId: "SHOPIFY_PAYMENT_TYPE", shopId: props.id })
+    ]);
+    initializeLocalMappings();
+  });
+
+  await modal.present();
 }
 </script>
 

--- a/src/views/ShopifyShipmentMethods.vue
+++ b/src/views/ShopifyShipmentMethods.vue
@@ -8,6 +8,11 @@
           </ion-button>
         </ion-buttons>
         <ion-title>{{ translate("Shipment methods") }}</ion-title>
+        <ion-buttons slot="end">
+          <ion-button aria-label="Create shipment method" :disabled="!carriers.length" @click="openCreateModal()">
+            <ion-icon slot="icon-only" :icon="addOutline" />
+          </ion-button>
+        </ion-buttons>
         <ion-buttons slot="primary">
           <ion-button :disabled="!isDirty" @click="saveAllDirtyMappings()">
             {{ translate("Save all") }}
@@ -83,12 +88,13 @@
 </template>
 
 <script setup lang="ts">
-import { alertController, IonButton, IonButtons, IonChip, IonContent, IonHeader, IonIcon, IonInput, IonItem, IonLabel, IonPage, IonSegment, IonSegmentButton, IonSkeletonText, IonTitle, IonToolbar, onIonViewWillEnter } from "@ionic/vue";
+import { alertController, IonButton, IonButtons, IonChip, IonContent, IonHeader, IonIcon, IonInput, IonItem, IonLabel, IonPage, IonSegment, IonSegmentButton, IonSkeletonText, IonTitle, IonToolbar, modalController, onIonViewWillEnter } from "@ionic/vue";
 import { addOutline, airplaneOutline, arrowBackOutline, saveOutline, shieldCheckmarkOutline } from 'ionicons/icons'
 import { commonUtil, emitter, hasError, logger, translate } from '@common'
 import { useUtilStore } from '@/store/util';
 import { useNetSuiteStore } from '@/store/netSuite';
 import { useShopifyStore } from '@/store/shopify';
+import CreateShipmentMethodModal from '@/components/CreateShipmentMethodModal.vue';
 import { computed, defineProps, nextTick, ref, watch } from "vue";
 import { onBeforeRouteLeave, useRouter } from "vue-router";
 
@@ -313,6 +319,30 @@ onBeforeRouteLeave(() => confirmLeaveWithDirtyMappings());
 
 function navigateBack() {
   router.push(backHref.value);
+}
+
+async function openCreateModal() {
+  const modal = await modalController.create({
+    component: CreateShipmentMethodModal,
+    componentProps: {
+      shopId: props.id,
+      productStoreId: shop.value.productStoreId,
+      carrierPartyId: selectedCarrierPartyId.value,
+      carriers: carriers.value
+    }
+  });
+
+  modal.onDidDismiss().then(async ({ data }) => {
+    if (!data?.created) return;
+    await Promise.all([
+      netSuiteStore.fetchProductStoreShipmentMethods({ productStoreId: shop.value.productStoreId }),
+      shopifyStore.fetchShopifyShopsCarrierShipments({ shopId: props.id })
+    ]);
+    if (data.carrierPartyId) selectedCarrierPartyId.value = data.carrierPartyId;
+    initializeLocalMappings();
+  });
+
+  await modal.present();
 }
 </script>
 


### PR DESCRIPTION
## What
Adds the ability to create new payment method types and shipment method types directly from the Shopify company app, with their Shopify value mapping, via two new modals:
- `CreatePaymentMethodModal.vue`
- `CreateShipmentMethodModal.vue`

The create actions live in the util store; `ShopifyPaymentMethods.vue` and `ShopifyShipmentMethods.vue` wire the modals in.

## Commits
- feat: create new payment and shipment method types with Shopify mapping
- refactor: move payment method type create to util store
- refactor: move shipment-method create action to util store
- fix: point payment method type create at oms endpoint

## Scope / notes
- Isolated from the Shopify Batch Order Sync work (PR #279). This branch is cut fresh from `main` with only the 4 payment/shipment commits — no order-sync changes.
- Pre-existing (not introduced here): `ShopifyPaymentMethods.vue` / `ShopifyShipmentMethods.vue` carry an unused `hasError` import from `@common` that already exists on `main`; left untouched to keep this PR scoped.
- Production build passes. (`main` has no unit-test suite; that tooling lives on the order-sync branch.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)