### PR TITLE
fix: improve service job modal interactions in Produc Sync

### DIFF
--- a/src/components/common/ServiceJobDetailsModal.vue
+++ b/src/components/common/ServiceJobDetailsModal.vue
@@ -198,6 +198,7 @@ const props = withDefaults(defineProps<{
   parameterDescription?: string;
   canRunNow?: boolean;
   canEdit?: boolean;
+  allowEmptySchedule?: boolean;
   runNowDisabledReason?: string;
   editDisabledReason?: string;
   runHandler?: (() => Promise<unknown>) | null;
@@ -209,6 +210,7 @@ const props = withDefaults(defineProps<{
   parameterDescription: 'Job and service parameters used for this Shopify product sync.',
   canRunNow: true,
   canEdit: true,
+  allowEmptySchedule: false,
   runNowDisabledReason: '',
   editDisabledReason: '',
   runHandler: null,
@@ -232,7 +234,7 @@ const originalCronExpression = computed(() => String(jobDetails.value.cronExpres
 const originalActive = computed(() => String(jobDetails.value.paused || 'N').toUpperCase() !== 'Y');
 const isDirty = computed(() => draftCronExpression.value !== originalCronExpression.value || draftActive.value !== originalActive.value);
 const isScheduleValid = computed(() => {
-  if (!draftCronExpression.value) return true;
+  if (!draftCronExpression.value) return props.allowEmptySchedule;
   try { cronstrue.toString(draftCronExpression.value); return true; } catch (_error) { return false; }
 });
 const scheduleDescription = computed(() => {

--- a/src/components/common/ServiceJobDetailsModal.vue
+++ b/src/components/common/ServiceJobDetailsModal.vue
@@ -187,10 +187,12 @@ import { computed, ref, watch } from 'vue';
 import { commonUtil, translate } from '@common';
 import { formatDateTime } from '@/utils';
 import { useServiceJob } from '@/composables/useServiceJobs';
+import { refreshAfterMutation } from '@/services/appCacheBootstrap';
 
 const props = withDefaults(defineProps<{
   isOpen: boolean;
   jobName: string;
+  productStoreId?: string;
   title?: string;
   allowedParameterNames?: string[];
   parameterDescription?: string;
@@ -202,6 +204,7 @@ const props = withDefaults(defineProps<{
   saveHandler?: ((payload: { cronExpression: string; paused: boolean }) => Promise<unknown>) | null;
 }>(), {
   title: '',
+  productStoreId: '',
   allowedParameterNames: () => [],
   parameterDescription: 'Job and service parameters used for this Shopify product sync.',
   canRunNow: true,
@@ -229,7 +232,7 @@ const originalCronExpression = computed(() => String(jobDetails.value.cronExpres
 const originalActive = computed(() => String(jobDetails.value.paused || 'N').toUpperCase() !== 'Y');
 const isDirty = computed(() => draftCronExpression.value !== originalCronExpression.value || draftActive.value !== originalActive.value);
 const isScheduleValid = computed(() => {
-  if (!draftCronExpression.value) return false;
+  if (!draftCronExpression.value) return true;
   try { cronstrue.toString(draftCronExpression.value); return true; } catch (_error) { return false; }
 });
 const scheduleDescription = computed(() => {
@@ -264,7 +267,7 @@ async function load() {
   isLoading.value = true; loadError.value = '';
   try {
     const [details, runs, audits] = await Promise.all([
-      fetchJobDetail(props.jobName),
+      fetchJobDetail(props.jobName, props.productStoreId),
       fetchJobRuns(props.jobName, { pageSize: 5, pageIndex: 0 }),
       fetchJobAuditHistory(props.jobName, { pageSize: 10, pageIndex: 0 }),
     ]);
@@ -313,7 +316,12 @@ async function save() {
   try {
     const paused = !draftActive.value;
     if (props.saveHandler) await props.saveHandler({ cronExpression: draftCronExpression.value, paused });
-    else await updateJob({ jobName: props.jobName, cronExpression: draftCronExpression.value, paused: paused ? 'Y' : 'N' });
+    else {
+      await updateJob({ jobName: props.jobName, cronExpression: draftCronExpression.value, paused: paused ? 'Y' : 'N' });
+      await refreshAfterMutation('serviceJob', { jobName: props.jobName });
+    }
+    jobDetails.value.cronExpression = draftCronExpression.value;
+    jobDetails.value.paused = paused ? 'Y' : 'N';
     commonUtil.showToast(translate('Sync job updated successfully.'));
     emit('updated'); emit('close');
   } catch (_error) { commonUtil.showToast(translate('Something went wrong.')); }

--- a/src/views/ShopifyProductSync.vue
+++ b/src/views/ShopifyProductSync.vue
@@ -317,6 +317,7 @@
           :product-store-id="shop?.productStoreId || ''"
           :title="syncJobDetailsTitle"
           :save-handler="saveSyncJobDetails"
+          :allow-empty-schedule="true"
           @updated="handleRefresh"
           @close="handleSyncJobDetailsDidDismiss"
         />

--- a/src/views/ShopifyProductSync.vue
+++ b/src/views/ShopifyProductSync.vue
@@ -314,7 +314,9 @@
         <ServiceJobDetailsModal
           :is-open="showSyncJobDetailsModal"
           :job-name="selectedSyncJobDetailsJob?.jobName || ''"
+          :product-store-id="shop?.productStoreId || ''"
           :title="syncJobDetailsTitle"
+          :save-handler="saveSyncJobDetails"
           @updated="handleRefresh"
           @close="handleSyncJobDetailsDidDismiss"
         />
@@ -485,9 +487,8 @@
                   <ion-checkbox
                     slot="end"
                     :checked="areAllVisibleProductsSelected"
-                    :indeterminate="areSomeVisibleProductsSelected"
                     data-testid="product-sync-products-select-all-checkbox"
-                    @click.stop="toggleAllVisibleProducts"
+                    style="pointer-events: none;"
                   />
                 </ion-item>
 
@@ -511,7 +512,7 @@
                     slot="end"
                     :checked="isProductSelected(product.id)"
                     :data-testid="`product-sync-products-checkbox-${getProductId(product)}`"
-                    @click.stop="toggleProduct(product)"
+                    style="pointer-events: none;"
                   />
                 </ion-item>
               </ion-list>
@@ -2355,6 +2356,9 @@ async function resyncProduct(record: any) {
 
   isSaving.value = true;
   try {
+    if (!selectedShopSystemMessageRemoteId.value) {
+      await loadSelectedShopSystemMessageRemoteId();
+    }
     const result = await syncShopifyProductsOnDemand({
       shopId: props.id,
       shopifyProductId: [shopifyProductId]
@@ -2659,6 +2663,8 @@ async function updateSyncJob(payload: any, successMessage: string) {
       });
     }
 
+    await refreshAfterMutation("serviceJob", { jobName: payload.jobName });
+
     if (showSyncJobDetailsModal.value) {
       await refreshSyncJobDetails();
     }
@@ -2719,22 +2725,19 @@ async function requestRefreshSyncJobDetails() {
   await refreshSyncJobDetails();
 }
 
-async function saveSyncJobDetails() {
-  if (!selectedSyncJobDetailsJob.value?.jobName || !syncJobDetailsDirty.value || !isSyncJobDraftScheduleValid.value) return;
+async function saveSyncJobDetails(payload: { cronExpression: string; paused: boolean }) {
+  if (!selectedSyncJobDetailsJob.value?.jobName) {
+    throw new Error("No job selected");
+  }
 
-  isSyncJobDetailsSaving.value = true;
-  try {
-    const updated = await updateSyncJob({
-      jobName: selectedSyncJobDetailsJob.value.jobName,
-      cronExpression: syncJobDraftCronExpression.value,
-      paused: syncJobDraftActive.value ? "N" : "Y"
-    }, translate("Sync job updated successfully."));
+  const updated = await updateSyncJob({
+    jobName: selectedSyncJobDetailsJob.value.jobName,
+    cronExpression: payload.cronExpression,
+    paused: payload.paused ? "Y" : "N"
+  }, ""); // Pass empty string to avoid duplicate toast with modal
 
-    if (updated) {
-      showSyncJobDetailsModal.value = false;
-    }
-  } finally {
-    isSyncJobDetailsSaving.value = false;
+  if (!updated) {
+    throw new Error("Failed to update sync job");
   }
 }
 


### PR DESCRIPTION
### Related Issues
closes #325

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->

This PR resolves several UI state bugs and improves the data handling for service jobs:

1. **Fixes Checkbox State Desync:** Solves the issue in Product and Order sync pages where clicking exactly on a checkbox would turn it blue (due to Ionic's internal state) without updating the Vue selected count or state. This was fixed by making the checkboxes purely visual (`pointer-events: none;`) and relying entirely on the parent `<ion-item>` click handler.
2. **Service Job Modal Enhancements:** Ensures `fetchJobDetail` receives the correct `productStoreId` context. It also fixes a bug preventing users from saving paused jobs with empty cron expressions and correctly forcefully refreshes the `serviceJob` cache domain after any mutations so the UI updates instantly.
3. **On-Demand Sync Safety:** Ensures `systemMessageRemoteId` is correctly loaded into scope before dispatching manual sync requests.
