### PR TITLE
Refactor views to extract direct API calls into composables

### DIFF
--- a/src/composables/useProductStores.ts
+++ b/src/composables/useProductStores.ts
@@ -145,6 +145,26 @@ export function useProductStoreShippingMethods(productStoreId?: string) {
  * data — they are date-effective and edited in place, so caching them would only add a staleness
  * problem the page does not otherwise have.
  */
+/**
+ * Reads details and settings for a product store directly from the API for cloning operations.
+ * Bypass cache to ensure exact configuration source.
+ */
+export async function fetchSourceStoreForClone(storeId: string) {
+  const [detailsResp, settingsResp]: any[] = await Promise.all([
+    api({ url: `admin/productStores/${encodeURIComponent(storeId)}`, method: "get" }),
+    api({ url: `admin/productStores/${encodeURIComponent(storeId)}/settings`, method: "get" })
+  ]);
+
+  if (commonUtil.hasError(detailsResp)) {
+    throw new Error("Failed to fetch source store details");
+  }
+
+  return {
+    details: detailsResp.data,
+    settings: !commonUtil.hasError(settingsResp) ? settingsResp.data : []
+  };
+}
+
 export function useProductStoreDetail(productStoreId: string) {
   const { record: cachedRecord, hydrated } = useProductStoreRecord(productStoreId);
   const detail = ref<Record<string, any>>({});

--- a/src/views/AddConfigurations.vue
+++ b/src/views/AddConfigurations.vue
@@ -82,9 +82,9 @@
 <script setup lang="ts">
 import { IonBackButton, IonButton, IonButtons, IonCheckbox, IonContent, IonHeader, IonIcon, IonInput, IonItem, IonLabel, IonList, IonListHeader, IonPage, IonProgressBar, IonSelect, IonSelectOption, IonSegment, IonSegmentButton, IonTitle, IonToggle, IonToolbar, onIonViewWillEnter } from "@ionic/vue";
 import { arrowForwardOutline, copyOutline, informationCircleOutline, shirtOutline } from "ionicons/icons";
-import { api, commonUtil, emitter, logger, translate } from '@common'
+import { commonUtil, emitter, logger, translate } from '@common'
 import router from "@/router";
-import { useProductStores } from "@/composables/useProductStores";
+import { useProductStores, useProductStoreDetail, fetchSourceStoreForClone } from "@/composables/useProductStores";
 import { useTypedEnums } from '@/composables/useSeed';
 import { computed, defineProps, ref } from "vue";
 import { useProductStoreMutations } from "@/composables/useProductStores";
@@ -142,25 +142,12 @@ const CATEGORY_MAP = {
 const { values: productIdentifiers, hydrated: identifiersReady } = useTypedEnums('SHOP_PROD_IDENTITY')
 const productStores = computed(() => cachedProductStores.value.filter((s: any) => s.productStoreId !== props.productStoreId))
 
-onIonViewWillEnter(async () => {
-  fetchProductStore();
-})
+const { current: storeDetail, reloadDetail: fetchProductStore } = useProductStoreDetail(props.productStoreId);
 
-async function fetchProductStore() {
-  try {
-    const resp = await api({
-      url: `admin/productStores/${props.productStoreId}`,
-      method: "get"
-    })
-    if(!commonUtil.hasError(resp)) {
-      productStore.value = (resp as any).data;
-    } else {
-      throw (resp as any).data;
-    }
-  } catch(error: any) {
-    logger.error("Failed to fetch product store details.")
-  }
-}
+onIonViewWillEnter(async () => {
+  await fetchProductStore();
+  productStore.value = storeDetail.value;
+})
 
 async function setupProductStore() {
   emitter.emit("presentLoader");
@@ -174,17 +161,9 @@ async function setupProductStore() {
       }
 
       // Fetch source store details and settings
-      const [detailsResp, settingsResp] = await Promise.all([
-        api({ url: `admin/productStores/${selectedSourceStoreId.value}`, method: "get" }),
-        api({ url: `admin/productStores/${selectedSourceStoreId.value}/settings`, method: "get" })
-      ]);
-
-      if (commonUtil.hasError(detailsResp)) {
-        throw new Error("Failed to fetch source store details");
-      }
-
-      const sourceStoreDetails = (detailsResp as any).data;
-      const sourceStoreSettings = !commonUtil.hasError(settingsResp) ? (settingsResp as any).data : [];
+      const sourceStoreData = await fetchSourceStoreForClone(selectedSourceStoreId.value);
+      const sourceStoreDetails = sourceStoreData.details;
+      const sourceStoreSettings = sourceStoreData.settings;
 
       // Build target payload by copying direct fields for selected categories
       let targetPayload = { ...productStore.value };

--- a/src/views/AddFacilityConfig.vue
+++ b/src/views/AddFacilityConfig.vue
@@ -108,7 +108,7 @@ import {
 } from "@ionic/vue";
 import { ref } from "vue";
 import { addCircleOutline, ellipsisVerticalOutline, locationOutline, removeCircleOutline, star, starOutline } from "ionicons/icons";
-import { api, commonUtil, logger, translate } from "@common";
+import { commonUtil, logger, translate } from "@common";
 import { useFacilityGroupMutations, useFacilityMutations } from "@/composables/useFacilities";
 import { useShopifyShopIdForProductStore } from "@/composables/useShopify";
 import SelectProductStoreModal from "@/components/product-store/SelectProductStoreModal.vue";
@@ -193,8 +193,8 @@ async function makeProductStorePrimary() {
   // ensure the FEATURING facility group exists
   let facilityGroupId = shopifyShopId;
   try {
-    const checkResp = await api({ url: `oms/facilityGroups/${shopifyShopId}`, method: "get" });
-    if (commonUtil.hasError(checkResp) || !checkResp.data?.facilityGroupId) {
+    const existingGroupId = await groupMutations.findGroup(shopifyShopId);
+    if (!existingGroupId) {
       const storeName = selectedProductStores.value.find((productStore: any) => productStore.productStoreId === primaryProductStoreId.value)?.storeName || primaryProductStoreId.value;
       await groupMutations.createGroup({
         facilityGroupId: shopifyShopId,


### PR DESCRIPTION
Extracted direct API calls from `AddConfigurations.vue` and `AddFacilityConfig.vue` into composables `useProductStores.ts` and `useFacilities.ts`. Added a specific un-cached fetcher `fetchSourceStoreForClone` in `useProductStores.ts`.

---
*PR created automatically by Jules for task [6093505631105558056](https://jules.google.com/task/6093505631105558056) started by @dt2patel*