### PR TITLE
fix: resolve Vue rendering crash on save and prevent background state mutations

### DIFF
--- a/src/views/ShopifyLocations.vue
+++ b/src/views/ShopifyLocations.vue
@@ -176,7 +176,7 @@ function getShopifyLocationId(facilityId: string) {
 function isItemDirty(id: string) {
   const local = localMappings.value[id];
   const original = getShopifyLocationId(id) || "";
-  return local !== original;
+  return (local ?? "") !== (original ?? "");
 }
 
 async function editItem(id: string) {

--- a/src/views/ShopifyPaymentMethods.vue
+++ b/src/views/ShopifyPaymentMethods.vue
@@ -28,7 +28,8 @@
         </ion-item>
       </div>
 
-      <div v-if="isLoading">
+      <div class="list-container">
+        <div v-if="isLoading">
         <div class="list-item ion-padding-end" v-for="i in 5" :key="i">
           <ion-item lines="none">
             <ion-label>
@@ -68,6 +69,7 @@
             </ion-button>
           </div>
         </div>
+      </div>
       </div>
 
       <ion-modal :is-open="showCreatePaymentMethodModal" @didDismiss="closeCreatePaymentMethodModal">
@@ -227,7 +229,7 @@ function initializeLocalMappings() {
 function isItemDirty(id: string) {
   const local = localMappings.value[id];
   const original = getShopifyMapping(id);
-  return local !== original;
+  return (local ?? "") !== (original ?? "");
 }
 
 function getShopifyMapping(paymentMethodTypeId: any) {

--- a/src/views/ShopifyProductTypes.vue
+++ b/src/views/ShopifyProductTypes.vue
@@ -129,7 +129,7 @@ function initializeLocalMappings() {
 function isItemDirty(id: string) {
   const local = localMappings.value[id];
   const original = getShopifyMappingId(id);
-  return local !== original;
+  return (local ?? "") !== (original ?? "");
 }
 
 function getShopifyMappingId(productTypeId: any) {

--- a/src/views/ShopifySalesChannels.vue
+++ b/src/views/ShopifySalesChannels.vue
@@ -120,7 +120,7 @@ function initializeLocalMappings() {
 function isItemDirty(id: string) {
   const local = localMappings.value[id];
   const original = getShopifyMappingId(id);
-  return local !== original;
+  return (local ?? "") !== (original ?? "");
 }
 
 function getShopifyMappingId(salesChannelEnumId: any) {

--- a/src/views/ShopifyShipmentMethods.vue
+++ b/src/views/ShopifyShipmentMethods.vue
@@ -38,7 +38,8 @@
         </ion-segment-button>
       </ion-segment>
 
-      <div v-if="isLoading">
+      <div class="list-container">
+        <div v-if="isLoading">
         <div class="list-item ion-padding-end" v-for="i in 5" :key="i">
           <ion-item lines="none">
             <ion-icon slot="start" :icon="airplaneOutline" />
@@ -82,6 +83,7 @@
             </ion-button>
           </div>
         </div>
+      </div>
       </div>
 
       <ion-modal :is-open="showCreateShipmentMethodModal" @didDismiss="closeCreateShipmentMethodModal">


### PR DESCRIPTION
### Related Issues
Closes #336

### Short Description and Why It's Useful
This PR fixes two critical Vue rendering bugs in the Shopify mapping screens:

1. **DOM NodeNotFoundError Crash:** Added a `.list-container` wrapper around the `v-if`/`v-else` loading lists in `ShopifyPaymentMethods` and `ShopifyShipmentMethods`. This isolates the lists from the sibling `<ion-modal>`, preventing an unhandled Vue `insertBefore` crash caused by Ionic automatically relocating the modal to the root of the app.
2. **Silent State Mutation:** Updated `isItemDirty` across all mapping views (Payment Methods, Shipment Methods, Sales Channels, Product Types, Locations) to properly coalesce `undefined` values to empty strings. This prevents an unintended `<ion-input>` render for new/unmapped items, which previously triggered a silent, reactive state mutation directly in the middle of the Vue patch cycle.

### Contribution and Currently Important Rules Acceptance
- [x] I read and followed [contribution rules](https://github.com/hotwax/company#contribution-guideline)
