### PR TITLE
Fixed: Construct the Worker at the call site so Vite can statically analyze it and emit a real chunk; change the factory to wrap an existing Worker instead of a URL.

### DIFF
--- a/src/services/pollingService.ts
+++ b/src/services/pollingService.ts
@@ -77,8 +77,16 @@ export function createSyncService(opts: SyncServiceOptions): SyncService {
     // Best-effort: drop the superseded single-purpose cache DB from before CompanyCacheDB.
     void deleteLegacyCaches();
 
-    const { api, terminate: term, worker } = WorkerFactory.createWorker<SyncHarness>(
-      new URL("@/workers/appSync.worker.ts", import.meta.url),
+    // Construct the Worker here (not inside WorkerFactory) so Vite's worker transform can
+    // statically analyze `new Worker(new URL(...))` and emit a real chunk. Passing a URL through
+    // a factory hides it from Vite, which then inlines the worker as a `data:video/mp2t` asset.
+    const appSyncWorker = new Worker(
+      new URL("../workers/appSync.worker.ts", import.meta.url),
+      { type: "module" },
+    );
+    const { api, terminate: term, worker } = WorkerFactory.fromWorker<SyncHarness>(
+      appSyncWorker,
+      "appSync.worker.ts",
     );
     harness = api;
     terminate = term;


### PR DESCRIPTION


### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#

### Short Description and Why It's Useful
Fixed: Construct the Worker at the call site so Vite can statically analyze it and emit a real chunk; change the factory to wrap an existing Worker instead of a URL.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/company#contribution-guideline)