### PR TITLE
fix(facility): address UI bugs and cache constant consistency

### DIFF
--- a/src/components/facility/VirtualFacilityActionsPopover.vue
+++ b/src/components/facility/VirtualFacilityActionsPopover.vue
@@ -23,14 +23,9 @@ import {
   alertController,
   popoverController
 } from "@ionic/vue";
-import { commonUtil, translate } from "@common";
-import { useFacilityArchive } from "@/composables/useFacilities";
+import { translate } from "@common";
 
 const props = defineProps<{ facility: any }>();
-
-// The archive composable owns resolving (and, once, creating) the ARCHIVE group and refreshing the
-// cached memberships both lists on the Parking page are derived from.
-const { archive } = useFacilityArchive();
 
 async function renameVirtualFacility() {
   const alert = await alertController.create({
@@ -40,7 +35,7 @@ async function renameVirtualFacility() {
       { text: translate('Cancel'), role: "cancel" },
       {
         text: translate('Apply'),
-        handler: (data) => { popoverController.dismiss(data.facilityName); }
+        handler: (data) => { popoverController.dismiss({ action: 'rename', name: data.facilityName }); }
       }
     ]
   });
@@ -48,14 +43,6 @@ async function renameVirtualFacility() {
 }
 
 async function archiveVirtualFacility() {
-  const resp: any = await archive(props.facility.facilityId);
-  if (commonUtil.hasError(resp)) {
-    commonUtil.showToast(translate('Failed to archive parking.'));
-  } else {
-    // No list surgery here: the composable re-listed the ARCHIVE group, so the parking moves out of
-    // the active list and into the archived modal on its own.
-    commonUtil.showToast(translate("Parking archived successfully."));
-  }
-  popoverController.dismiss();
+  popoverController.dismiss({ action: 'archive' });
 }
 </script>

--- a/src/composables/useFacilities.ts
+++ b/src/composables/useFacilities.ts
@@ -1000,7 +1000,6 @@ export function useFacilityMutations(facilityId: string) {
 }
 
 /** The id of the group parkings are archived into. Created on first archive if absent. */
-const ARCHIVE_GROUP_ID = "ARCHIVE";
 
 /**
  * Creating a facility — the one write with no facility id to scope to.
@@ -1181,15 +1180,15 @@ export function useFacilityArchive() {
   async function ensureArchiveGroup(): Promise<string> {
     // Cache first — the group list is a login snapshot, so a hit costs no request at all.
     const cached = await facilityGroupCache.all();
-    if (cached.some((group: any) => group.facilityGroupId === ARCHIVE_GROUP_ID)) return ARCHIVE_GROUP_ID;
+    if (cached.some((group: any) => group.facilityGroupId === ARCHIVE_FACILITY_GROUP_ID)) return ARCHIVE_FACILITY_GROUP_ID;
 
     // A cache miss is not proof of absence (the group may have been created outside this app since
     // login), so confirm against the server before trying to create it.
     try {
-      const resp: any = await api({ url: `oms/facilityGroups/${ARCHIVE_GROUP_ID}`, method: "get" });
+      const resp: any = await api({ url: `oms/facilityGroups/${ARCHIVE_FACILITY_GROUP_ID}`, method: "get" });
       if (!commonUtil.hasError(resp) && resp.data?.facilityGroupId) {
         await resyncDomain("facilityGroup"); // cache was stale — fix it while we know
-        return ARCHIVE_GROUP_ID;
+        return ARCHIVE_FACILITY_GROUP_ID;
       }
     } catch {
       // not found — fall through and create it
@@ -1199,11 +1198,11 @@ export function useFacilityArchive() {
       const resp: any = await api({
         url: "oms/facilityGroups",
         method: "post",
-        data: { facilityGroupId: ARCHIVE_GROUP_ID, facilityGroupName: "Archive" },
+        data: { facilityGroupId: ARCHIVE_FACILITY_GROUP_ID, facilityGroupName: "Archive" },
       });
       if (!commonUtil.hasError(resp)) {
         await refreshAfterMutation("facilityGroup", {});
-        return ARCHIVE_GROUP_ID;
+        return ARCHIVE_FACILITY_GROUP_ID;
       }
     } catch (error) {
       logger.error("Failed to create archive group", error);
@@ -1212,7 +1211,7 @@ export function useFacilityArchive() {
   }
 
   const refreshArchive = () =>
-    refreshAfterMutation("facilityGroupMember", { facilityGroupId: ARCHIVE_GROUP_ID });
+    refreshAfterMutation("facilityGroupMember", { facilityGroupId: ARCHIVE_FACILITY_GROUP_ID });
 
   return {
     async archive(facilityId: string) {
@@ -1234,7 +1233,7 @@ export function useFacilityArchive() {
      */
     async unarchive(facilityId: string, fromDate: number | string) {
       const resp: any = await api({
-        url: `admin/facilityGroups/${ARCHIVE_GROUP_ID}/facilities/${encodeURIComponent(facilityId)}/association`,
+        url: `admin/facilityGroups/${ARCHIVE_FACILITY_GROUP_ID}/facilities/${encodeURIComponent(facilityId)}/association`,
         method: "post",
         data: { fromDate, thruDate: Date.now() },
       });

--- a/src/views/CreateFacility.vue
+++ b/src/views/CreateFacility.vue
@@ -185,14 +185,18 @@ async function createFacility() {
       commonUtil.showToast(translate("Facility created successfully."));
 
       // create default pick location (locations are live-read, so no cache consequence)
-      await useFacilityMutations(facilityId).saveLocation({
-        locationTypeEnumId: "FLT_PICKLOC",
-        areaId: "TL",
-        aisleId: "TL",
-        sectionId: "TL",
-        levelId: "LL",
-        positionId: "01"
-      });
+      try {
+        await useFacilityMutations(facilityId).saveLocation({
+          locationTypeEnumId: "FLT_PICKLOC",
+          areaId: "TL",
+          aisleId: "TL",
+          sectionId: "TL",
+          levelId: "LL",
+          positionId: "01"
+        });
+      } catch(e) {
+        logger.error(e);
+      }
 
       router.replace(`/create-facility/address/${facilityId}`);
     } else {

--- a/src/views/Parking.vue
+++ b/src/views/Parking.vue
@@ -171,7 +171,7 @@ import VirtualFacilityActionsPopover from '@/components/facility/VirtualFacility
 const { virtualFacilities: cachedVirtualFacilities } = useFacilityPartitions();
 const { archivedFacilities } = useArchivedFacilities();
 const { createVirtualFacility: createVirtualFacilityRecord } = useFacilityCreation();
-const { unarchive } = useFacilityArchive();
+const { unarchive, archive } = useFacilityArchive();
 const { fetchOrderCounts } = useFacilityOrderCounts();
 const { organizationPartyId, loadOrganizationPartyId } = useOrganization();
 
@@ -307,17 +307,31 @@ async function openVirtualFacilityActionsPopover(event: Event, facility: any) {
   popover.present();
 
   const result = await popover.onDidDismiss();
-  if (result.data && result.data !== facility.facilityName) {
-    try {
-      const resp = await useFacilityMutations(facility.facilityId).updateFacility({ facilityName: result.data });
-      if (!commonUtil.hasError(resp)) {
-        commonUtil.showToast(translate('Parking renamed successfully.'));
-      } else {
-        throw resp.data;
+  if (result.data) {
+    if (result.data.action === "rename" && result.data.name !== facility.facilityName) {
+      try {
+        const resp = await useFacilityMutations(facility.facilityId).updateFacility({ facilityName: result.data.name });
+        if (!commonUtil.hasError(resp)) {
+          commonUtil.showToast(translate('Parking renamed successfully.'));
+        } else {
+          throw resp.data;
+        }
+      } catch (error) {
+        commonUtil.showToast(translate('Failed to rename parking.'));
+        logger.error('Failed to rename parking.', error);
       }
-    } catch (error) {
-      commonUtil.showToast(translate('Failed to rename parking.'));
-      logger.error('Failed to rename parking.', error);
+    } else if (result.data.action === "archive") {
+      try {
+        const resp = await archive(facility.facilityId);
+        if (!commonUtil.hasError(resp)) {
+          commonUtil.showToast(translate("Parking archived successfully."));
+        } else {
+          throw resp.data;
+        }
+      } catch (error) {
+        commonUtil.showToast(translate('Failed to archive parking.'));
+        logger.error('Failed to archive parking.', error);
+      }
     }
   }
 }


### PR DESCRIPTION
This PR fixes several small UI inconsistencies and a cache constant issue in the new facility and carrier management implementation. Specifically:
- **Constant Consolidation**: Removed duplicate constants for `ARCHIVE_GROUP_ID` in `useFacilities.ts`.
- **Popover Logic**: Refactored `VirtualFacilityActionsPopover.vue` to simply emit an event instead of firing an API request, ensuring `Parking.vue` handles all mutation logic consistently.
- **Added Try/Catch**: Added error handling in `CreateFacility.vue` during default pick location creation.

---
*PR created automatically by Jules for task [4309026215999730527](https://jules.google.com/task/4309026215999730527) started by @dt2patel*