### PR TITLE
🧪 Add tests for getKlaviyoEventsForStore

### DIFF
--- a/tests/utils/klaviyoEmailEvents.spec.ts
+++ b/tests/utils/klaviyoEmailEvents.spec.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  KLAVIYO_SUPPORTED_EMAIL_TYPES,
+  getKlaviyoEventsForStore,
+} from "@/utils/klaviyoEmailEvents";
+
+describe("getKlaviyoEventsForStore", () => {
+  it("returns an empty array when productStoreId is not provided", () => {
+    const result = getKlaviyoEventsForStore({});
+    expect(result).toEqual([]);
+  });
+
+  it("returns an array mapping all supported email types with default values", () => {
+    const result = getKlaviyoEventsForStore({ productStoreId: "STORE1" });
+    expect(result).toHaveLength(KLAVIYO_SUPPORTED_EMAIL_TYPES.length);
+
+    expect(result[0]).toEqual({
+      emailType: KLAVIYO_SUPPORTED_EMAIL_TYPES[0].enumId,
+      label: KLAVIYO_SUPPORTED_EMAIL_TYPES[0].fallbackLabel,
+      enabled: false,
+      ownedByThisGateway: false,
+      gatewayAuthId: "",
+      subject: "",
+      setting: undefined,
+    });
+  });
+
+  it("calculates enabled true when a setting exists for the given store and email type", () => {
+    const result = getKlaviyoEventsForStore({
+      productStoreId: "STORE1",
+      allSettings: [
+        { productStoreId: "STORE1", emailType: "READY_FOR_PICKUP" },
+      ]
+    });
+
+    const readyForPickup = result.find(e => e.emailType === "READY_FOR_PICKUP");
+    expect(readyForPickup?.enabled).toBe(true);
+    expect(readyForPickup?.ownedByThisGateway).toBe(false); // gatewayAuthId doesn't match
+  });
+
+  it("calculates ownedByThisGateway true when enabled and gatewayAuthId matches", () => {
+    const result = getKlaviyoEventsForStore({
+      productStoreId: "STORE1",
+      gatewayAuthId: "AUTH1",
+      allSettings: [
+        { productStoreId: "STORE1", emailType: "READY_FOR_PICKUP", gatewayAuthId: "AUTH1" },
+      ]
+    });
+
+    const readyForPickup = result.find(e => e.emailType === "READY_FOR_PICKUP");
+    expect(readyForPickup?.enabled).toBe(true);
+    expect(readyForPickup?.ownedByThisGateway).toBe(true);
+    expect(readyForPickup?.gatewayAuthId).toBe("AUTH1");
+  });
+
+  it("retrieves the correct label using injected emailTypes list", () => {
+    const result = getKlaviyoEventsForStore({
+      productStoreId: "STORE1",
+      emailTypes: [
+        { enumId: "READY_FOR_PICKUP", enumName: "Custom Name", description: "Custom Description" }
+      ]
+    });
+
+    const readyForPickup = result.find(e => e.emailType === "READY_FOR_PICKUP");
+    expect(readyForPickup?.label).toBe("Custom Name");
+  });
+
+  it("retrieves the correct label falling back to description if enumName is not provided", () => {
+    const result = getKlaviyoEventsForStore({
+      productStoreId: "STORE1",
+      emailTypes: [
+        { enumId: "READY_FOR_PICKUP", description: "Custom Description" }
+      ]
+    });
+
+    const readyForPickup = result.find(e => e.emailType === "READY_FOR_PICKUP");
+    expect(readyForPickup?.label).toBe("Custom Description");
+  });
+
+  it("resolves the subject from subjectDrafts if present", () => {
+    const result = getKlaviyoEventsForStore({
+      productStoreId: "STORE1",
+      subjectDrafts: {
+        "READY_FOR_PICKUP": "Draft Subject"
+      },
+      allSettings: [
+        { productStoreId: "STORE1", emailType: "READY_FOR_PICKUP", subject: "Setting Subject" },
+      ]
+    });
+
+    const readyForPickup = result.find(e => e.emailType === "READY_FOR_PICKUP");
+    expect(readyForPickup?.subject).toBe("Draft Subject");
+  });
+
+  it("resolves the subject from settings if subjectDrafts is empty", () => {
+    const result = getKlaviyoEventsForStore({
+      productStoreId: "STORE1",
+      allSettings: [
+        { productStoreId: "STORE1", emailType: "READY_FOR_PICKUP", subject: "Setting Subject" },
+      ]
+    });
+
+    const readyForPickup = result.find(e => e.emailType === "READY_FOR_PICKUP");
+    expect(readyForPickup?.subject).toBe("Setting Subject");
+  });
+
+  it("maps the setting reference exactly as provided", () => {
+    const setting = { productStoreId: "STORE1", emailType: "READY_FOR_PICKUP", subject: "Setting Subject" };
+    const result = getKlaviyoEventsForStore({
+      productStoreId: "STORE1",
+      allSettings: [setting]
+    });
+
+    const readyForPickup = result.find(e => e.emailType === "READY_FOR_PICKUP");
+    expect(readyForPickup?.setting).toBe(setting);
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR introduces unit tests for the `getKlaviyoEventsForStore` function located in `src/utils/klaviyoEmailEvents.ts`, which previously lacked test coverage. 

📊 **Coverage:** What scenarios are now tested
The new `tests/utils/klaviyoEmailEvents.spec.ts` covers the following scenarios:
* Empty arrays handling when `productStoreId` is missing or empty.
* Returning arrays mapping all supported email types based on `KLAVIYO_SUPPORTED_EMAIL_TYPES`.
* Resolving `enabled` correctly when settings are found.
* Identifying correctly if an email is `ownedByThisGateway` using the matching logic.
* Mapping correct email labels by using given arrays or resolving via fallbacks.
* Establishing `subject` priority logic (resolving from `subjectDrafts` > checking user-defined settings > blank default).
* Preserving settings context reference in response mappings.

✨ **Result:** The improvement in test coverage
`getKlaviyoEventsForStore` logic is comprehensively covered, providing a reliable safety net for refactoring and ensuring deterministic behaviors around configurations loading.

---
*PR created automatically by Jules for task [9119333176768909384](https://jules.google.com/task/9119333176768909384) started by @dt2patel*