### PR TITLE
fix(order-sync): handle 404 on uninitialized key dates and update date picker UI

### DIFF
--- a/src/composables/useShopify.ts
+++ b/src/composables/useShopify.ts
@@ -2799,8 +2799,12 @@ async function fetchLandmarkDates(): Promise<void> {
         systemPropertyId_op: "in",
         pageSize: 100,
       },
+    }).catch((err: any) => {
+      if (err.response?.status === 404) return { data: [] };
+      throw err;
     });
-    const rows: any[] = Array.isArray(resp?.data) ? resp.data : resp?.data?.systemPropertyList ?? [];
+
+    const rows = Array.isArray(resp?.data) ? resp.data : resp?.data?.systemPropertyList ?? [];
 
     // One pass, grouped by the shop the row belongs to. Every shop's dates land in one request, which
     // is why switching shops never costs another.

--- a/src/views/ShopifyOrderSync.vue
+++ b/src/views/ShopifyOrderSync.vue
@@ -513,12 +513,10 @@
               <p>{{ activeLandmark?.description }}</p>
             </ion-label>
           </ion-item>
-          <ion-item>
-            <ion-label>{{ translate("Date") }}</ion-label>
-            <ion-datetime-button slot="end" datetime="landmark-datetime" />
-            <ion-popover :keep-contents-on-did-dismiss="true">
-              <ion-datetime id="landmark-datetime" presentation="date-time" v-model="landmarkDateValue" />
-            </ion-popover>
+          <ion-item lines="none">
+            <ion-input type="datetime-local" :value="landmarkDateValue" label-placement="stacked" clear-input :aria-label="translate('Date')" @ionInput="landmarkDateValue = String($event.detail.value || '')">
+              <div slot="label">{{ translate("Date") }}</div>
+            </ion-input>
           </ion-item>
           <ion-item v-if="landmarkSuggestionLoading" lines="none">
             <ion-spinner slot="start" name="crescent" />
@@ -638,7 +636,7 @@
               {{ translate("Select all") }}
               <p>{{ selectedOrders.length }} {{ translate("selected") }}</p>
             </ion-label>
-            <ion-checkbox slot="end" :checked="allSelected" @click.stop="toggleAll" />
+            <ion-checkbox slot="end" :checked="allSelected" style="pointer-events: none;" />
           </ion-item>
           <ion-item v-for="order in orders" :key="order.legacyResourceId" button @click="toggleOrder(order)">
             <ion-label>
@@ -648,7 +646,7 @@
               <p>{{ formatOrderDate(order.createdAt) }}</p>
             </ion-label>
             <ion-note slot="end">{{ order.totalAmount || translate("No total") }} {{ order.currencyCode || "" }}</ion-note>
-            <ion-checkbox slot="end" :checked="isSelected(order.legacyResourceId)" @click.stop="toggleOrder(order)" />
+            <ion-checkbox slot="end" :checked="isSelected(order.legacyResourceId)" style="pointer-events: none;" />
           </ion-item>
         </ion-list>
         <ion-list v-else-if="isLoading" lines="none"><ion-item><ion-spinner name="crescent" /></ion-item></ion-list>
@@ -712,8 +710,6 @@ import {
   IonCheckbox,
   IonChip,
   IonContent,
-  IonDatetime,
-  IonDatetimeButton,
   IonFooter,
   IonHeader,
   IonIcon,
@@ -1082,6 +1078,7 @@ function openMdmLogDetails(logId: unknown) {
     ...Object.values(orderSync.importsBySystemMessageId || {}).flat().map((entry) => entry.logId),
     ...(orderSync.recentAudits || []).map((order) => order.logId),
     ...(orderSync.recentErrors || []).map((error) => error.logId),
+    ...(orderSync.failedDataManagerLogs || []).map((log) => log.logId),
   ].filter(Boolean));
   if (!safeLogIds.has(id)) return;
   selectedMdmLogId.value = id;
@@ -1219,7 +1216,7 @@ const landmarkDateRows = computed(() => ([
 
 const showLandmarkDateModal = ref(false);
 const activeLandmarkKey = ref<LandmarkDateKey>("launchDate");
-const landmarkDateValue = ref("");
+const landmarkDateValue = ref<string | undefined>(undefined);
 const landmarkSuggestedDate = ref("");
 const landmarkSuggestionLoading = ref(false);
 const isLandmarkSaving = ref(false);
@@ -1235,7 +1232,7 @@ async function openLandmarkDateModal(key: LandmarkDateKey) {
   landmarkSaveError.value = "";
   landmarkSuggestedDate.value = "";
   const existing = orderSync.landmarkDates[key];
-  landmarkDateValue.value = existing ? toDatetimeInput(existing) : "";
+  landmarkDateValue.value = existing ? toDatetimeInput(existing) : toDatetimeInput(new Date().toISOString());
   showLandmarkDateModal.value = true;
   landmarkSuggestionLoading.value = true;
   try {

--- a/src/views/ShopifyOrderSync.vue
+++ b/src/views/ShopifyOrderSync.vue
@@ -1232,7 +1232,7 @@ async function openLandmarkDateModal(key: LandmarkDateKey) {
   landmarkSaveError.value = "";
   landmarkSuggestedDate.value = "";
   const existing = orderSync.landmarkDates[key];
-  landmarkDateValue.value = existing ? toDatetimeInput(existing) : toDatetimeInput(new Date().toISOString());
+  landmarkDateValue.value = existing ? toDatetimeInput(existing) : undefined;
   showLandmarkDateModal.value = true;
   landmarkSuggestionLoading.value = true;
   try {


### PR DESCRIPTION
### Related Issues
<!-- Put related issue number which this PR is closing. For example #123 -->

Closes #332

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->

**1. Fixes 404 Error on Key Dates Card:**
Added a `.catch()` block to the `systemProperties` API call in `useShopify.ts`. This gracefully handles the `404 Not Found` error thrown by Moqui when a shop has no saved dates, preventing the "Key dates" card from breaking and allowing it to show the "Setup required" state correctly.

**2. Date Picker UI Update:**
Replaced the bulky `IonDatetime` calendar in `ShopifyOrderSync.vue` with a native `ion-input type="datetime-local"`. This matches the sleek native design used in the "Replay orders" modal and resolves previous rendering issues with the date picker button.

- [x] I read and followed [contribution rules](https://github.com/hotwax/company#contribution-guideline)