### PR TITLE
fix onboarding : hide real-time order SQS job for fallback batch mode

### DIFF
--- a/src/views/ProductStoreOnboarding.vue
+++ b/src/views/ProductStoreOnboarding.vue
@@ -1174,7 +1174,11 @@ const shopifyConnectionRequirements = computed(() => {
 })
 const orderJobRequirements = computed(() => {
   return shopifyJobRequirements.value.filter((requirement: any) => {
-    return ["job.orderImport", "job.orderHistory", "job.realtimeOrderImport", "dataManager.orderConfigs"].includes(requirement.id)
+    const requiredIds = ["job.orderImport", "job.orderHistory", "dataManager.orderConfigs"]
+    if (shouldConfigureRealtimeOrderImport.value) {
+      requiredIds.push("job.realtimeOrderImport")
+    }
+    return requiredIds.includes(requirement.id)
   })
 })
 const shouldConfigureRealtimeOrderImport = computed(() => onboardingStore.draft.orderImportMode === "Realtime and fallback batch")


### PR DESCRIPTION
Conditionally exclude `job.realtimeOrderImport` from `orderJobRequirements` when the `shouldConfigureRealtimeOrderImport` flag is false. This ensures the job is not evaluated as a required gap and does not block the user from finishing the setup when the 'Fallback batch only' mode is selected.

### Related Issues
<!-- Put related issue number which this PR is closing. For example #123 -->

Closes #330

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->

This PR fixes a bug in the "Create product store" onboarding wizard. Previously, the "Real-time order SQS job" was incorrectly displayed under the Order import readiness section even when the "Fallback batch only" mode was selected. By hiding this requirement for that mode, this PR prevents the user from being incorrectly prompted or blocked by an unnecessary job configuration.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

<img width="1920" height="928" alt="image" src="https://github.com/user-attachments/assets/4bd59dbf-9e8f-4b5c-a7f4-2b31c63a69ad" />


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/company#contribution-guideline)
