### PR TITLE
fix refresh cache on job update to prevent stale UI

### DIFF
--- a/src/composables/useServiceJobs.ts
+++ b/src/composables/useServiceJobs.ts
@@ -1,6 +1,7 @@
 import { computed, reactive, toRefs } from "vue";
-import { api, logger } from "@common";
+import { api, logger, commonUtil } from "@common";
 import cronstrue from "cronstrue";
+import { refreshAfterMutation } from "@/services/appCacheBootstrap";
 import { serviceJobCache, serviceJobRunCache } from "@/utils/cacheEntities";
 import { useCachedList, useCachedRecord } from "./useCachedList";
 
@@ -391,11 +392,15 @@ export function useServiceJob() {
   };
 
   const updateJob = async (payload: any) => {
-    return await api({
+    const resp = await api({
       url: `admin/serviceJobs/${payload.jobName}`,
       method: "PUT",
       data: payload,
     });
+    if (!commonUtil.hasError(resp)) {
+      await refreshAfterMutation("serviceJob", { jobName: payload.jobName });
+    }
+    return resp;
   };
 
   const runNow = async (jobName: string) => {

--- a/src/composables/useServiceJobs.ts
+++ b/src/composables/useServiceJobs.ts
@@ -391,13 +391,13 @@ export function useServiceJob() {
     return getEntityAuditLogs(resp?.data);
   };
 
-  const updateJob = async (payload: any) => {
+  const updateJob = async (payload: any, options: { skipRefresh?: boolean } = {}) => {
     const resp = await api({
       url: `admin/serviceJobs/${payload.jobName}`,
       method: "PUT",
       data: payload,
     });
-    if (!commonUtil.hasError(resp)) {
+    if (!commonUtil.hasError(resp) && !options.skipRefresh) {
       await refreshAfterMutation("serviceJob", { jobName: payload.jobName });
     }
     return resp;

--- a/src/composables/useShopify.ts
+++ b/src/composables/useShopify.ts
@@ -3239,14 +3239,14 @@ export function useShopifyOrderSync() {
       parameter.parameterName === "fromDate"
         ? { ...parameter, parameterValue: toJobTimestamp(fromDateIso) }
         : parameter);
-    await updateJob({ jobName, serviceJobParameters: swapped });
+    await updateJob({ jobName, serviceJobParameters: swapped }, { skipRefresh: true });
     try {
       const resp: any = await runJobNow(jobName);
       const result = { jobName, fromDate: fromDateIso, ...(resp?.data ?? {}) };
       state.lastRunResult = result;
       return result;
     } finally {
-      await updateJob({ jobName, serviceJobParameters: baseline });
+      await updateJob({ jobName, serviceJobParameters: baseline }, { skipRefresh: true });
       await refreshAfterMutation("serviceJob", { jobName });
     }
   }


### PR DESCRIPTION
### Related Issues
<!-- Put related issue number which this PR is closing. For example #123 -->

Closes #328

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->

Added `refreshAfterMutation` to the central `updateJob` function in `useServiceJobs.ts`. 

This fixes a bug where the UI (like on the Shopify Product Sync page) would continue to display stale schedule and paused states after updating a service job. While the backend was saving correctly, the IndexedDB cache was never being commanded to refresh itself. Now, any UI component relying on the default save behavior will correctly and instantly reflect the real backend state!

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

N/A (No visual layout changes, just fixing data reactivity)

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/company#contribution-guideline)
