### PR TITLE
fix: Handle empty inputs and malformed keys in Shopify mapping config…

### DIFF
--- a/src/views/ShopifyLocations.vue
+++ b/src/views/ShopifyLocations.vue
@@ -191,10 +191,11 @@ async function editItem(id: string) {
 }
 
 async function saveMapping(facilityId: string) {
-  const shopifyLocationId = localMappings.value[facilityId];
+  const shopifyLocationId = (localMappings.value[facilityId] || "").trim();
+  const oldShopifyLocationId = getShopifyLocationId(facilityId) || "";
 
-  if (!shopifyLocationId) {
-    commonUtil.showToast(translate("Please provide a Shopify location ID"));
+  if (!shopifyLocationId && !oldShopifyLocationId) {
+    editingItemId.value = "";
     return;
   }
 
@@ -225,9 +226,10 @@ async function saveAllDirtyMappings() {
 
   try {
     for (const id of dirtyIds) {
+      const shopifyLocationId = (localMappings.value[id] || "").trim();
       await shopMutations.saveLocation({
         facilityId: id,
-        shopifyLocationId: localMappings.value[id]
+        shopifyLocationId: shopifyLocationId
       }, { refresh: false });
     }
     await shopMutations.refreshLocations();

--- a/src/views/ShopifyPaymentMethods.vue
+++ b/src/views/ShopifyPaymentMethods.vue
@@ -322,11 +322,11 @@ async function createPaymentMethod() {
 }
 
 async function saveMapping(paymentMethodTypeId: string) {
-  const newMappedKey = localMappings.value[paymentMethodTypeId];
+  const newMappedKey = (localMappings.value[paymentMethodTypeId] || "").trim();
   const oldMappedKey = getShopifyMapping(paymentMethodTypeId);
 
-  if (!newMappedKey) {
-    commonUtil.showToast(translate("Please provide a Shopify payment method name"));
+  if (!newMappedKey && !oldMappedKey) {
+    editingItemId.value = "";
     return;
   }
 
@@ -339,19 +339,21 @@ async function saveMapping(paymentMethodTypeId: string) {
       }, { refresh: false });
     }
 
-    const resp = await shopMutations.saveTypeMapping({
-      mappedTypeId: "SHOPIFY_PAYMENT_TYPE",
-      mappedKey: newMappedKey,
-      mappedValue: paymentMethodTypeId
-    }, { refresh: false });
+    if (newMappedKey) {
+      const resp = await shopMutations.saveTypeMapping({
+        mappedTypeId: "SHOPIFY_PAYMENT_TYPE",
+        mappedKey: newMappedKey,
+        mappedValue: paymentMethodTypeId
+      }, { refresh: false });
 
-    if (!commonUtil.hasError(resp)) {
-      commonUtil.showToast(translate("Mapping updated successfully"));
-      await shopMutations.refreshTypeMappings();
-      editingItemId.value = "";
-    } else {
-      throw resp.data;
+      if (commonUtil.hasError(resp)) {
+        throw resp.data;
+      }
     }
+
+    commonUtil.showToast(translate("Mapping updated successfully"));
+    await shopMutations.refreshTypeMappings();
+    editingItemId.value = "";
   } catch (error) {
     logger.error(error);
     commonUtil.showToast(translate("Failed to update mapping"));
@@ -376,11 +378,13 @@ async function saveAllDirtyMappings() {
 
     await Promise.all(dirtyIds.map(async (id) => {
       const newMappedKey = localMappings.value[id];
-      await shopMutations.saveTypeMapping({
-        mappedTypeId: "SHOPIFY_PAYMENT_TYPE",
-        mappedKey: newMappedKey,
-        mappedValue: id
-      }, { refresh: false });
+      if (newMappedKey) {
+        await shopMutations.saveTypeMapping({
+          mappedTypeId: "SHOPIFY_PAYMENT_TYPE",
+          mappedKey: newMappedKey,
+          mappedValue: id
+        }, { refresh: false });
+      }
     }));
 
     await shopMutations.refreshTypeMappings();

--- a/src/views/ShopifyProductTypes.vue
+++ b/src/views/ShopifyProductTypes.vue
@@ -149,11 +149,11 @@ async function editItem(id: string) {
 }
 
 async function saveMapping(productTypeId: string) {
-  const newMappedKey = localMappings.value[productTypeId];
+  const newMappedKey = (localMappings.value[productTypeId] || "").trim();
   const oldMappedKey = getShopifyMappingId(productTypeId);
 
-  if (!newMappedKey) {
-    commonUtil.showToast(translate("Please provide a Shopify product type name"));
+  if (!newMappedKey && !oldMappedKey) {
+    editingItemId.value = "";
     return;
   }
 
@@ -166,19 +166,20 @@ async function saveMapping(productTypeId: string) {
       }, { refresh: false });
     }
 
-    const resp = await shopMutations.saveTypeMapping({
-      mappedTypeId: "SHOPIFY_PRODUCT_TYPE",
-      mappedKey: newMappedKey,
-      mappedValue: productTypeId
-    }, { refresh: false });
-
-    if (!commonUtil.hasError(resp)) {
-      commonUtil.showToast(translate("Mapping updated successfully"));
-      await shopMutations.refreshTypeMappings();
-      editingItemId.value = "";
-    } else {
-      throw resp.data;
+    if (newMappedKey) {
+      const resp = await shopMutations.saveTypeMapping({
+        mappedTypeId: "SHOPIFY_PRODUCT_TYPE",
+        mappedKey: newMappedKey,
+        mappedValue: productTypeId
+      }, { refresh: false });
+      if (commonUtil.hasError(resp)) {
+        throw resp.data;
+      }
     }
+
+    commonUtil.showToast(translate("Mapping updated successfully"));
+    await shopMutations.refreshTypeMappings();
+    editingItemId.value = "";
   } catch (error) {
     logger.error(error);
     commonUtil.showToast(translate("Failed to update mapping"));
@@ -201,12 +202,13 @@ async function saveAllDirtyMappings() {
           mappedKey: oldMappedKey
         }, { refresh: false });
       }
-
-      await shopMutations.saveTypeMapping({
-        mappedTypeId: "SHOPIFY_PRODUCT_TYPE",
-        mappedKey: newMappedKey,
-        mappedValue: id
-      }, { refresh: false });
+      if (newMappedKey) {
+        await shopMutations.saveTypeMapping({
+          mappedTypeId: "SHOPIFY_PRODUCT_TYPE",
+          mappedKey: newMappedKey,
+          mappedValue: id
+        }, { refresh: false });
+      }
     }
     await shopMutations.refreshTypeMappings();
     commonUtil.showToast(translate("All mappings saved successfully"));

--- a/src/views/ShopifySalesChannels.vue
+++ b/src/views/ShopifySalesChannels.vue
@@ -140,11 +140,11 @@ async function editItem(id: string) {
 }
 
 async function saveMapping(salesChannelEnumId: string) {
-  const newMappedKey = localMappings.value[salesChannelEnumId];
+  const newMappedKey = (localMappings.value[salesChannelEnumId] || "").trim();
   const oldMappedKey = getShopifyMappingId(salesChannelEnumId);
 
-  if (!newMappedKey) {
-    commonUtil.showToast(translate("Please provide a Shopify order source name"));
+  if (!newMappedKey && !oldMappedKey) {
+    editingItemId.value = "";
     return;
   }
 
@@ -157,19 +157,21 @@ async function saveMapping(salesChannelEnumId: string) {
       }, { refresh: false });
     }
 
-    const resp = await shopMutations.saveTypeMapping({
-      mappedTypeId: "SHOPIFY_ORDER_SOURCE",
-      mappedKey: newMappedKey,
-      mappedValue: salesChannelEnumId
-    }, { refresh: false });
+    if (newMappedKey) {
+      const resp = await shopMutations.saveTypeMapping({
+        mappedTypeId: "SHOPIFY_ORDER_SOURCE",
+        mappedKey: newMappedKey,
+        mappedValue: salesChannelEnumId
+      }, { refresh: false });
 
-    if (!commonUtil.hasError(resp)) {
-      commonUtil.showToast(translate("Mapping updated successfully"));
-      await shopMutations.refreshTypeMappings();
-      editingItemId.value = "";
-    } else {
-      throw resp.data;
+      if (commonUtil.hasError(resp)) {
+        throw resp.data;
+      }
     }
+
+    commonUtil.showToast(translate("Mapping updated successfully"));
+    await shopMutations.refreshTypeMappings();
+    editingItemId.value = "";
   } catch (error) {
     logger.error(error);
     commonUtil.showToast(translate("Failed to update mapping"));
@@ -194,11 +196,13 @@ async function saveAllDirtyMappings() {
 
     await Promise.all(dirtyIds.map(async (id) => {
       const newMappedKey = localMappings.value[id];
-      await shopMutations.saveTypeMapping({
-        mappedTypeId: "SHOPIFY_ORDER_SOURCE",
-        mappedKey: newMappedKey,
-        mappedValue: id
-      }, { refresh: false });
+      if (newMappedKey) {
+        await shopMutations.saveTypeMapping({
+          mappedTypeId: "SHOPIFY_ORDER_SOURCE",
+          mappedKey: newMappedKey,
+          mappedValue: id
+        }, { refresh: false });
+      }
     }));
 
     await shopMutations.refreshTypeMappings();

--- a/src/views/ShopifyShipmentMethods.vue
+++ b/src/views/ShopifyShipmentMethods.vue
@@ -220,7 +220,9 @@ function initializeLocalMappings() {
       // in edit mode forever because it could never be reseeded.
       if (!userEditedKeys.value.has(key)) {
         localMappings.value[key] = {
-          shopifyShippingMethod: original ? original.shopifyShippingMethod : ""
+          shopifyShippingMethod: original ? original.shopifyShippingMethod : "",
+          carrierPartyId: sm.partyId,
+          shipmentMethodTypeId: sm.shipmentMethodTypeId
         };
       }
     }
@@ -264,9 +266,11 @@ async function editItem(carrierPartyId: string, shipmentMethodTypeId: string) {
 
 async function saveMapping(shipmentMethodTypeId: string) {
   const key = `${selectedCarrierPartyId.value}_${shipmentMethodTypeId}`;
-  const mapping = localMappings.value[key];
-  if (!mapping.shopifyShippingMethod) {
-    commonUtil.showToast(translate("Please provide Shopify name"));
+  const newMappedKey = (localMappings.value[key]?.shopifyShippingMethod || "").trim();
+  const oldMappedKey = getShopifyMapping(shipmentMethodTypeId);
+
+  if (!newMappedKey && !oldMappedKey) {
+    editingItemKey.value = "";
     return;
   }
 
@@ -274,8 +278,7 @@ async function saveMapping(shipmentMethodTypeId: string) {
   try {
     const resp = await shopMutations.saveCarrierShipment({
       shipmentMethodTypeId,
-      shopifyShippingMethod: mapping.shopifyShippingMethod,
-      carrierPartyId: selectedCarrierPartyId.value
+      shopifyShippingMethod: newMappedKey
     }, { refresh: false });
 
     if (!commonUtil.hasError(resp)) {
@@ -303,12 +306,12 @@ async function saveAllDirtyMappings() {
 
   try {
     await Promise.all(dirtyKeys.map(async (key) => {
-      const [carrierPartyId, shipmentMethodTypeId] = key.split('_');
       const mapping = localMappings.value[key];
+      const newMappedKey = (mapping.shopifyShippingMethod || "").trim();
+      
       await shopMutations.saveCarrierShipment({
-        shipmentMethodTypeId,
-        shopifyShippingMethod: mapping.shopifyShippingMethod,
-        carrierPartyId: carrierPartyId
+        shipmentMethodTypeId: mapping.shipmentMethodTypeId,
+        shopifyShippingMethod: newMappedKey
       }, { refresh: false });
     }));
     await shopMutations.refreshCarrierShipments();


### PR DESCRIPTION
### Related Issues
<!-- Put related issue number which this PR is closing. For example #123 -->

closes #338

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->

This PR fixes multiple bugs across the Shopify configuration pages that prevented users from successfully deleting mappings:
1. **Empty Input Handling**: Updated `ShopifyProductTypes`, `ShopifySalesChannels`, `ShopifyPaymentMethods`, `ShopifyLocations`, and `ShopifyShipmentMethods` to correctly handle empty string inputs when a user attempts to clear a mapping.
2. **Key Parsing Bug Fix**: Fixed a bug in `ShopifyShipmentMethods` where `.split('_')` incorrectly broke apart internal keys containing underscores (e.g., `_NA__TEST_METHOD`). This caused malformed payloads resulting in foreign key constraint errors (`[23000]`). Mappings are now safely read from the object directly.
3. **Payload Alignment**: Removed `carrierPartyId` from the `saveCarrierShipment` payload to properly align with API expectations.

**Note:** While this ensures the frontend sends the correct deletion requests, a corresponding OMS backend PR is still required to add `<method type="delete">` to `oms.rest.xml`, otherwise the backend will continue throwing `DuplicateKeyException` on `carrierShipments`.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

N/A (Bug fix for data mapping; no UI layout changes)

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/company#contribution-guideline)
