### PR TITLE
Refactor Vue views to use unified domain composables

### DIFF
--- a/src/composables/useProductStores.ts
+++ b/src/composables/useProductStores.ts
@@ -217,6 +217,88 @@ export function useProductStoreMutations(productStoreId: string) {
       data: { ...payload, productStoreId },
     }) as Promise<any>,
 
+    async cloneSettingsFrom(
+      sourceStoreId: string,
+      categories: Record<string, { selected: boolean }>,
+      categoryMap: Record<string, { fields: string[]; settings: string[] }>
+    ) {
+      // 1. Fetch details and settings of source store, and details of target store
+      const [sourceDetailsResp, sourceSettingsResp, targetDetailsResp] = await Promise.all([
+        api({ url: `admin/productStores/${encodeURIComponent(sourceStoreId)}`, method: "get" }),
+        api({ url: `admin/productStores/${encodeURIComponent(sourceStoreId)}/settings`, method: "get" }),
+        api({ url: `admin/productStores/${encodeURIComponent(productStoreId)}`, method: "get" })
+      ]);
+
+      if (commonUtil.hasError(sourceDetailsResp) || commonUtil.hasError(targetDetailsResp)) {
+        throw new Error("Failed to fetch product store details");
+      }
+
+      const sourceDetails = (sourceDetailsResp as any).data;
+      const sourceSettings = !commonUtil.hasError(sourceSettingsResp) ? (sourceSettingsResp as any).data : [];
+      const targetDetails = (targetDetailsResp as any).data;
+
+      // 2. Build direct fields payload for target store
+      let targetPayload = { ...targetDetails };
+
+      Object.keys(categories).forEach((key: string) => {
+        if (categories[key].selected) {
+          const mapping = categoryMap[key];
+          mapping.fields.forEach((field: string) => {
+            if (sourceDetails[field] !== undefined) {
+              targetPayload[field] = sourceDetails[field];
+            }
+          });
+        }
+      });
+
+      // Update target product store details
+      const updateDetailsResp: any = await api({
+        url: `admin/productStores/${encodeURIComponent(productStoreId)}`,
+        method: "put",
+        data: { ...targetPayload, productStoreId },
+      });
+      if (commonUtil.hasError(updateDetailsResp)) {
+        throw updateDetailsResp.data;
+      }
+      await refreshAfterMutation("productStore", { productStoreId });
+
+      // 3. Build settings copy promises
+      const settingsPromises: Promise<any>[] = [];
+      const activeSourceSettings = sourceSettings.filter((s: any) => !s.thruDate && s.settingValue);
+
+      Object.keys(categories).forEach((key: string) => {
+        if (categories[key].selected) {
+          const mapping = categoryMap[key];
+          const settingsToClone = activeSourceSettings.filter((s: any) => mapping.settings.includes(s.settingTypeEnumId));
+
+          settingsToClone.forEach((setting: any) => {
+            settingsPromises.push(
+              api({
+                url: `admin/productStores/${encodeURIComponent(productStoreId)}/settings`,
+                method: "post",
+                data: {
+                  fromDate: Date.now(),
+                  productStoreId,
+                  settingTypeEnumId: setting.settingTypeEnumId,
+                  settingValue: setting.settingValue
+                },
+              })
+            );
+          });
+        }
+      });
+
+      if (settingsPromises.length > 0) {
+        const results = await Promise.allSettled(settingsPromises);
+        const failed = results.filter(r => r.status === "rejected");
+        if (failed.length > 0) {
+          logger.warn(`Failed to clone ${failed.length} settings`);
+        }
+      }
+
+      return updateDetailsResp;
+    },
+
     async addFacility(payload: { facilityId: string; fromDate?: number }) {
       const resp: any = await api({
         url: `admin/productStores/${storeId()}/facilities/${encodeURIComponent(payload.facilityId)}/association`,

--- a/src/views/AddConfigurations.vue
+++ b/src/views/AddConfigurations.vue
@@ -87,13 +87,14 @@ import router from "@/router";
 import { useProductStores } from "@/composables/useProductStores";
 import { useTypedEnums } from '@/composables/useSeed';
 import { computed, defineProps, ref } from "vue";
-import { useProductStoreMutations } from "@/composables/useProductStores";
+import { useProductStoreDetail, useProductStoreMutations } from "@/composables/useProductStores";
 
 const { productStores: cachedProductStores } = useProductStores();
 
 const props = defineProps(["productStoreId"]);
 
-const productStore = ref({}) as any;
+const { current: productStore, load: loadProductStore } = useProductStoreDetail(props.productStoreId);
+
 const configMode = ref("manual");
 const selectedSourceStoreId = ref("");
 const formData = ref({
@@ -143,24 +144,8 @@ const { values: productIdentifiers, hydrated: identifiersReady } = useTypedEnums
 const productStores = computed(() => cachedProductStores.value.filter((s: any) => s.productStoreId !== props.productStoreId))
 
 onIonViewWillEnter(async () => {
-  fetchProductStore();
+  await loadProductStore();
 })
-
-async function fetchProductStore() {
-  try {
-    const resp = await api({
-      url: `admin/productStores/${props.productStoreId}`,
-      method: "get"
-    })
-    if(!commonUtil.hasError(resp)) {
-      productStore.value = (resp as any).data;
-    } else {
-      throw (resp as any).data;
-    }
-  } catch(error: any) {
-    logger.error("Failed to fetch product store details.")
-  }
-}
 
 async function setupProductStore() {
   emitter.emit("presentLoader");
@@ -173,64 +158,11 @@ async function setupProductStore() {
         return;
       }
 
-      // Fetch source store details and settings
-      const [detailsResp, settingsResp] = await Promise.all([
-        api({ url: `admin/productStores/${selectedSourceStoreId.value}`, method: "get" }),
-        api({ url: `admin/productStores/${selectedSourceStoreId.value}/settings`, method: "get" })
-      ]);
-
-      if (commonUtil.hasError(detailsResp)) {
-        throw new Error("Failed to fetch source store details");
-      }
-
-      const sourceStoreDetails = (detailsResp as any).data;
-      const sourceStoreSettings = !commonUtil.hasError(settingsResp) ? (settingsResp as any).data : [];
-
-      // Build target payload by copying direct fields for selected categories
-      let targetPayload = { ...productStore.value };
-
-      Object.keys(categories.value).forEach((key: string) => {
-        if (categories.value[key].selected) {
-          const mapping = CATEGORY_MAP[key];
-          mapping.fields.forEach((field: string) => {
-            if (sourceStoreDetails[field] !== undefined) {
-              targetPayload[field] = sourceStoreDetails[field];
-            }
-          });
-        }
-      });
-
-      // Update target store details
-      const updateDetailsResp = await useProductStoreMutations(targetPayload.productStoreId).updateStore(targetPayload);
-      if (commonUtil.hasError(updateDetailsResp)) {
-        throw updateDetailsResp.data;
-      }
-
-      // Update settings for selected categories
-      const settingsPromises: Promise<any>[] = [];
-      const activeSourceSettings = sourceStoreSettings.filter((s: any) => !s.thruDate && s.settingValue);
-
-      Object.keys(categories.value).forEach((key: string) => {
-        if (categories.value[key].selected) {
-          const mapping = CATEGORY_MAP[key];
-          const settingsToClone = activeSourceSettings.filter((s: any) => mapping.settings.includes(s.settingTypeEnumId));
-          
-          settingsToClone.forEach((setting: any) => {
-            settingsPromises.push(
-              useProductStoreMutations(props.productStoreId).saveSettings({
-                fromDate: Date.now(),
-                productStoreId: props.productStoreId,
-                settingTypeEnumId: setting.settingTypeEnumId,
-                settingValue: setting.settingValue
-              })
-            );
-          });
-        }
-      });
-
-      if (settingsPromises.length > 0) {
-        await Promise.allSettled(settingsPromises);
-      }
+      await useProductStoreMutations(props.productStoreId).cloneSettingsFrom(
+        selectedSourceStoreId.value,
+        categories.value,
+        CATEGORY_MAP
+      );
 
       commonUtil.showToast(translate("Product store configurations cloned successfully."));
     } else {

--- a/src/views/AddFacilityAddress.vue
+++ b/src/views/AddFacilityAddress.vue
@@ -159,6 +159,7 @@ import { colorWandOutline, locationOutline } from "ionicons/icons";
 import { api, commonUtil, logger, translate } from "@common";
 import { useGeocode, useGeos } from "@/composables/useSeed";
 import router from "@/router";
+import { useFacilityMutations } from "@/composables/useFacilities";
 
 const props = defineProps<{ facilityId: string }>();
 
@@ -220,15 +221,12 @@ async function addAddress() {
     return;
   }
 
+  const mutations = useFacilityMutations(props.facilityId);
+
   try {
-    const resp = await api({
-      url: "oms/facilityContactMechs/facilityAddress",
-      method: "post",
-      data: {
-        facilityId: props.facilityId,
-        contactMechPurposeTypeId: "PRIMARY_LOCATION",
-        ...formData.value
-      }
+    const resp = await mutations.createPostalAddress({
+      contactMechPurposeTypeId: "PRIMARY_LOCATION",
+      ...formData.value
     });
     if (!commonUtil.hasError(resp)) {
       commonUtil.showToast(translate("Facility address created successfully."));
@@ -243,15 +241,10 @@ async function addAddress() {
 
   if (contactNumber.value) {
     try {
-      await api({
-        url: "oms/facilityContactMechs/facilityPhone",
-        method: "post",
-        data: {
-          facilityId: props.facilityId,
-          contactMechPurposeTypeId: "PRIMARY_PHONE",
-          contactNumber: contactNumber.value.trim(),
-          countryCode: countryCode.value.replace("+", "")
-        }
+      await mutations.createTelecomNumber({
+        contactMechPurposeTypeId: "PRIMARY_PHONE",
+        contactNumber: contactNumber.value.trim(),
+        countryCode: countryCode.value.replace("+", "")
       });
     } catch (err) {
       // The address already toasted success and we navigate on regardless, so without this the
@@ -263,14 +256,9 @@ async function addAddress() {
 
   if (emailAddress.value) {
     try {
-      await api({
-        url: "oms/facilityContactMechs/facilityEmail",
-        method: "post",
-        data: {
-          facilityId: props.facilityId,
-          contactMechPurposeTypeId: "PRIMARY_EMAIL",
-          infoString: emailAddress.value
-        }
+      await mutations.createEmailAddress({
+        contactMechPurposeTypeId: "PRIMARY_EMAIL",
+        infoString: emailAddress.value
       });
     } catch (err) {
       commonUtil.showToast(translate("Facility address saved, but the email address could not be saved."));

--- a/src/views/CloneProductStore.vue
+++ b/src/views/CloneProductStore.vue
@@ -158,70 +158,11 @@ async function confirmClone() {
 async function executeClone() {
   emitter.emit("presentLoader");
   try {
-    // 1. Fetch details and settings of source store, and details of target store
-    const [sourceDetailsResp, sourceSettingsResp, targetDetailsResp] = await Promise.all([
-      api({ url: `admin/productStores/${sourceStoreId.value}`, method: "get" }),
-      api({ url: `admin/productStores/${sourceStoreId.value}/settings`, method: "get" }),
-      api({ url: `admin/productStores/${targetStoreId.value}`, method: "get" })
-    ]);
-
-    if (commonUtil.hasError(sourceDetailsResp) || commonUtil.hasError(targetDetailsResp)) {
-      throw new Error("Failed to fetch product store details");
-    }
-
-    const sourceDetails = (sourceDetailsResp as any).data;
-    const sourceSettings = !commonUtil.hasError(sourceSettingsResp) ? (sourceSettingsResp as any).data : [];
-    const targetDetails = (targetDetailsResp as any).data;
-
-    // 2. Build direct fields payload for target store
-    let targetPayload = { ...targetDetails };
-
-    Object.keys(categories.value).forEach((key: string) => {
-      if (categories.value[key].selected) {
-        const mapping = CATEGORY_MAP[key];
-        mapping.fields.forEach((field: string) => {
-          if (sourceDetails[field] !== undefined) {
-            targetPayload[field] = sourceDetails[field];
-          }
-        });
-      }
-    });
-
-    // Update target product store details
-    const detailsUpdateResp = await useProductStoreMutations(targetPayload.productStoreId).updateStore(targetPayload);
-    if (commonUtil.hasError(detailsUpdateResp)) {
-      throw detailsUpdateResp.data;
-    }
-
-    // 3. Build settings copy promises
-    const settingsPromises: Promise<any>[] = [];
-    const activeSourceSettings = sourceSettings.filter((s: any) => !s.thruDate && s.settingValue);
-
-    Object.keys(categories.value).forEach((key: string) => {
-      if (categories.value[key].selected) {
-        const mapping = CATEGORY_MAP[key];
-        const settingsToClone = activeSourceSettings.filter((s: any) => mapping.settings.includes(s.settingTypeEnumId));
-        
-        settingsToClone.forEach((setting: any) => {
-          settingsPromises.push(
-            useProductStoreMutations(targetStoreId.value).saveSettings({
-              fromDate: Date.now(),
-              productStoreId: targetStoreId.value,
-              settingTypeEnumId: setting.settingTypeEnumId,
-              settingValue: setting.settingValue
-            })
-          );
-        });
-      }
-    });
-
-    if (settingsPromises.length > 0) {
-      const results = await Promise.allSettled(settingsPromises);
-      const failed = results.filter(r => r.status === "rejected");
-      if (failed.length > 0) {
-        logger.warn(`Failed to clone ${failed.length} settings`);
-      }
-    }
+    await useProductStoreMutations(targetStoreId.value).cloneSettingsFrom(
+      sourceStoreId.value,
+      categories.value,
+      CATEGORY_MAP
+    );
 
     commonUtil.showToast(translate("Product store settings cloned successfully."));
     router.replace(`/product-store-details/${targetStoreId.value}`);


### PR DESCRIPTION
Refactored Vue view components to be thin presentation layers by extracting business logic, API calls, and data transformations into `src/composables/` domain composables.

- `AddFacilityAddress.vue`: Replaced direct `api()` calls for postal, telecom, and email creation with methods from `useFacilityMutations`.
- `CloneProductStore.vue`: Consolidated direct API fetching and settings copying logic into a unified `cloneSettingsFrom` method in `useProductStoreMutations`.
- `AddConfigurations.vue`: Extracted `api()` store detail fetching to use `useProductStoreDetail` and utilized the new `cloneSettingsFrom` composable method.

This architectural improvement enforces single sources of truth per domain and standardizes data hydration across views.

---
*PR created automatically by Jules for task [2003860899318602836](https://jules.google.com/task/2003860899318602836) started by @dt2patel*